### PR TITLE
feat: add --check-drift flag to detect local modifications before integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ go.work.sum
 # .vscode/
 # Added by goreleaser init:
 dist/
+gitspork

--- a/cmd/integrate-local.go
+++ b/cmd/integrate-local.go
@@ -25,6 +25,7 @@ func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
 	var upstreamPath string
 	var downstreamPath string
 	var forceRePrompt bool
+	var checkDrift bool
 
 	var cmd = &cobra.Command{
 		Use:   "integrate-local",
@@ -36,6 +37,7 @@ func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
 				UpstreamPath:   upstreamPath,
 				DownstreamPath: downstreamPath,
 				ForceRePrompt:  forceRePrompt,
+				CheckDrift:     checkDrift,
 			})
 		},
 	}
@@ -46,6 +48,8 @@ func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
 		"local path to integrate/re-integrate w/ the standards set at the upstream-path")
 	cmd.PersistentFlags().BoolVarP(&forceRePrompt, "force-re-prompt", "f", false,
 		"If true, will disregard and previous prompt input value caches for templated instructions, requiring values to be re-input by the user")
+	cmd.PersistentFlags().BoolVar(&checkDrift, "check-drift", false,
+		"If true, will check for local modifications to upstream-owned files before integration and prompt to continue")
 
 	return cmd
 }

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -27,6 +27,7 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 	var upstreamRepoToken string
 	var downstreamRepoPath string
 	var forceRePrompt bool
+	var checkDrift bool
 
 	var cmd = &cobra.Command{
 		Use:   "integrate",
@@ -41,6 +42,7 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 				UpstreamRepoToken:   upstreamRepoToken,
 				DownstreamRepoPath:  downstreamRepoPath,
 				ForceRePrompt:       forceRePrompt,
+				CheckDrift:          checkDrift,
 			})
 		},
 	}
@@ -57,6 +59,8 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 		"local path to the downstream repo clone to integrate/re-integrate, defaults to the present working directory")
 	cmd.PersistentFlags().BoolVarP(&forceRePrompt, "force-re-prompt", "f", false,
 		"If true, will disregard and previous prompt input value caches for templated instructions, requiring values to be re-input by the user")
+	cmd.PersistentFlags().BoolVar(&checkDrift, "check-drift", false,
+		"If true, will check for local modifications to upstream-owned files before integration and prompt to continue")
 
 	return cmd
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,3 +51,20 @@ post_integrate:
 ## For Downstream Integrators
 
 More coming soon, see the [root README.md](../README.md) in the meantime for the info currently available.
+
+### Drift Detection
+
+Before integration overwrites your local modifications to upstream-owned files, you can preview what will change using the `--check-drift` flag:
+
+```bash
+gitspork integrate \
+  --upstream-repo-url https://github.com/your-org/your-upstream \
+  --upstream-repo-version v2.0.0 \
+  --check-drift
+```
+
+When drift is detected, gitspork will:
+- Show a colored diff of each modified upstream-owned file
+- Prompt you to continue or abort the integration
+
+This is useful when you've made local edits to upstream-owned files and want to review what will be overwritten before proceeding.

--- a/internal/gitspork.go
+++ b/internal/gitspork.go
@@ -94,6 +94,7 @@ type IntegrateOptions struct {
 	UpstreamRepoToken   string
 	DownstreamRepoPath  string
 	ForceRePrompt       bool
+	CheckDrift          bool
 }
 
 // IntegrateLocalOptions are options for the IntegrateLocal method
@@ -102,6 +103,7 @@ type IntegrateLocalOptions struct {
 	UpstreamPath   string
 	DownstreamPath string
 	ForceRePrompt  bool
+	CheckDrift     bool
 }
 
 // ParseGitSporkConfig will parse a .gitspork.yml config file at the provided path

--- a/internal/integrate-local.go
+++ b/internal/integrate-local.go
@@ -10,5 +10,5 @@ func IntegrateLocal(opts *IntegrateLocalOptions) error {
 		return err
 	}
 
-	return integrate(gitSporkConfig, opts.UpstreamPath, opts.DownstreamPath, opts.ForceRePrompt, opts.Logger)
+	return integrate(gitSporkConfig, opts.UpstreamPath, opts.DownstreamPath, opts.ForceRePrompt, opts.CheckDrift, opts.Logger)
 }

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport/http"
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	"github.com/gobwas/glob"
+	"github.com/rockholla/gitspork/internal/input"
 	"gopkg.in/yaml.v2"
 )
 
@@ -531,13 +532,16 @@ func checkUpstreamDrift(gitSporkConfig *GitSporkConfig, upstreamPath string, dow
 	if driftFound {
 		fmt.Println("")
 		logger.Log("%s", yellowBold.Sprint("The integration will overwrite the modified files shown above."))
-		fmt.Print("Do you want to continue? (y/N): ")
 
-		var response string
-		fmt.Scanln(&response)
-		response = strings.ToLower(strings.TrimSpace(response))
+		result, err := input.RequestInput(&input.RequestInputOptions{
+			Type:   input.YesNo,
+			Prompt: "Do you want to continue?",
+		})
+		if err != nil {
+			return fmt.Errorf("error reading user input: %v", err)
+		}
 
-		if response != "y" && response != "yes" {
+		if !result.BoolValue {
 			return fmt.Errorf("integration aborted by user")
 		}
 		fmt.Println("")

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -77,11 +77,18 @@ func Integrate(opts *IntegrateOptions) error {
 		return err
 	}
 
-	return integrate(gitSporkConfig, upstreamRootPath, opts.DownstreamRepoPath, opts.ForceRePrompt, opts.Logger)
+	return integrate(gitSporkConfig, upstreamRootPath, opts.DownstreamRepoPath, opts.ForceRePrompt, opts.CheckDrift, opts.Logger)
 }
 
-func integrate(gitSporkConfig *GitSporkConfig, upstreamPath string, downstreamPath string, forceRePrompt bool, logger *Logger) error {
+func integrate(gitSporkConfig *GitSporkConfig, upstreamPath string, downstreamPath string, forceRePrompt bool, checkDrift bool, logger *Logger) error {
 	greenBold := color.New(color.FgHiGreen, color.Bold)
+
+	// Check for drift in upstream-owned files if requested
+	if checkDrift {
+		if err := checkUpstreamDrift(gitSporkConfig, upstreamPath, downstreamPath, logger); err != nil {
+			return fmt.Errorf("drift check failed: %v", err)
+		}
+	}
 
 	preIntegrateMigrations := []*GitSporkConfigMigrationInstructions{}
 	postIntegrateMigrations := []*GitSporkConfigMigrationInstructions{}
@@ -465,4 +472,76 @@ func recordCompleteMigration(migrationID string, downstreamRepoPath string) erro
 		state.MigrationsComplete = append(state.MigrationsComplete, migrationID)
 	}
 	return saveDownstreamState(downstreamRepoPath, state)
+}
+
+// checkUpstreamDrift detects local modifications to upstream-owned files by comparing upstream with downstream
+func checkUpstreamDrift(gitSporkConfig *GitSporkConfig, upstreamPath string, downstreamPath string, logger *Logger) error {
+	yellowBold := color.New(color.FgHiYellow, color.Bold)
+	redBold := color.New(color.FgHiRed, color.Bold)
+	cyanBold := color.New(color.FgHiCyan, color.Bold)
+
+	// Get the list of upstream-owned files
+	upstreamFiles, err := getIntegrateFiles(upstreamPath, gitSporkConfig.UpstreamOwned)
+	if err != nil {
+		return fmt.Errorf("error determining upstream-owned files: %v", err)
+	}
+
+	driftFound := false
+	for _, upstreamFile := range upstreamFiles {
+		upstreamFilePath := filepath.Join(upstreamPath, upstreamFile)
+		downstreamFilePath := filepath.Join(downstreamPath, upstreamFile)
+
+		// Check if the file exists in downstream
+		if _, err := os.Stat(downstreamFilePath); os.IsNotExist(err) {
+			// File doesn't exist in downstream yet, skip drift check
+			continue
+		}
+
+		// Read both files and compare
+		upstreamContent, err := os.ReadFile(upstreamFilePath)
+		if err != nil {
+			return fmt.Errorf("error reading upstream file %s: %v", upstreamFile, err)
+		}
+
+		downstreamContent, err := os.ReadFile(downstreamFilePath)
+		if err != nil {
+			return fmt.Errorf("error reading downstream file %s: %v", upstreamFile, err)
+		}
+
+		// Compare content
+		if string(upstreamContent) != string(downstreamContent) {
+			if !driftFound {
+				fmt.Println("")
+				logger.Log("%s", yellowBold.Sprint("⚠️  Drift detected in upstream-owned files"))
+				fmt.Println("")
+				driftFound = true
+			}
+
+			logger.Log("%s %s", redBold.Sprint("Modified:"), cyanBold.Sprint(upstreamFile))
+
+			// Show diff using git diff
+			cmd := exec.Command("git", "diff", "--no-index", "--color=always", upstreamFilePath, downstreamFilePath)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = downstreamPath
+			_ = cmd.Run() // Ignore error as git diff returns non-zero when there are differences
+		}
+	}
+
+	if driftFound {
+		fmt.Println("")
+		logger.Log("%s", yellowBold.Sprint("The integration will overwrite the modified files shown above."))
+		fmt.Print("Do you want to continue? (y/N): ")
+
+		var response string
+		fmt.Scanln(&response)
+		response = strings.ToLower(strings.TrimSpace(response))
+
+		if response != "y" && response != "yes" {
+			return fmt.Errorf("integration aborted by user")
+		}
+		fmt.Println("")
+	}
+
+	return nil
 }

--- a/internal/integrate_drift_test.go
+++ b/internal/integrate_drift_test.go
@@ -1,0 +1,150 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckUpstreamDrift(t *testing.T) {
+	t.Run("detects drift when files differ", func(t *testing.T) {
+		// Create upstream and downstream directories
+		upstreamPath, err := os.MkdirTemp("", "gitspork-drift-upstream-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(upstreamPath)
+
+		downstreamPath, err := os.MkdirTemp("", "gitspork-drift-downstream-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(downstreamPath)
+
+		// Create .gitspork.yml in upstream
+		gitsporkConfig := `version: v0.0.1
+upstream_owned:
+- test.txt
+`
+		err = os.WriteFile(filepath.Join(upstreamPath, ".gitspork.yml"), []byte(gitsporkConfig), 0644)
+		require.NoError(t, err)
+
+		// Create matching file in upstream
+		upstreamContent := "upstream content\n"
+		err = os.WriteFile(filepath.Join(upstreamPath, "test.txt"), []byte(upstreamContent), 0644)
+		require.NoError(t, err)
+
+		// Create modified file in downstream
+		downstreamContent := "downstream modified content\n"
+		err = os.WriteFile(filepath.Join(downstreamPath, "test.txt"), []byte(downstreamContent), 0644)
+		require.NoError(t, err)
+
+		// Parse config and detect drift
+		config, err := getGitSporkConfig(upstreamPath)
+		require.NoError(t, err)
+
+		// Test drift detection logic (without prompting)
+		upstreamFiles, err := getIntegrateFiles(upstreamPath, config.UpstreamOwned)
+		require.NoError(t, err)
+		assert.NotEmpty(t, upstreamFiles, "Should find upstream-owned files")
+
+		// Verify drift would be detected
+		foundDrift := false
+		for _, file := range upstreamFiles {
+			upstreamFilePath := filepath.Join(upstreamPath, file)
+			downstreamFilePath := filepath.Join(downstreamPath, file)
+
+			if _, err := os.Stat(downstreamFilePath); err == nil {
+				upstreamBytes, _ := os.ReadFile(upstreamFilePath)
+				downstreamBytes, _ := os.ReadFile(downstreamFilePath)
+
+				if string(upstreamBytes) != string(downstreamBytes) {
+					foundDrift = true
+					break
+				}
+			}
+		}
+		assert.True(t, foundDrift, "Should detect drift in modified file")
+	})
+
+	t.Run("no drift when files match", func(t *testing.T) {
+		// Create upstream and downstream directories
+		upstreamPath, err := os.MkdirTemp("", "gitspork-drift-upstream-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(upstreamPath)
+
+		downstreamPath, err := os.MkdirTemp("", "gitspork-drift-downstream-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(downstreamPath)
+
+		// Create .gitspork.yml in upstream
+		gitsporkConfig := `version: v0.0.1
+upstream_owned:
+- test.txt
+`
+		err = os.WriteFile(filepath.Join(upstreamPath, ".gitspork.yml"), []byte(gitsporkConfig), 0644)
+		require.NoError(t, err)
+
+		// Create matching files in both upstream and downstream
+		content := "same content\n"
+		err = os.WriteFile(filepath.Join(upstreamPath, "test.txt"), []byte(content), 0644)
+		require.NoError(t, err)
+		err = os.WriteFile(filepath.Join(downstreamPath, "test.txt"), []byte(content), 0644)
+		require.NoError(t, err)
+
+		// Parse config
+		config, err := getGitSporkConfig(upstreamPath)
+		require.NoError(t, err)
+
+		// Test no drift
+		upstreamFiles, err := getIntegrateFiles(upstreamPath, config.UpstreamOwned)
+		require.NoError(t, err)
+
+		foundDrift := false
+		for _, file := range upstreamFiles {
+			upstreamFilePath := filepath.Join(upstreamPath, file)
+			downstreamFilePath := filepath.Join(downstreamPath, file)
+
+			if _, err := os.Stat(downstreamFilePath); err == nil {
+				upstreamBytes, _ := os.ReadFile(upstreamFilePath)
+				downstreamBytes, _ := os.ReadFile(downstreamFilePath)
+
+				if string(upstreamBytes) != string(downstreamBytes) {
+					foundDrift = true
+					break
+				}
+			}
+		}
+		assert.False(t, foundDrift, "Should not detect drift when files match")
+	})
+
+	t.Run("skips files that don't exist in downstream", func(t *testing.T) {
+		// Create upstream directory
+		upstreamPath, err := os.MkdirTemp("", "gitspork-drift-upstream-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(upstreamPath)
+
+		// Create empty downstream directory
+		downstreamPath, err := os.MkdirTemp("", "gitspork-drift-downstream-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(downstreamPath)
+
+		// Create .gitspork.yml in upstream
+		gitsporkConfig := `version: v0.0.1
+upstream_owned:
+- test.txt
+`
+		err = os.WriteFile(filepath.Join(upstreamPath, ".gitspork.yml"), []byte(gitsporkConfig), 0644)
+		require.NoError(t, err)
+
+		// Create file only in upstream
+		err = os.WriteFile(filepath.Join(upstreamPath, "test.txt"), []byte("content"), 0644)
+		require.NoError(t, err)
+
+		// Parse config and check drift - should not error
+		config, err := getGitSporkConfig(upstreamPath)
+		require.NoError(t, err)
+
+		err = checkUpstreamDrift(config, upstreamPath, downstreamPath, NewLogger())
+		assert.NoError(t, err, "Should not error when downstream files don't exist yet")
+	})
+}


### PR DESCRIPTION
## Goal

Add an opt-in \`--check-drift\` flag to \`integrate\` and \`integrate-local\` that shows a colored diff of any upstream-owned files locally modified in the downstream, then prompts to continue or abort before any file changes happen.

## Review Guide

The new behavior is entirely opt-in — no behavior change unless \`--check-drift\` is passed. Key paths to review:

- \`internal/integrate.go\` — \`checkUpstreamDrift()\` runs before any file modifications; uses existing \`getIntegrateFiles()\` and \`input.RequestInput()\` patterns
- \`cmd/integrate.go\` / \`cmd/integrate-local.go\` — flag wiring only, nothing else changed
- \`internal/integrate_drift_test.go\` — unit tests for detect/no-detect/skip cases; run with \`make test\`

To test locally: run \`gitspork integrate --check-drift ...\` against a downstream that has a modified upstream-owned file.

**Note:** The reviewer has raised a design question about whether this approach fully covers all drift scenarios (shared-ownership blocks, config version changes). This flag currently covers only \`upstream_owned\` file drift — more complex drift detection may warrant a separate follow-up.

## Repo Specific

N/A