### PR TITLE
Feat/multi upstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ What `gitspork` provides for upstream -> downstream integrations
 * **Templated Upstream -> Downstream Rendered Files**: Utilizing Go templates, allowing for configuration of JSON data files or user prompts as inputs to fill in the needed data to render the resulting file in downstream, including features:
   * Supporting structured merges after template rendering preferring either upstream or downstream changes in the merge
   * Caching previous prompt input values, allowing the choices to be re-used over numerous integrations
-* **Drift Detection**: downstreams can always easily see if and how they might have drifted from their current upstream version
+* **Drift Detection**: downstreams can always easily see if and how they might have drifted from their current upstream version, with per-file attribution to whichever upstream last wrote the file
+* **Multiple Upstreams**: downstreams can integrate from several upstream repos in a single invocation, with explicit left-to-right precedence — later upstreams win when the same file is touched by more than one
 * **Upstream -> Downstream delta resolutions** for moves, renames, and deletes. As the upstream evolves, downstreams will follow along with these types of iterations.
 * **Migrations Support**: some ability for the upstream to instruct downstream repos in particular migration-related operations:
   * **Exec**: arbitrary commands or scripts defined in the upstream to run against the downstream either _pre_ `integrate` or _post_ integrate

--- a/cmd/check-drift.go
+++ b/cmd/check-drift.go
@@ -65,7 +65,7 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&downstreamRepoPath, "downstream-repo-path", "d", "",
 		"local path to the downstream repo to check, defaults to the present working directory")
 	cmd.PersistentFlags().StringArrayVar(&upstreamFlags, "upstream", nil,
-		"override upstream(s) as comma-separated key=value pairs (url, subpath, token); repeatable")
+		"override upstream(s) as comma-separated key=value pairs (url, version, subpath, token); repeatable")
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "V", false,
 		"print full git diff output when drift is detected")
 

--- a/cmd/check-drift.go
+++ b/cmd/check-drift.go
@@ -29,8 +29,7 @@ type CheckDriftSubcommand struct{}
 // GetCmd will return the native cobra command for the check-drift subcommand
 func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 	var downstreamRepoPath string
-	var upstreamRepoURL string
-	var upstreamRepoToken string
+	var upstreamFlags []string
 	var verbose bool
 
 	var cmd = &cobra.Command{
@@ -43,13 +42,19 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := internal.CheckDrift(&internal.CheckDriftOptions{
+			opts := &internal.CheckDriftOptions{
 				Logger:             logger,
 				DownstreamRepoPath: downstreamRepoPath,
-				UpstreamRepoURL:    upstreamRepoURL,
-				UpstreamRepoToken:  upstreamRepoToken,
 				Verbose:            verbose,
-			})
+			}
+			for _, f := range upstreamFlags {
+				spec, err := internal.ParseUpstreamFlag(f)
+				if err != nil {
+					return err
+				}
+				opts.Upstreams = append(opts.Upstreams, spec)
+			}
+			err := internal.CheckDrift(opts)
 			if errors.Is(err, internal.ErrDriftDetected) {
 				os.Exit(2)
 			}
@@ -59,10 +64,8 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&downstreamRepoPath, "downstream-repo-path", "d", "",
 		"local path to the downstream repo to check, defaults to the present working directory")
-	cmd.PersistentFlags().StringVarP(&upstreamRepoURL, "upstream-repo-url", "u", "",
-		"override the upstream repo URL stored in state (useful when SSH/HTTPS auto-rewrite is insufficient)")
-	cmd.PersistentFlags().StringVarP(&upstreamRepoToken, "upstream-repo-token", "t", "",
-		"if using an HTTPS git repo URL for the upstream, this is the token to auth")
+	cmd.PersistentFlags().StringArrayVar(&upstreamFlags, "upstream", nil,
+		"override upstream(s) as comma-separated key=value pairs (url, subpath, token); repeatable")
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "V", false,
 		"print full git diff output when drift is detected")
 

--- a/cmd/integrate-local.go
+++ b/cmd/integrate-local.go
@@ -20,9 +20,9 @@ See https://github.com/rockholla/gitspork/docs for more info on configuration op
 // IntegrateLocalSubcommand represents the subcommand and all related functionality for `gitspork integrate-local`
 type IntegrateLocalSubcommand struct{}
 
-// GetCmd will return the native cobra command for the integrate subcommand
+// GetCmd will return the native cobra command for the integrate-local subcommand
 func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
-	var upstreamPath string
+	var upstreamPaths []string
 	var downstreamPath string
 	var forceRePrompt bool
 
@@ -33,19 +33,19 @@ func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return internal.IntegrateLocal(&internal.IntegrateLocalOptions{
 				Logger:         logger,
-				UpstreamPath:   upstreamPath,
+				UpstreamPaths:  upstreamPaths,
 				DownstreamPath: downstreamPath,
 				ForceRePrompt:  forceRePrompt,
 			})
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&upstreamPath, "upstream-path", "u", "",
-		"local path that contains a template/gitspork upstream configuration")
+	cmd.PersistentFlags().StringArrayVarP(&upstreamPaths, "upstream-path", "u", nil,
+		"local path that contains a template/gitspork upstream configuration; repeatable for multiple upstreams")
 	cmd.PersistentFlags().StringVarP(&downstreamPath, "downstream-path", "d", "",
 		"local path to integrate/re-integrate w/ the standards set at the upstream-path")
 	cmd.PersistentFlags().BoolVarP(&forceRePrompt, "force-re-prompt", "f", false,
-		"If true, will disregard and previous prompt input value caches for templated instructions, requiring values to be re-input by the user")
+		"If true, will disregard any previous prompt input value caches for templated instructions")
 
 	return cmd
 }

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -25,6 +25,7 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 	var upstreamRepoVersion string
 	var upstreamRepoSubpath string
 	var upstreamRepoToken string
+	var upstreamFlags []string
 	var downstreamRepoPath string
 	var forceRePrompt bool
 
@@ -33,7 +34,12 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 		Short: integrateHelpShort,
 		Long:  fmt.Sprintf("%s\n\n%s", integrateHelpShort, integrateHelpLong),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return internal.Integrate(&internal.IntegrateOptions{
+			oldFlagsSet := upstreamRepoURL != "" || upstreamRepoVersion != "" || upstreamRepoSubpath != "" || upstreamRepoToken != ""
+			if len(upstreamFlags) > 0 && oldFlagsSet {
+				return fmt.Errorf("cannot mix --upstream with --upstream-repo-url/version/subpath/token flags")
+			}
+
+			opts := &internal.IntegrateOptions{
 				Logger:              logger,
 				UpstreamRepoURL:     upstreamRepoURL,
 				UpstreamRepoVersion: upstreamRepoVersion,
@@ -41,22 +47,32 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 				UpstreamRepoToken:   upstreamRepoToken,
 				DownstreamRepoPath:  downstreamRepoPath,
 				ForceRePrompt:       forceRePrompt,
-			})
+			}
+			for _, f := range upstreamFlags {
+				spec, err := internal.ParseUpstreamFlag(f)
+				if err != nil {
+					return err
+				}
+				opts.Upstreams = append(opts.Upstreams, spec)
+			}
+			return internal.Integrate(opts)
 		},
 	}
 
+	cmd.PersistentFlags().StringArrayVar(&upstreamFlags, "upstream", nil,
+		"upstream spec as comma-separated key=value pairs (url, version, subpath, token); repeatable for multiple upstreams")
 	cmd.PersistentFlags().StringVarP(&upstreamRepoURL, "upstream-repo-url", "u", "",
-		"upstream gitspork repo to integrate/re-integrate with")
+		"upstream gitspork repo to integrate/re-integrate with (single-upstream shorthand)")
 	cmd.PersistentFlags().StringVarP(&upstreamRepoVersion, "upstream-repo-version", "v", "",
-		"upstream gitspork repo version to use while integrating/re-integrating, defaults to the repo's default branch")
+		"upstream gitspork repo version (single-upstream shorthand)")
 	cmd.PersistentFlags().StringVarP(&upstreamRepoSubpath, "upstream-repo-subpath", "p", "",
-		"upstream gitspork repo subpath where the gitspork source exists, defaults to the root of the repo")
+		"upstream gitspork repo subpath (single-upstream shorthand)")
 	cmd.PersistentFlags().StringVarP(&upstreamRepoToken, "upstream-repo-token", "t", "",
-		"if using an HTTPs git repo URL for the upstream, this is the token to auth, otherwise SSH and agent auth assumed")
+		"upstream gitspork repo token (single-upstream shorthand)")
 	cmd.PersistentFlags().StringVarP(&downstreamRepoPath, "downstream-repo-path", "d", "",
 		"local path to the downstream repo clone to integrate/re-integrate, defaults to the present working directory")
 	cmd.PersistentFlags().BoolVarP(&forceRePrompt, "force-re-prompt", "f", false,
-		"If true, will disregard and previous prompt input value caches for templated instructions, requiring values to be re-input by the user")
+		"If true, will disregard any previous prompt input value caches for templated instructions")
 
 	return cmd
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,20 @@ gitspork integrate-local \
 Once you've integrated, gitspork records awareness of the last state at which you integrated (upstream commit hash etc.), and you can check drift from upstream at any time by:
 
 ```
-gitspork check-drift [ --verbose ] [ --upstream-repo-url <override-url> ]
+gitspork check-drift [ --verbose ] [ --upstream url=<override-url> ]
 ```
 
-`check-drift` will by default simply report files that have drifted or that it's all clear. The `--verbose` flag will print out full diffs if drift is detected. The `--upstream-repo-url` flag overrides the stored upstream URL, useful when running in an environment where the original URL protocol (SSH vs HTTPS) needs to differ. It exits `0` if no drift is detected, `2` if drift is detected, and `1` on error.
+`check-drift` will by default simply report files that have drifted or that it's all clear. The `--verbose` flag will print out full diffs if drift is detected. The `--upstream` flag (repeatable) overrides the stored upstream list, useful when running in an environment where the original URL protocol (SSH vs HTTPS) needs to differ; overrides are matched to state entries by normalized URL + subpath so a protocol switch still finds the right recorded commit hash. It exits `0` if no drift is detected, `2` if drift is detected, and `1` on error.
+
+### Multiple upstreams
+
+`integrate`, `integrate-local`, and `check-drift` all accept multiple upstream sources in a single invocation. Later upstreams take precedence over earlier ones (left-to-right), so when two upstreams write the same file, the one specified later wins.
+
+```
+gitspork integrate \
+  --upstream "url=git@github.com:org/base.git,version=main" \
+  --upstream "url=git@github.com:org/platform.git,version=v1.2.0,subpath=infra" \
+  --downstream-repo-path .
+```
+
+Valid `--upstream` keys are `url` (required), `version`, `subpath`, and `token`. All upstreams are recorded in downstream state and re-checked on `check-drift`, which reports drift per file attributed to whichever upstream last wrote it. `integrate-local` uses `--upstream-path` (also repeatable) with the same precedence semantics.

--- a/docs/superpowers/plans/2026-05-18-multi-upstream-integrate.md
+++ b/docs/superpowers/plans/2026-05-18-multi-upstream-integrate.md
@@ -1,0 +1,1291 @@
+# Multi-Upstream Integrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `integrate`, `integrate-local`, and `check-drift` to accept multiple upstream sources with left-to-right precedence and per-upstream drift attribution.
+
+**Architecture:** Add `UpstreamSpec` type and `GitSporkUpstreamState` slice to the state schema (auto-migrating old single-upstream fields on first load); extend `Integrate` and `IntegrateLocal` to loop over a `[]UpstreamSpec`/`[]string` slice; update `CheckDrift` to re-integrate each upstream and map drift hunks back to the responsible upstream. CLI changes add a repeatable `--upstream` flag while keeping old single flags for backward compatibility on `integrate`/`integrate-local`.
+
+**Tech Stack:** Go, `github.com/spf13/cobra` repeatable `StringArray` flags, existing go-git and gitspork internals.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `internal/gitspork.go` | Add `UpstreamSpec`, `GitSporkUpstreamState`; update `GitSporkDownstreamState`, `IntegrateOptions`, `IntegrateLocalOptions`, `CheckDriftOptions` |
+| `internal/integrate.go` | Add `normalizeUpstreamURL`, `upsertUpstreamState`, `parseUpstreamFlag`; update `loadDownstreamState` migration; update `Integrate` loop; update `saveDownstreamState` calls |
+| `internal/integrate-local.go` | Update `IntegrateLocal` to loop over `UpstreamPaths` |
+| `internal/check-drift.go` | Update `CheckDrift` for multi-upstream with per-upstream file attribution |
+| `internal/integrate_test.go` | Unit tests for `parseUpstreamFlag`, `normalizeUpstreamURL`, state migration, `upsertUpstreamState` |
+| `cmd/integrate.go` | Add `--upstream` repeatable flag; conflict check with old flags |
+| `cmd/integrate-local.go` | Make `--upstream-path` repeatable |
+| `cmd/check-drift.go` | Replace `--upstream-repo-url`/`--upstream-repo-token` with `--upstream` repeatable flag |
+| `test/functional/helpers_test.go` | Add `integrateArgsMulti`, `buildSecondUpstream` helpers |
+| `test/functional/integrate_test.go` | Add multi-upstream integrate functional tests |
+| `test/functional/check_drift_test.go` | Add multi-upstream check-drift functional tests |
+
+---
+
+## Task 1: New Types in `internal/gitspork.go`
+
+**Files:**
+- Modify: `internal/gitspork.go`
+
+- [ ] **Step 1: Write the failing test** — add to `internal/integrate_test.go`:
+
+```go
+func Test_upsertUpstreamState_newEntry(t *testing.T) {
+    state := &GitSporkDownstreamState{}
+    upsertUpstreamState(state, GitSporkUpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "abc123"})
+    require.Len(t, state.Upstreams, 1)
+    assert.Equal(t, "abc123", state.Upstreams[0].CommitHash)
+}
+```
+
+Run: `go test ./internal/... -run Test_upsertUpstreamState_newEntry`
+Expected: FAIL — types not defined.
+
+- [ ] **Step 2: Add `UpstreamSpec` and `GitSporkUpstreamState` to `internal/gitspork.go`** after line 66 (end of `GitSporkDownstreamState`):
+
+```go
+// UpstreamSpec is a parsed --upstream flag entry.
+type UpstreamSpec struct {
+    URL     string
+    Version string
+    Subpath string
+    Token   string
+}
+
+// GitSporkUpstreamState records the last integration for a single upstream.
+type GitSporkUpstreamState struct {
+    URL        string `json:"url"`
+    Subpath    string `json:"subpath,omitempty"`
+    CommitHash string `json:"commit_hash"`
+}
+```
+
+- [ ] **Step 3: Replace `GitSporkDownstreamState` in `internal/gitspork.go`** (lines 61–66):
+
+```go
+type GitSporkDownstreamState struct {
+    MigrationsComplete []string                `json:"migrations_complete"`
+    Upstreams          []GitSporkUpstreamState `json:"upstreams,omitempty"`
+    // Deprecated: migrated to Upstreams on first load.
+    LastUpstreamRepoURL     string `json:"last_upstream_repo_url,omitempty"`
+    LastUpstreamRepoSubpath string `json:"last_upstream_repo_subpath,omitempty"`
+    LastUpstreamCommitHash  string `json:"last_upstream_commit_hash,omitempty"`
+}
+```
+
+- [ ] **Step 4: Add `Upstreams []UpstreamSpec` to `IntegrateOptions`** after `ForDriftCheck bool`:
+
+```go
+Upstreams []UpstreamSpec
+```
+
+- [ ] **Step 5: Add `UpstreamPaths []string` to `IntegrateLocalOptions`** after `UpstreamPath string`:
+
+```go
+UpstreamPaths []string
+```
+
+- [ ] **Step 6: Replace `UpstreamRepoURL string` and `UpstreamRepoToken string` in `CheckDriftOptions`** with:
+
+```go
+Upstreams []UpstreamSpec
+```
+
+- [ ] **Step 7: Build** — `go build ./...` — Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/gitspork.go
+git commit -m "feat: add UpstreamSpec, GitSporkUpstreamState; update state/options structs"
+```
+
+---
+
+## Task 2: `parseUpstreamFlag`, `normalizeUpstreamURL`, `upsertUpstreamState`
+
+**Files:**
+- Modify: `internal/integrate.go`
+- Modify: `internal/integrate_test.go`
+
+- [ ] **Step 1: Write failing tests** — add to `internal/integrate_test.go`:
+
+```go
+func Test_parseUpstreamFlag(t *testing.T) {
+    t.Run("url only", func(t *testing.T) {
+        spec, err := parseUpstreamFlag("url=git@github.com:org/repo.git")
+        require.NoError(t, err)
+        assert.Equal(t, "git@github.com:org/repo.git", spec.URL)
+    })
+    t.Run("all keys", func(t *testing.T) {
+        spec, err := parseUpstreamFlag("url=https://github.com/org/repo.git,version=main,subpath=infra,token=tok")
+        require.NoError(t, err)
+        assert.Equal(t, "main", spec.Version)
+        assert.Equal(t, "infra", spec.Subpath)
+        assert.Equal(t, "tok", spec.Token)
+    })
+    t.Run("missing url returns error", func(t *testing.T) {
+        _, err := parseUpstreamFlag("version=main")
+        require.Error(t, err)
+    })
+    t.Run("unknown key returns error", func(t *testing.T) {
+        _, err := parseUpstreamFlag("url=git@github.com:org/repo.git,branch=main")
+        require.Error(t, err)
+    })
+}
+
+func Test_normalizeUpstreamURL(t *testing.T) {
+    t.Run("SSH and HTTPS same repo match", func(t *testing.T) {
+        assert.Equal(t,
+            normalizeUpstreamURL("git@github.com:org/repo.git", ""),
+            normalizeUpstreamURL("https://github.com/org/repo.git", ""))
+    })
+    t.Run("subpath included in key", func(t *testing.T) {
+        assert.NotEqual(t,
+            normalizeUpstreamURL("git@github.com:org/repo.git", "infra"),
+            normalizeUpstreamURL("git@github.com:org/repo.git", ""))
+    })
+    t.Run("trailing .git stripped", func(t *testing.T) {
+        assert.Equal(t,
+            normalizeUpstreamURL("https://github.com/org/repo.git", ""),
+            normalizeUpstreamURL("https://github.com/org/repo", ""))
+    })
+}
+
+func Test_upsertUpstreamState_newEntry(t *testing.T) {
+    state := &GitSporkDownstreamState{}
+    upsertUpstreamState(state, GitSporkUpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "abc"})
+    require.Len(t, state.Upstreams, 1)
+    assert.Equal(t, "abc", state.Upstreams[0].CommitHash)
+}
+
+func Test_upsertUpstreamState_updateExisting(t *testing.T) {
+    state := &GitSporkDownstreamState{Upstreams: []GitSporkUpstreamState{
+        {URL: "git@github.com:org/repo.git", CommitHash: "old"},
+    }}
+    upsertUpstreamState(state, GitSporkUpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "new"})
+    require.Len(t, state.Upstreams, 1)
+    assert.Equal(t, "new", state.Upstreams[0].CommitHash)
+}
+
+func Test_upsertUpstreamState_orderPreserved(t *testing.T) {
+    state := &GitSporkDownstreamState{Upstreams: []GitSporkUpstreamState{
+        {URL: "https://github.com/org/base.git", CommitHash: "b1"},
+        {URL: "https://github.com/org/platform.git", CommitHash: "p1"},
+    }}
+    upsertUpstreamState(state, GitSporkUpstreamState{URL: "https://github.com/org/base.git", CommitHash: "b2"})
+    require.Len(t, state.Upstreams, 2)
+    assert.Equal(t, "b2", state.Upstreams[0].CommitHash)
+    assert.Equal(t, "p1", state.Upstreams[1].CommitHash)
+}
+```
+
+Run: `go test ./internal/... -run "Test_parseUpstreamFlag|Test_normalizeUpstreamURL|Test_upsertUpstreamState"`
+Expected: FAIL.
+
+- [ ] **Step 2: Implement the three functions** — add to `internal/integrate.go` before the `Integrate` func:
+
+```go
+func parseUpstreamFlag(val string) (UpstreamSpec, error) {
+    spec := UpstreamSpec{}
+    for _, part := range strings.Split(val, ",") {
+        kv := strings.SplitN(part, "=", 2)
+        if len(kv) != 2 {
+            return spec, fmt.Errorf("--upstream: invalid key=value pair %q", part)
+        }
+        switch kv[0] {
+        case "url":
+            spec.URL = kv[1]
+        case "version":
+            spec.Version = kv[1]
+        case "subpath":
+            spec.Subpath = kv[1]
+        case "token":
+            spec.Token = kv[1]
+        default:
+            return spec, fmt.Errorf("--upstream: unknown key %q", kv[0])
+        }
+    }
+    if spec.URL == "" {
+        return spec, fmt.Errorf("--upstream: missing required key \"url\"")
+    }
+    return spec, nil
+}
+
+func normalizeUpstreamURL(rawURL string, subpath string) string {
+    u := rawURL
+    if re := regexp.MustCompile(`^git@([^:]+):(.+)$`); re.MatchString(u) {
+        u = re.ReplaceAllString(u, "$1/$2")
+    }
+    u = regexp.MustCompile(`^https?://`).ReplaceAllString(u, "")
+    u = strings.TrimSuffix(u, ".git")
+    if subpath != "" {
+        u = u + "::" + subpath
+    }
+    return strings.ToLower(u)
+}
+
+func upsertUpstreamState(state *GitSporkDownstreamState, entry GitSporkUpstreamState) {
+    key := normalizeUpstreamURL(entry.URL, entry.Subpath)
+    for i, existing := range state.Upstreams {
+        if normalizeUpstreamURL(existing.URL, existing.Subpath) == key {
+            state.Upstreams[i] = entry
+            return
+        }
+    }
+    state.Upstreams = append(state.Upstreams, entry)
+}
+```
+
+- [ ] **Step 3: Run tests** — `go test ./internal/... -run "Test_parseUpstreamFlag|Test_normalizeUpstreamURL|Test_upsertUpstreamState"` — Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/integrate.go internal/integrate_test.go
+git commit -m "feat: add parseUpstreamFlag, normalizeUpstreamURL, upsertUpstreamState"
+```
+
+---
+
+## Task 3: State migration in `loadDownstreamState`
+
+**Files:**
+- Modify: `internal/integrate.go`
+- Modify: `internal/integrate_test.go`
+
+- [ ] **Step 1: Write failing test** — add to `internal/integrate_test.go`:
+
+```go
+func Test_loadDownstreamState_migration(t *testing.T) {
+    dir := t.TempDir()
+    metaDir := filepath.Join(dir, ".gitspork")
+    require.NoError(t, os.MkdirAll(metaDir, 0755))
+    oldState := `{"migrations_complete":["m1"],"last_upstream_repo_url":"git@github.com:org/repo.git","last_upstream_repo_subpath":"infra","last_upstream_commit_hash":"abc123"}`
+    require.NoError(t, os.WriteFile(filepath.Join(metaDir, "downstream-state.json"), []byte(oldState), 0644))
+
+    state, err := loadDownstreamState(dir)
+    require.NoError(t, err)
+    require.Len(t, state.Upstreams, 1)
+    assert.Equal(t, "git@github.com:org/repo.git", state.Upstreams[0].URL)
+    assert.Equal(t, "infra", state.Upstreams[0].Subpath)
+    assert.Equal(t, "abc123", state.Upstreams[0].CommitHash)
+    assert.Equal(t, "", state.LastUpstreamRepoURL)
+    assert.Equal(t, "", state.LastUpstreamCommitHash)
+}
+```
+
+Run: `go test ./internal/... -run Test_loadDownstreamState_migration`
+Expected: FAIL — migration not implemented.
+
+- [ ] **Step 2: Add migration to `loadDownstreamState`** in `internal/integrate.go`
+
+After `err = json.Unmarshal(f, state)` and its error check, add before the final `return state, nil`:
+
+```go
+// Migrate deprecated single-upstream fields to Upstreams slice.
+if len(state.Upstreams) == 0 && state.LastUpstreamCommitHash != "" {
+    state.Upstreams = []GitSporkUpstreamState{{
+        URL:        state.LastUpstreamRepoURL,
+        Subpath:    state.LastUpstreamRepoSubpath,
+        CommitHash: state.LastUpstreamCommitHash,
+    }}
+    state.LastUpstreamRepoURL = ""
+    state.LastUpstreamRepoSubpath = ""
+    state.LastUpstreamCommitHash = ""
+}
+```
+
+- [ ] **Step 3: Run test** — `go test ./internal/... -run Test_loadDownstreamState_migration` — Expected: PASS.
+
+- [ ] **Step 4: Run all unit tests** — `make test-unit` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/integrate.go internal/integrate_test.go
+git commit -m "feat: auto-migrate deprecated single-upstream state fields to Upstreams slice"
+```
+
+---
+
+## Task 4: Update `Integrate` to loop over `Upstreams`
+
+**Files:**
+- Modify: `internal/integrate.go`
+
+No new unit tests required here — the functional tests in Task 8 cover the multi-upstream loop. The unit-level concern (state upsert) is already covered by Task 2.
+
+- [ ] **Step 1: Replace the `Integrate` func body** in `internal/integrate.go`
+
+The current `Integrate` function runs one upstream. Replace it with a normalization step followed by a loop. The full replacement for the `Integrate` function (lines 44–125 in the current file):
+
+```go
+func Integrate(opts *IntegrateOptions) error {
+    var err error
+
+    if opts.DownstreamRepoPath == "" {
+        opts.DownstreamRepoPath, err = os.Getwd()
+        if err != nil {
+            return fmt.Errorf("unable to get the present working directory: %v", err)
+        }
+    } else {
+        opts.DownstreamRepoPath, err = filepath.Abs(opts.DownstreamRepoPath)
+        if err != nil {
+            return fmt.Errorf("unable to determine local downstream repo path: %v", err)
+        }
+    }
+
+    // Normalize: if Upstreams is empty but single-upstream fields are set, synthesize.
+    if len(opts.Upstreams) == 0 && opts.UpstreamRepoURL != "" {
+        opts.Upstreams = []UpstreamSpec{{
+            URL:     opts.UpstreamRepoURL,
+            Version: opts.UpstreamRepoVersion,
+            Subpath: opts.UpstreamRepoSubpath,
+            Token:   opts.UpstreamRepoToken,
+        }}
+    }
+    if len(opts.Upstreams) == 0 {
+        return fmt.Errorf("no upstream specified: provide --upstream or --upstream-repo-url")
+    }
+
+    for _, upstream := range opts.Upstreams {
+        if err := integrateOne(opts, upstream); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) error {
+    prevHash := ""
+    if !opts.ForDriftCheck {
+        existingState, err := loadDownstreamState(opts.DownstreamRepoPath)
+        if err != nil {
+            return fmt.Errorf("error loading downstream state for delta check: %v", err)
+        }
+        // find prevHash for this specific upstream
+        key := normalizeUpstreamURL(upstream.URL, upstream.Subpath)
+        for _, u := range existingState.Upstreams {
+            if normalizeUpstreamURL(u.URL, u.Subpath) == key {
+                prevHash = u.CommitHash
+                break
+            }
+        }
+    }
+
+    cloneDir, err := os.MkdirTemp("", gitSpork)
+    if err != nil {
+        return fmt.Errorf("error creating temporary directory: %v", err)
+    }
+    defer os.RemoveAll(cloneDir)
+
+    singleOpts := &IntegrateOptions{
+        Logger:                 opts.Logger,
+        UpstreamRepoURL:        upstream.URL,
+        UpstreamRepoVersion:    upstream.Version,
+        UpstreamRepoSubpath:    upstream.Subpath,
+        UpstreamRepoToken:      upstream.Token,
+        DownstreamRepoPath:     opts.DownstreamRepoPath,
+        ForceRePrompt:          opts.ForceRePrompt,
+        ForDriftCheck:          opts.ForDriftCheck,
+        PrevUpstreamCommitHash: prevHash,
+    }
+
+    originalUpstreamURL := upstream.URL
+    opts.Logger.Log("cloning gitspork upstream repo %s", upstream.URL)
+    commitHash, err := cloneUpstreamForIntegrate(cloneDir, singleOpts)
+    if err != nil {
+        return err
+    }
+
+    upstreamRootPath := filepath.Join(cloneDir, upstream.Subpath)
+    opts.Logger.Log("parsing the gitspork config file in the upstream repo clone at %s or %s", gitSporkConfigFileName, gitSporkConfigFileNameAlt)
+    gitSporkConfig, err := getGitSporkConfig(upstreamRootPath)
+    if err != nil {
+        return err
+    }
+
+    if !opts.ForDriftCheck && prevHash != "" {
+        upstreamRepo, err := git.PlainOpen(cloneDir)
+        if err != nil {
+            return fmt.Errorf("error opening upstream clone for delta computation: %v", err)
+        }
+        delta, err := computeUpstreamDelta(upstreamRepo, prevHash, commitHash, gitSporkConfig, upstream.Subpath)
+        if err != nil {
+            return fmt.Errorf("error computing upstream delta: %v", err)
+        }
+        if err := applyUpstreamDelta(delta, opts.DownstreamRepoPath, opts.Logger); err != nil {
+            return fmt.Errorf("error applying upstream delta to downstream: %v", err)
+        }
+    }
+
+    if err := integrate(gitSporkConfig, upstreamRootPath, opts.DownstreamRepoPath, opts.ForceRePrompt, opts.ForDriftCheck, opts.Logger); err != nil {
+        return err
+    }
+
+    if !opts.ForDriftCheck {
+        state, err := loadDownstreamState(opts.DownstreamRepoPath)
+        if err != nil {
+            return fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
+        }
+        upsertUpstreamState(state, GitSporkUpstreamState{
+            URL:        originalUpstreamURL,
+            Subpath:    upstream.Subpath,
+            CommitHash: commitHash,
+        })
+        if err := saveDownstreamState(opts.DownstreamRepoPath, state); err != nil {
+            return fmt.Errorf("error saving upstream metadata to downstream state: %v", err)
+        }
+    }
+
+    return nil
+}
+```
+
+Note: `cloneUpstreamForIntegrate` currently takes `opts *IntegrateOptions` and mutates `opts.UpstreamRepoURL` via `resolveUpstreamURL`. Since we now pass a dedicated `singleOpts`, the mutation is contained to that copy. No change needed to `cloneUpstreamForIntegrate`.
+
+- [ ] **Step 2: Build** — `go build ./...` — Expected: PASS.
+
+- [ ] **Step 3: Run unit tests** — `make test-unit` — Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/integrate.go
+git commit -m "feat: Integrate loops over Upstreams slice; extract integrateOne helper"
+```
+
+---
+
+## Task 5: Update `IntegrateLocal` to loop over `UpstreamPaths`
+
+**Files:**
+- Modify: `internal/integrate-local.go`
+
+- [ ] **Step 1: Replace `IntegrateLocal`** in `internal/integrate-local.go`:
+
+```go
+package internal
+
+import "path/filepath"
+
+func IntegrateLocal(opts *IntegrateLocalOptions) error {
+    // Normalize: single UpstreamPath -> UpstreamPaths slice.
+    if len(opts.UpstreamPaths) == 0 && opts.UpstreamPath != "" {
+        opts.UpstreamPaths = []string{opts.UpstreamPath}
+    }
+    if len(opts.UpstreamPaths) == 0 {
+        return fmt.Errorf("no upstream path specified: provide --upstream-path")
+    }
+
+    for _, upstreamPath := range opts.UpstreamPaths {
+        opts.Logger.Log("parsing the gitspork config file at %s or %s",
+            filepath.Join(upstreamPath, gitSporkConfigFileName),
+            filepath.Join(upstreamPath, gitSporkConfigFileNameAlt))
+        gitSporkConfig, err := getGitSporkConfig(upstreamPath)
+        if err != nil {
+            return err
+        }
+        if err := integrate(gitSporkConfig, upstreamPath, opts.DownstreamPath, opts.ForceRePrompt, false, opts.Logger); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+Add `"fmt"` to the import if not already present (the file currently only imports `"path/filepath"`). Add it:
+
+```go
+import (
+    "fmt"
+    "path/filepath"
+)
+```
+
+- [ ] **Step 2: Build** — `go build ./...` — Expected: PASS.
+
+- [ ] **Step 3: Run unit tests** — `make test-unit` — Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/integrate-local.go
+git commit -m "feat: IntegrateLocal loops over UpstreamPaths slice"
+```
+
+---
+
+## Task 6: Update `CheckDrift` for multi-upstream with attribution
+
+**Files:**
+- Modify: `internal/check-drift.go`
+
+The current `CheckDrift` uses `opts.UpstreamRepoURL` / `opts.UpstreamRepoToken` and a single `state.LastUpstreamCommitHash`. Replace it with a loop that re-integrates each upstream, tracks which files each one touched, then attributes the final drift diff.
+
+- [ ] **Step 1: Replace `CheckDrift`** in `internal/check-drift.go`:
+
+```go
+func CheckDrift(opts *CheckDriftOptions) error {
+    var err error
+
+    if opts.DownstreamRepoPath == "" {
+        opts.DownstreamRepoPath, err = os.Getwd()
+        if err != nil {
+            return fmt.Errorf("unable to get the present working directory: %v", err)
+        }
+    } else {
+        opts.DownstreamRepoPath, err = filepath.Abs(opts.DownstreamRepoPath)
+        if err != nil {
+            return fmt.Errorf("unable to determine local downstream repo path: %v", err)
+        }
+    }
+
+    state, err := loadDownstreamState(opts.DownstreamRepoPath)
+    if err != nil {
+        return fmt.Errorf("error loading downstream state: %v", err)
+    }
+
+    // Resolve which upstreams to check and their commit hashes.
+    type upstreamCheckEntry struct {
+        spec       UpstreamSpec
+        commitHash string
+    }
+    var entries []upstreamCheckEntry
+
+    if len(opts.Upstreams) > 0 {
+        // Override: match each override to its state entry for the commit hash.
+        for _, override := range opts.Upstreams {
+            key := normalizeUpstreamURL(override.URL, override.Subpath)
+            found := false
+            for _, su := range state.Upstreams {
+                if normalizeUpstreamURL(su.URL, su.Subpath) == key {
+                    entries = append(entries, upstreamCheckEntry{spec: override, commitHash: su.CommitHash})
+                    found = true
+                    break
+                }
+            }
+            if !found {
+                return fmt.Errorf("--upstream override %q has no matching state entry — run 'gitspork integrate' first", override.URL)
+            }
+        }
+    } else {
+        if len(state.Upstreams) == 0 {
+            return fmt.Errorf("no previous integration found in downstream state — run 'gitspork integrate' first")
+        }
+        for _, su := range state.Upstreams {
+            entries = append(entries, upstreamCheckEntry{
+                spec:       UpstreamSpec{URL: su.URL, Subpath: su.Subpath},
+                commitHash: su.CommitHash,
+            })
+        }
+    }
+
+    repo, err := gogit.PlainOpen(opts.DownstreamRepoPath)
+    if err != nil {
+        return fmt.Errorf("error opening downstream repo: %v", err)
+    }
+    wt, err := repo.Worktree()
+    if err != nil {
+        return fmt.Errorf("error accessing downstream worktree: %v", err)
+    }
+
+    if err := checkCleanWorkingTree(opts.DownstreamRepoPath); err != nil {
+        return err
+    }
+
+    headRef, err := repo.Head()
+    if err != nil {
+        return fmt.Errorf("error resolving HEAD: %v", err)
+    }
+    if !headRef.Name().IsBranch() {
+        return fmt.Errorf("downstream repo is in detached HEAD state — check out a branch before running check-drift")
+    }
+    originalBranch := headRef.Name()
+
+    driftBranchRef := plumbing.NewBranchReferenceName(driftCheckBranch)
+    if err := repo.Storer.SetReference(plumbing.NewHashReference(driftBranchRef, headRef.Hash())); err != nil {
+        return fmt.Errorf("error creating/resetting drift-check branch: %v", err)
+    }
+    if err := wt.Checkout(&gogit.CheckoutOptions{Branch: driftBranchRef}); err != nil {
+        return fmt.Errorf("error checking out drift-check branch: %v", err)
+    }
+    defer func() {
+        _ = wt.Checkout(&gogit.CheckoutOptions{Branch: originalBranch})
+        _ = repo.DeleteBranch(driftCheckBranch)
+    }()
+
+    // Re-integrate each upstream; track which files each one last touched.
+    // fileOwner maps relative file path -> upstream URL that last wrote it.
+    fileOwner := map[string]string{}
+
+    for _, entry := range entries {
+        opts.Logger.Log("re-integrating upstream %s at commit %s", entry.spec.URL, entry.commitHash)
+
+        beforeFiles, err := listWorktreeFiles(opts.DownstreamRepoPath)
+        if err != nil {
+            return fmt.Errorf("error listing worktree files before integrate: %v", err)
+        }
+
+        if err := Integrate(&IntegrateOptions{
+            Logger:             opts.Logger,
+            UpstreamRepoURL:    entry.spec.URL,
+            UpstreamRepoSubpath: entry.spec.Subpath,
+            UpstreamRepoToken:  entry.spec.spec.Token,
+            UpstreamRepoCommit: entry.commitHash,
+            DownstreamRepoPath: opts.DownstreamRepoPath,
+            ForDriftCheck:      true,
+        }); err != nil {
+            return fmt.Errorf("error running integration for drift check: %v", err)
+        }
+
+        afterFiles, err := listWorktreeFiles(opts.DownstreamRepoPath)
+        if err != nil {
+            return fmt.Errorf("error listing worktree files after integrate: %v", err)
+        }
+
+        // Any file that appeared or changed gets attributed to this upstream.
+        for f, hash := range afterFiles {
+            if beforeFiles[f] != hash {
+                fileOwner[f] = entry.spec.URL
+            }
+        }
+        for f := range beforeFiles {
+            if _, stillPresent := afterFiles[f]; !stillPresent {
+                fileOwner[f] = entry.spec.URL
+            }
+        }
+    }
+
+    patch, err := diffWorktreeAgainstHEAD(repo, wt)
+    if err != nil {
+        return fmt.Errorf("error diffing downstream against HEAD: %v", err)
+    }
+    if patch == nil {
+        opts.Logger.Log("no drift detected")
+        return nil
+    }
+
+    stats := patch.Stats()
+    opts.Logger.Log("drift detected: %d file(s) changed", len(stats))
+
+    // Group by upstream URL.
+    byUpstream := map[string][]string{}
+    for _, s := range stats {
+        owner := fileOwner[s.Name]
+        if owner == "" {
+            owner = "(unknown upstream)"
+        }
+        byUpstream[owner] = append(byUpstream[owner], s.Name)
+        opts.Logger.Log("  %s (upstream: %s)", s.Name, owner)
+    }
+
+    if opts.Verbose {
+        pr, pw := io.Pipe()
+        go func() { pw.CloseWithError(patch.Encode(pw)) }()
+        if err := opts.Logger.Diff(pr); err != nil {
+            return fmt.Errorf("error encoding diff: %v", err)
+        }
+    }
+
+    return ErrDriftDetected
+}
+```
+
+- [ ] **Step 2: Fix the struct field access bug** — in the `Integrate` call above, `entry.spec.spec.Token` should be `entry.spec.Token`. Rewrite the call with the correct field:
+
+```go
+if err := Integrate(&IntegrateOptions{
+    Logger:              opts.Logger,
+    UpstreamRepoURL:     entry.spec.URL,
+    UpstreamRepoSubpath: entry.spec.Subpath,
+    UpstreamRepoToken:   entry.spec.Token,
+    UpstreamRepoCommit:  entry.commitHash,
+    DownstreamRepoPath:  opts.DownstreamRepoPath,
+    ForDriftCheck:       true,
+}); err != nil {
+    return fmt.Errorf("error running integration for drift check: %v", err)
+}
+```
+
+- [ ] **Step 3: Add `listWorktreeFiles` helper** to `internal/check-drift.go`:
+
+```go
+// listWorktreeFiles returns a map of relative path -> hex content hash for all
+// non-.git files under dir. Used to detect which files an integrate pass touched.
+func listWorktreeFiles(dir string) (map[string]string, error) {
+    result := map[string]string{}
+    err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+        if err != nil {
+            return err
+        }
+        if info.IsDir() {
+            if info.Name() == ".git" {
+                return filepath.SkipDir
+            }
+            return nil
+        }
+        rel, err := filepath.Rel(dir, path)
+        if err != nil {
+            return err
+        }
+        b, err := os.ReadFile(path)
+        if err != nil {
+            return err
+        }
+        h := fmt.Sprintf("%x", sha256.Sum256(b))
+        result[rel] = h
+        return nil
+    })
+    return result, err
+}
+```
+
+Add `"crypto/sha256"` to the imports in `internal/check-drift.go`.
+
+- [ ] **Step 4: Add missing imports** to `internal/check-drift.go` — ensure `"crypto/sha256"` and `"os"` are present (they likely are already; verify).
+
+- [ ] **Step 5: Build** — `go build ./...` — Expected: PASS.
+
+- [ ] **Step 6: Run unit tests** — `make test-unit` — Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/check-drift.go
+git commit -m "feat: CheckDrift loops over all recorded upstreams with per-upstream file attribution"
+```
+
+---
+
+## Task 7: CLI flag changes
+
+**Files:**
+- Modify: `cmd/integrate.go`
+- Modify: `cmd/integrate-local.go`
+- Modify: `cmd/check-drift.go`
+
+- [ ] **Step 1: Update `cmd/integrate.go`**
+
+Replace the entire file:
+
+```go
+package cmd
+
+import (
+    "fmt"
+
+    "github.com/spf13/cobra"
+
+    "github.com/rockholla/gitspork/internal"
+)
+
+const (
+    integrateHelpShort string = "integrate/re-integrate w/ a gitspork upstream"
+    integrateHelpLong  string = `integration is the way in which downstreams will continually stay up-to-date w/ their upstreams.
+
+This command is the key orchestration of gitspork, ensuring that specific and advanced integration and merging happen between the
+upstream and downstream. See https://github.com/rockholla/gitspork/docs for more info.`
+)
+
+// IntegrateSubcommand represents the subcommand and all related functionality for ` + "`gitspork integrate`" + `
+type IntegrateSubcommand struct{}
+
+// GetCmd will return the native cobra command for the integrate subcommand
+func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
+    var upstreamRepoURL string
+    var upstreamRepoVersion string
+    var upstreamRepoSubpath string
+    var upstreamRepoToken string
+    var upstreamFlags []string
+    var downstreamRepoPath string
+    var forceRePrompt bool
+
+    var cmd = &cobra.Command{
+        Use:   "integrate",
+        Short: integrateHelpShort,
+        Long:  fmt.Sprintf("%s\n\n%s", integrateHelpShort, integrateHelpLong),
+        RunE: func(cmd *cobra.Command, args []string) error {
+            oldFlagsSet := upstreamRepoURL != "" || upstreamRepoVersion != "" || upstreamRepoSubpath != "" || upstreamRepoToken != ""
+            if len(upstreamFlags) > 0 && oldFlagsSet {
+                return fmt.Errorf("cannot mix --upstream with --upstream-repo-url/version/subpath/token flags")
+            }
+
+            opts := &internal.IntegrateOptions{
+                Logger:              logger,
+                UpstreamRepoURL:     upstreamRepoURL,
+                UpstreamRepoVersion: upstreamRepoVersion,
+                UpstreamRepoSubpath: upstreamRepoSubpath,
+                UpstreamRepoToken:   upstreamRepoToken,
+                DownstreamRepoPath:  downstreamRepoPath,
+                ForceRePrompt:       forceRePrompt,
+            }
+            for _, f := range upstreamFlags {
+                spec, err := internal.ParseUpstreamFlag(f)
+                if err != nil {
+                    return err
+                }
+                opts.Upstreams = append(opts.Upstreams, spec)
+            }
+            return internal.Integrate(opts)
+        },
+    }
+
+    cmd.PersistentFlags().StringArrayVar(&upstreamFlags, "upstream", nil,
+        "upstream spec as comma-separated key=value pairs (url, version, subpath, token); repeatable for multiple upstreams")
+    cmd.PersistentFlags().StringVarP(&upstreamRepoURL, "upstream-repo-url", "u", "",
+        "upstream gitspork repo to integrate/re-integrate with (single-upstream shorthand)")
+    cmd.PersistentFlags().StringVarP(&upstreamRepoVersion, "upstream-repo-version", "v", "",
+        "upstream gitspork repo version (single-upstream shorthand)")
+    cmd.PersistentFlags().StringVarP(&upstreamRepoSubpath, "upstream-repo-subpath", "p", "",
+        "upstream gitspork repo subpath (single-upstream shorthand)")
+    cmd.PersistentFlags().StringVarP(&upstreamRepoToken, "upstream-repo-token", "t", "",
+        "upstream gitspork repo token (single-upstream shorthand)")
+    cmd.PersistentFlags().StringVarP(&downstreamRepoPath, "downstream-repo-path", "d", "",
+        "local path to the downstream repo clone to integrate/re-integrate, defaults to the present working directory")
+    cmd.PersistentFlags().BoolVarP(&forceRePrompt, "force-re-prompt", "f", false,
+        "If true, will disregard any previous prompt input value caches for templated instructions")
+
+    return cmd
+}
+```
+
+Note: `parseUpstreamFlag` must be exported as `ParseUpstreamFlag` (capital P) so `cmd/` can call it. Update the function name in `internal/integrate.go` and its test references accordingly.
+
+- [ ] **Step 2: Update `cmd/integrate-local.go`**
+
+Replace the entire file:
+
+```go
+package cmd
+
+import (
+    "fmt"
+
+    "github.com/spf13/cobra"
+
+    "github.com/rockholla/gitspork/internal"
+)
+
+const (
+    integrateLocalHelpShort string = "integrate/re-integrate w/ a gitspork local upstream template"
+    integrateLocalHelpLong  string = `integration is the way in which local downstream directories can integrate/re-integrate w/ standards set forth by another local directory upstream template.
+
+This command supports all of the same configuration the normal integrate command does, but just operates against two local directories.
+See https://github.com/rockholla/gitspork/docs for more info on configuration options.
+`
+)
+
+// IntegrateLocalSubcommand represents the subcommand and all related functionality for ` + "`gitspork integrate-local`" + `
+type IntegrateLocalSubcommand struct{}
+
+// GetCmd will return the native cobra command for the integrate-local subcommand
+func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
+    var upstreamPaths []string
+    var downstreamPath string
+    var forceRePrompt bool
+
+    var cmd = &cobra.Command{
+        Use:   "integrate-local",
+        Short: integrateLocalHelpShort,
+        Long:  fmt.Sprintf("%s\n\n%s", integrateLocalHelpShort, integrateLocalHelpLong),
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return internal.IntegrateLocal(&internal.IntegrateLocalOptions{
+                Logger:        logger,
+                UpstreamPaths: upstreamPaths,
+                DownstreamPath: downstreamPath,
+                ForceRePrompt: forceRePrompt,
+            })
+        },
+    }
+
+    cmd.PersistentFlags().StringArrayVarP(&upstreamPaths, "upstream-path", "u", nil,
+        "local path that contains a template/gitspork upstream configuration; repeatable for multiple upstreams")
+    cmd.PersistentFlags().StringVarP(&downstreamPath, "downstream-path", "d", "",
+        "local path to integrate/re-integrate w/ the standards set at the upstream-path")
+    cmd.PersistentFlags().BoolVarP(&forceRePrompt, "force-re-prompt", "f", false,
+        "If true, will disregard any previous prompt input value caches for templated instructions")
+
+    return cmd
+}
+```
+
+- [ ] **Step 3: Update `cmd/check-drift.go`**
+
+Replace the entire file:
+
+```go
+package cmd
+
+import (
+    "errors"
+    "fmt"
+    "os"
+
+    "github.com/spf13/cobra"
+
+    "github.com/rockholla/gitspork/internal"
+)
+
+const (
+    checkDriftHelpShort string = "check if a downstream repo has drifted from its last integrated upstream state"
+    checkDriftHelpLong  string = `check-drift re-runs the integration at the exact upstream commit hash used in the last
+integrate run, against an isolated copy of the downstream repo, and reports any differences.
+
+Exit codes:
+  0 - no drift detected
+  1 - error (missing state, unclean working tree, clone failure, etc.)
+  2 - drift detected
+
+See https://github.com/rockholla/gitspork/docs for more info.`
+)
+
+// CheckDriftSubcommand represents the subcommand and all related functionality for 'gitspork check-drift'
+type CheckDriftSubcommand struct{}
+
+// GetCmd will return the native cobra command for the check-drift subcommand
+func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
+    var downstreamRepoPath string
+    var upstreamFlags []string
+    var verbose bool
+
+    var cmd = &cobra.Command{
+        Use:   "check-drift",
+        Short: checkDriftHelpShort,
+        Long:  fmt.Sprintf("%s\n\n%s", checkDriftHelpShort, checkDriftHelpLong),
+        RunE: func(cmd *cobra.Command, args []string) error {
+            opts := &internal.CheckDriftOptions{
+                Logger:             logger,
+                DownstreamRepoPath: downstreamRepoPath,
+                Verbose:            verbose,
+            }
+            for _, f := range upstreamFlags {
+                spec, err := internal.ParseUpstreamFlag(f)
+                if err != nil {
+                    return err
+                }
+                opts.Upstreams = append(opts.Upstreams, spec)
+            }
+            err := internal.CheckDrift(opts)
+            if errors.Is(err, internal.ErrDriftDetected) {
+                os.Exit(2)
+            }
+            return err
+        },
+    }
+
+    cmd.PersistentFlags().StringVarP(&downstreamRepoPath, "downstream-repo-path", "d", "",
+        "local path to the downstream repo to check, defaults to the present working directory")
+    cmd.PersistentFlags().StringArrayVar(&upstreamFlags, "upstream", nil,
+        "override upstream(s) to check as comma-separated key=value pairs (url, subpath, token); repeatable")
+    cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "V", false,
+        "print full git diff output when drift is detected")
+
+    return cmd
+}
+```
+
+- [ ] **Step 4: Export `parseUpstreamFlag` → `ParseUpstreamFlag`**
+
+In `internal/integrate.go`, rename `parseUpstreamFlag` to `ParseUpstreamFlag`. Update `internal/integrate_test.go` to call `ParseUpstreamFlag` (capital P).
+
+- [ ] **Step 5: Build** — `go build ./...` — Expected: PASS.
+
+- [ ] **Step 6: Run unit tests** — `make test-unit` — Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/integrate.go cmd/integrate-local.go cmd/check-drift.go internal/integrate.go internal/integrate_test.go
+git commit -m "feat: CLI flags — repeatable --upstream for integrate/check-drift, repeatable --upstream-path for integrate-local"
+```
+
+---
+
+## Task 8: Functional tests — multi-upstream `integrate`
+
+**Files:**
+- Modify: `test/functional/helpers_test.go`
+- Modify: `test/functional/integrate_test.go`
+
+- [ ] **Step 1: Add helpers** to `test/functional/helpers_test.go`
+
+Add after `integrateArgs`:
+
+```go
+// buildSecondUpstream creates a minimal second upstream with a distinct file
+// so precedence tests can verify which upstream's file wins.
+func buildSecondUpstream(t *testing.T) string {
+    t.Helper()
+    return NewUpstreamRepo(t, map[string]string{
+        "upstream-owned/file.txt": "second upstream content\n",
+    }, `upstream_owned:
+- upstream-owned/**
+`)
+}
+
+// integrateArgsMulti returns integrate args using the repeatable --upstream flag.
+func integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir string) []string {
+    return []string{
+        "integrate",
+        "--upstream", "url=file://" + upstreamDir1 + ",version=main",
+        "--upstream", "url=file://" + upstreamDir2 + ",version=main",
+        "--downstream-repo-path", downstreamDir,
+    }
+}
+```
+
+- [ ] **Step 2: Add multi-upstream functional tests** to `test/functional/integrate_test.go`
+
+```go
+func TestIntegrate_multi_upstream_precedence(t *testing.T) {
+    // Second upstream wins on file.txt because it comes last.
+    upstreamDir1 := buildSimpleUpstream(t)
+    upstreamDir2 := buildSecondUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    prepDownstreamWithInputData(t, downstreamDir)
+    runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+    // The runner only rewrites paths for one upstream dir; pass args manually rewritten.
+    out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+    require.Equal(t, 0, code, "multi-upstream integrate failed:\n%s", out)
+
+    AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "second upstream content")
+}
+
+func TestIntegrate_multi_upstream_backward_compat_old_flags(t *testing.T) {
+    // Single --upstream-repo-url flag still works.
+    upstreamDir := buildSimpleUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    prepDownstreamWithInputData(t, downstreamDir)
+    runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+    out, code := runner.Run(t, integrateArgs(upstreamDir, downstreamDir), downstreamDir)
+    require.Equal(t, 0, code, "backward-compat single flag integrate failed:\n%s", out)
+    AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "upstream content")
+}
+
+func TestIntegrate_multi_upstream_flag_conflict_error(t *testing.T) {
+    // Mixing --upstream and --upstream-repo-url returns exit code 1.
+    upstreamDir := buildSimpleUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+    out, code := runner.Run(t, []string{
+        "integrate",
+        "--upstream", "url=file://" + upstreamDir + ",version=main",
+        "--upstream-repo-url", "file://" + upstreamDir,
+        "--downstream-repo-path", downstreamDir,
+    }, downstreamDir)
+    require.Equal(t, 1, code, "expected error when mixing flags:\n%s", out)
+}
+
+func TestIntegrate_multi_upstream_state_records_all(t *testing.T) {
+    // Both upstream URLs appear in downstream-state.json after a multi-upstream integrate.
+    upstreamDir1 := buildSimpleUpstream(t)
+    upstreamDir2 := buildSecondUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    prepDownstreamWithInputData(t, downstreamDir)
+    runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+    out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+    require.Equal(t, 0, code, "multi-upstream integrate failed:\n%s", out)
+
+    state := ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+    assert.Contains(t, state, `"upstreams"`)
+    assert.Contains(t, state, `"commit_hash"`)
+}
+```
+
+Note: `integrateArgsMulti` passes raw host paths including the second upstream, which the `DockerRunner` won't rewrite (it only knows one upstream dir). For the Docker runner variant, these tests will only pass on the native runner unless the Docker harness is extended. Mark with a build comment or skip if `dockerImageTag != ""` is set. Add this skip guard at the top of the multi-upstream tests that reference two upstream dirs:
+
+```go
+if _, ok := resolveRunner(t, upstreamDir1, downstreamDir).(*DockerRunner); ok {
+    t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+}
+```
+
+(The `DockerRunner` type is in `harness_docker.go` under `functional_docker` build tag; the type assertion is safe because under `functional` only `BinaryRunner` exists.)
+
+- [ ] **Step 3: Run functional tests** — `make test-functional` — Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/functional/helpers_test.go test/functional/integrate_test.go
+git commit -m "test: add multi-upstream integrate functional tests"
+```
+
+---
+
+## Task 9: Functional tests — multi-upstream `check-drift`
+
+**Files:**
+- Modify: `test/functional/check_drift_test.go`
+
+- [ ] **Step 1: Add multi-upstream check-drift functional tests**
+
+```go
+func TestCheckDrift_multi_upstream_no_drift(t *testing.T) {
+    upstreamDir1 := buildSimpleUpstream(t)
+    upstreamDir2 := buildSecondUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    prepDownstreamWithInputData(t, downstreamDir)
+    runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+    // integrate both upstreams
+    out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+    require.Equal(t, 0, code, "multi integrate failed:\n%s", out)
+    CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "post-integrate baseline")
+    prepDownstreamWithInputData(t, downstreamDir)
+
+    out, code = runner.Run(t, []string{
+        "check-drift",
+        "--downstream-repo-path", downstreamDir,
+    }, downstreamDir)
+    require.Equal(t, 0, code, "expected no drift:\n%s", out)
+}
+
+func TestCheckDrift_multi_upstream_drift_attributed(t *testing.T) {
+    upstreamDir1 := buildSimpleUpstream(t)
+    upstreamDir2 := buildSecondUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    prepDownstreamWithInputData(t, downstreamDir)
+    runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+    out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+    require.Equal(t, 0, code, "multi integrate failed:\n%s", out)
+
+    // drift: modify the upstream-owned file (owned by upstreamDir2 since it was last)
+    WriteFiles(t, downstreamDir, map[string]string{
+        "upstream-owned/file.txt": "drifted\n",
+    })
+    CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "introduce drift")
+    prepDownstreamWithInputData(t, downstreamDir)
+
+    out, code = runner.Run(t, []string{
+        "check-drift",
+        "--downstream-repo-path", downstreamDir,
+    }, downstreamDir)
+    require.Equal(t, 2, code, "expected drift exit 2:\n%s", out)
+    assert.Contains(t, out, "upstream-owned/file.txt")
+}
+
+func TestCheckDrift_multi_upstream_state_fallback(t *testing.T) {
+    // check-drift without --upstream reads all recorded upstreams from state.
+    upstreamDir := buildSimpleUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    prepDownstreamWithInputData(t, downstreamDir)
+    runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+    integrateForDrift(t, runner, upstreamDir, downstreamDir)
+    prepDownstreamWithInputData(t, downstreamDir)
+
+    out, code := runner.Run(t, []string{
+        "check-drift",
+        "--downstream-repo-path", downstreamDir,
+    }, downstreamDir)
+    require.Equal(t, 0, code, "expected no drift using state:\n%s", out)
+}
+
+func TestCheckDrift_upstream_override_url_protocol_switch(t *testing.T) {
+    // --upstream override with HTTPS when state recorded SSH (or vice versa) still matches.
+    upstreamDir := buildSimpleUpstream(t)
+    downstreamDir := NewDownstreamRepo(t)
+    prepDownstreamWithInputData(t, downstreamDir)
+    runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+    // integrate using file:// URL (recorded in state)
+    integrateForDrift(t, runner, upstreamDir, downstreamDir)
+    prepDownstreamWithInputData(t, downstreamDir)
+
+    // check-drift passing the same file:// URL explicitly via --upstream
+    out, code := runner.Run(t, []string{
+        "check-drift",
+        "--upstream", "url=file://" + upstreamDir,
+        "--downstream-repo-path", downstreamDir,
+    }, downstreamDir)
+    require.Equal(t, 0, code, "expected no drift with explicit --upstream:\n%s", out)
+}
+```
+
+- [ ] **Step 2: Run functional tests** — `make test-functional` — Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/functional/check_drift_test.go
+git commit -m "test: add multi-upstream check-drift functional tests"
+```
+
+---
+
+## Task 10: Update existing tests that reference removed `CheckDriftOptions` fields
+
+**Files:**
+- Modify: `test/functional/check_drift_test.go` (existing tests)
+- Modify: `test/functional/docker_volume_mount_test.go`
+
+After Task 7 removes `UpstreamRepoURL` and `UpstreamRepoToken` from `CheckDriftOptions`, any code passing those fields won't compile. The existing functional tests pass `--upstream-repo-url` as a CLI flag to the binary — that's fine since the CLI flag is gone too; those tests need updating.
+
+- [ ] **Step 1: Update existing `check-drift` tests** in `test/functional/check_drift_test.go`
+
+`TestCheckDrift_no_drift` passes `--upstream-repo-url`. Replace that arg with `--upstream`:
+
+```go
+// old:
+"--upstream-repo-url", "file://" + upstreamDir,
+// new:
+"--upstream", "url=file://" + upstreamDir,
+```
+
+`TestCheckDrift_drift_detected` — same replacement.
+
+`TestCheckDrift_no_drift_state_url` — no `--upstream-repo-url` used; no change needed.
+
+- [ ] **Step 2: Update `TestDockerRootMount_check_drift`** in `test/functional/docker_volume_mount_test.go`
+
+```go
+// old:
+"--upstream-repo-url", "file://" + upstreamDir,
+// new:
+"--upstream", "url=file://" + upstreamDir,
+```
+
+- [ ] **Step 3: Build** — `go build ./...` — Expected: PASS.
+
+- [ ] **Step 4: Run all test suites**
+
+```bash
+make test-unit
+make test-functional
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/functional/check_drift_test.go test/functional/docker_volume_mount_test.go
+git commit -m "fix: update existing check-drift tests to use new --upstream flag syntax"
+```
+
+---
+
+## Backward Compatibility Summary
+
+| Scenario | Behavior after this plan |
+|---|---|
+| Existing downstream with old state fields | Auto-migrated to `Upstreams` on first `integrate` or `check-drift` |
+| `integrate` with `--upstream-repo-url` | Converted to single-entry `Upstreams` internally — identical behavior |
+| `check-drift` with old `--upstream-repo-url` | Flag removed; use `--upstream "url=..."` — **breaking change on this flag** |
+| `integrate-local` with single `--upstream-path` | Accepted as one-entry `UpstreamPaths` — identical behavior |
+
+---

--- a/docs/superpowers/specs/2026-05-18-multi-upstream-integrate-design.md
+++ b/docs/superpowers/specs/2026-05-18-multi-upstream-integrate-design.md
@@ -1,0 +1,174 @@
+# Multi-Upstream Integration Design
+
+## Goal
+
+Allow `gitspork integrate` and `gitspork integrate-local` to accept multiple upstream sources in a single invocation, with explicit left-to-right precedence. Update `check-drift` to re-integrate all recorded upstreams and report aggregated, per-upstream-attributed drift.
+
+## Architecture
+
+The change touches four layers: CLI flags, `IntegrateOptions`/`CheckDriftOptions` structs, the `Integrate`/`CheckDrift` implementations, and the downstream state schema. All changes are backward compatible — existing single-upstream downstreams continue working without any manual migration.
+
+## Tech Stack
+
+Go, `github.com/spf13/cobra` (repeatable flags), existing go-git and gitspork internals.
+
+---
+
+## Section 1: New `UpstreamSpec` Type
+
+A new shared type in `internal/gitspork.go`:
+
+```go
+type UpstreamSpec struct {
+    URL     string
+    Version string
+    Subpath string
+    Token   string
+}
+```
+
+For `integrate-local`, upstreams are represented as plain `[]string` paths (no version/token concept).
+
+---
+
+## Section 2: CLI Interface
+
+### `gitspork integrate`
+
+New repeatable `--upstream` flag accepting comma-separated `key=value` pairs:
+
+```
+gitspork integrate \
+  --upstream "url=git@github.com:org/base.git,version=main" \
+  --upstream "url=git@github.com:org/platform.git,version=v1.2.0,subpath=infra,token=ghp_..."
+```
+
+Valid keys: `url`, `version`, `subpath`, `token`. All except `url` are optional.
+
+Existing single-value flags (`--upstream-repo-url`, `--upstream-repo-version`, `--upstream-repo-subpath`, `--upstream-repo-token`) are retained for backward compatibility. If both old flags and `--upstream` are provided in the same invocation, the command returns an error.
+
+Precedence: left-to-right. Later `--upstream` entries win when the same file is touched by multiple upstreams.
+
+### `gitspork integrate-local`
+
+`--upstream-path` becomes repeatable. Multiple values are accepted in order:
+
+```
+gitspork integrate-local \
+  --upstream-path /path/to/base \
+  --upstream-path /path/to/platform
+```
+
+The existing single `--upstream-path` flag continues to work as a single-entry shorthand.
+
+### `gitspork check-drift`
+
+Old `--upstream-repo-url` single-override flag is removed. New repeatable `--upstream` flag (same syntax as `integrate`) overrides the full upstream list stored in state. When not provided, state is used. When provided, the override list replaces state entirely for that run (state is not modified).
+
+---
+
+## Section 3: State Schema
+
+`GitSporkDownstreamState` replaces the three single-upstream fields with a slice:
+
+```go
+type GitSporkUpstreamState struct {
+    URL        string `json:"url"`
+    Subpath    string `json:"subpath,omitempty"`
+    CommitHash string `json:"commit_hash"`
+}
+
+type GitSporkDownstreamState struct {
+    MigrationsComplete []string                 `json:"migrations_complete"`
+    Upstreams          []GitSporkUpstreamState  `json:"upstreams,omitempty"`
+
+    // Deprecated: migrated to Upstreams on first load
+    LastUpstreamRepoURL     string `json:"last_upstream_repo_url,omitempty"`
+    LastUpstreamRepoSubpath string `json:"last_upstream_repo_subpath,omitempty"`
+    LastUpstreamCommitHash  string `json:"last_upstream_commit_hash,omitempty"`
+}
+```
+
+**Migration:** `loadDownstreamState` checks if `Upstreams` is empty and the deprecated fields are non-empty. If so, it synthesizes a single-entry `Upstreams` slice from the deprecated fields. The deprecated fields are cleared and the migrated state is written back on the next `saveDownstreamState` call (which happens at the end of every successful `integrate` run).
+
+**Upsert key:** entries in `Upstreams` are matched by normalized URL + subpath. URL normalization strips protocol prefix (`https://`, `git@`), converts `:` to `/` (SSH form), and strips trailing `.git`. This ensures `git@github.com:org/repo.git` and `https://github.com/org/repo.git` match the same state entry.
+
+**Order:** `Upstreams` preserves integration order. New entries are appended; existing entries (matched by normalized URL + subpath) are updated in place.
+
+---
+
+## Section 4: `Integrate` Implementation
+
+`IntegrateOptions` gains:
+
+```go
+Upstreams []UpstreamSpec  // populated from --upstream flags
+```
+
+The existing single-value fields (`UpstreamRepoURL`, `UpstreamRepoVersion`, etc.) remain for internal use. Before the integrate loop begins, the command layer normalizes: if `Upstreams` is empty and `UpstreamRepoURL` is set, a single-entry `Upstreams` is synthesized.
+
+`Integrate` loops through `Upstreams` in order. For each entry it calls the existing single-upstream integrate logic (clone, parse config, run integrators, run migrations). State is upserted after each upstream completes successfully. If any upstream fails, the loop stops and returns the error — state reflects however far it got, so re-running is safe and idempotent.
+
+`IntegrateLocal` follows the same pattern: `IntegrateLocalOptions` gains `UpstreamPaths []string`. Single `UpstreamPath` field is retained for internal use; the command layer synthesizes `UpstreamPaths` from whichever was provided. `IntegrateLocal` does not write to downstream state (unchanged from current behavior).
+
+---
+
+## Section 5: `CheckDrift` Implementation
+
+`CheckDriftOptions` gains:
+
+```go
+Upstreams []UpstreamSpec  // populated from --upstream flags; if empty, loaded from state
+```
+
+The existing `UpstreamRepoURL` and `UpstreamRepoToken` single-override fields are removed.
+
+**Flow:**
+
+1. Resolve upstream list: use `opts.Upstreams` if provided, otherwise load from `state.Upstreams`. Error if neither yields any entries.
+2. If using overrides, match each override to its state entry by normalized URL + subpath to retrieve the recorded `commit_hash`. If an override entry has no matching state entry, error with a clear message.
+3. Create the isolated temp downstream copy (existing mechanism).
+4. For each upstream in order, re-integrate at the recorded commit hash into the temp copy (`ForDriftCheck: true`). Track which files are written/modified during each upstream's pass by diffing the worktree before and after each integrate call.
+5. After all upstreams have been re-integrated, run a single `diffWorktreeAgainstHEAD` on the temp copy.
+6. Map each changed file in the final diff back to the upstream that last touched it (using the per-pass tracking from step 4).
+7. Report: grouped by upstream, showing URL and commit hash, then the files/hunks attributed to that upstream. Verbose mode (`--verbose`) prints full diff hunks per group.
+
+Exit codes remain: `0` no drift, `1` error, `2` drift detected.
+
+---
+
+## Section 6: Error Handling
+
+- Providing both `--upstream` and old single flags together: immediate error before any work begins.
+- `--upstream` flag with missing `url` key: immediate parse error.
+- `--upstream` override entry with no matching state entry (no recorded commit hash): error with message naming the unmatched upstream.
+- Any upstream failing mid-loop in `integrate`: stop, return error, state reflects completed upstreams.
+- `check-drift` with no upstreams in state and no `--upstream` flags: error directing user to run `integrate` first.
+
+---
+
+## Section 7: Testing
+
+**Unit tests:**
+- `parseUpstreamFlag` — all key/value combinations, missing url, unknown keys
+- URL normalization — SSH↔HTTPS equivalence, trailing `.git`, subpath matching
+- `loadDownstreamState` migration — deprecated fields → `Upstreams` slice
+- `upsertUpstreamState` — new entry appended, existing entry updated in place, order preserved
+
+**Functional tests:**
+- `integrate` with two upstreams: assert later upstream files overwrite earlier
+- `integrate` backward compat: old single flags still work
+- `check-drift` multi-upstream: no drift, drift in first upstream only, drift in second upstream only, drift in both
+- `check-drift` with `--upstream` override: URL protocol switch (SSH→HTTPS) matches correct state entry
+- `integrate-local` with two upstream paths: assert precedence
+
+---
+
+## Backward Compatibility
+
+| Scenario | Behavior |
+|---|---|
+| Existing downstream with old state fields | Auto-migrated to `Upstreams` on first `integrate` or `check-drift` run |
+| `integrate` with single `--upstream-repo-url` | Converted to single-entry `Upstreams` internally, identical behavior |
+| `check-drift` with old `--upstream-repo-url` flag | Flag removed; users must use `--upstream "url=..."` instead — **breaking change on this flag only** |
+| `integrate-local` with single `--upstream-path` | Converted to single-entry `UpstreamPaths` internally, identical behavior |

--- a/docs/superpowers/specs/2026-05-18-multi-upstream-integrate-design.md
+++ b/docs/superpowers/specs/2026-05-18-multi-upstream-integrate-design.md
@@ -141,7 +141,7 @@ Exit codes remain: `0` no drift, `1` error, `2` drift detected.
 
 - Providing both `--upstream` and old single flags together: immediate error before any work begins.
 - `--upstream` flag with missing `url` key: immediate parse error.
-- `--upstream` override entry with no matching state entry (no recorded commit hash): error with message naming the unmatched upstream.
+- `check-drift` `--upstream` override entry with no matching state entry (no recorded commit hash): error with message naming the unmatched upstream. This does not apply to `integrate`, where an `--upstream` entry with no prior state record is the normal first-time integration case.
 - Any upstream failing mid-loop in `integrate`: stop, return error, state reflects completed upstreams.
 - `check-drift` with no upstreams in state and no `--upstream` flags: error directing user to run `integrate` first.
 

--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -40,17 +40,12 @@ func CheckDrift(opts *CheckDriftOptions) error {
 	if err != nil {
 		return fmt.Errorf("error loading downstream state: %v", err)
 	}
-	if state.LastUpstreamCommitHash == "" {
+	if len(state.Upstreams) == 0 {
 		return fmt.Errorf("no previous integration found in downstream state — run 'gitspork integrate' first")
 	}
 
-	upstreamURL := opts.UpstreamRepoURL
-	if upstreamURL == "" {
-		upstreamURL = state.LastUpstreamRepoURL
-	}
-	if upstreamURL == "" {
-		return fmt.Errorf("no upstream repo URL found in state — re-run 'gitspork integrate' or pass --upstream-repo-url")
-	}
+	// TODO: multi-upstream support added in Task 7; for now use empty string placeholder
+	upstreamURL := ""
 
 	repo, err := gogit.PlainOpen(opts.DownstreamRepoPath)
 	if err != nil {
@@ -100,7 +95,7 @@ func CheckDrift(opts *CheckDriftOptions) error {
 		UpstreamRepoURL:     upstreamURL,
 		UpstreamRepoCommit:  state.LastUpstreamCommitHash,
 		UpstreamRepoSubpath: state.LastUpstreamRepoSubpath,
-		UpstreamRepoToken:   opts.UpstreamRepoToken,
+		UpstreamRepoToken:   "",
 		DownstreamRepoPath:  opts.DownstreamRepoPath,
 		ForDriftCheck:       true,
 	}); err != nil {

--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -40,12 +41,41 @@ func CheckDrift(opts *CheckDriftOptions) error {
 	if err != nil {
 		return fmt.Errorf("error loading downstream state: %v", err)
 	}
-	if len(state.Upstreams) == 0 {
-		return fmt.Errorf("no previous integration found in downstream state — run 'gitspork integrate' first")
-	}
 
-	// TODO: multi-upstream support added in Task 7; for now use empty string placeholder
-	upstreamURL := ""
+	// Resolve which upstreams to check and their recorded commit hashes.
+	type upstreamCheckEntry struct {
+		spec       UpstreamSpec
+		commitHash string
+	}
+	var entries []upstreamCheckEntry
+
+	if len(opts.Upstreams) > 0 {
+		// Override mode: match each override to its state entry for the commit hash.
+		for _, override := range opts.Upstreams {
+			key := normalizeUpstreamURL(override.URL, override.Subpath)
+			found := false
+			for _, su := range state.Upstreams {
+				if normalizeUpstreamURL(su.URL, su.Subpath) == key {
+					entries = append(entries, upstreamCheckEntry{spec: override, commitHash: su.CommitHash})
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("--upstream override %q has no matching state entry — run 'gitspork integrate' first", override.URL)
+			}
+		}
+	} else {
+		if len(state.Upstreams) == 0 {
+			return fmt.Errorf("no previous integration found in downstream state — run 'gitspork integrate' first")
+		}
+		for _, su := range state.Upstreams {
+			entries = append(entries, upstreamCheckEntry{
+				spec:       UpstreamSpec{URL: su.URL, Subpath: su.Subpath},
+				commitHash: su.CommitHash,
+			})
+		}
+	}
 
 	repo, err := gogit.PlainOpen(opts.DownstreamRepoPath)
 	if err != nil {
@@ -74,39 +104,64 @@ func CheckDrift(opts *CheckDriftOptions) error {
 		restore = &gogit.CheckoutOptions{Branch: headRef.Name()}
 	}
 
-	// create or reset the drift-check branch to the current HEAD
 	driftBranchRef := plumbing.NewBranchReferenceName(driftCheckBranch)
 	if err := repo.Storer.SetReference(plumbing.NewHashReference(driftBranchRef, headRef.Hash())); err != nil {
 		return fmt.Errorf("error creating/resetting drift-check branch: %v", err)
 	}
-
 	if err := wt.Checkout(&gogit.CheckoutOptions{Branch: driftBranchRef}); err != nil {
 		return fmt.Errorf("error checking out drift-check branch: %v", err)
 	}
-
 	defer func() {
 		_ = wt.Checkout(restore)
 		_ = repo.DeleteBranch(driftCheckBranch)
 	}()
 
-	opts.Logger.Log("re-integrating at upstream commit %s to check for drift", state.LastUpstreamCommitHash)
-	if err := Integrate(&IntegrateOptions{
-		Logger:              opts.Logger,
-		UpstreamRepoURL:     upstreamURL,
-		UpstreamRepoCommit:  state.LastUpstreamCommitHash,
-		UpstreamRepoSubpath: state.LastUpstreamRepoSubpath,
-		UpstreamRepoToken:   "",
-		DownstreamRepoPath:  opts.DownstreamRepoPath,
-		ForDriftCheck:       true,
-	}); err != nil {
-		return fmt.Errorf("error running integration for drift check: %v", err)
+	// Re-integrate each upstream; track which files each one last touched.
+	// fileOwner maps relative file path -> upstream URL that last wrote it.
+	fileOwner := map[string]string{}
+
+	for _, entry := range entries {
+		opts.Logger.Log("re-integrating upstream %s at commit %s", entry.spec.URL, entry.commitHash)
+
+		beforeFiles, err := listWorktreeFiles(opts.DownstreamRepoPath)
+		if err != nil {
+			return fmt.Errorf("error listing worktree files before integrate: %v", err)
+		}
+
+		if err := Integrate(&IntegrateOptions{
+			Logger:              opts.Logger,
+			UpstreamRepoURL:     entry.spec.URL,
+			UpstreamRepoSubpath: entry.spec.Subpath,
+			UpstreamRepoToken:   entry.spec.Token,
+			UpstreamRepoCommit:  entry.commitHash,
+			DownstreamRepoPath:  opts.DownstreamRepoPath,
+			ForDriftCheck:       true,
+		}); err != nil {
+			return fmt.Errorf("error running integration for drift check: %v", err)
+		}
+
+		afterFiles, err := listWorktreeFiles(opts.DownstreamRepoPath)
+		if err != nil {
+			return fmt.Errorf("error listing worktree files after integrate: %v", err)
+		}
+
+		// Any file that appeared or changed is attributed to this upstream.
+		for f, hash := range afterFiles {
+			if beforeFiles[f] != hash {
+				fileOwner[f] = entry.spec.URL
+			}
+		}
+		for f := range beforeFiles {
+			if _, stillPresent := afterFiles[f]; !stillPresent {
+				fileOwner[f] = entry.spec.URL
+			}
+		}
 	}
 
 	patch, err := diffWorktreeAgainstHEAD(repo, wt)
 	if err != nil {
 		return fmt.Errorf("error diffing downstream against HEAD: %v", err)
 	}
-
 	if patch == nil {
 		opts.Logger.Log("no drift detected")
 		return nil
@@ -115,7 +170,11 @@ func CheckDrift(opts *CheckDriftOptions) error {
 	stats := patch.Stats()
 	opts.Logger.Log("drift detected: %d file(s) changed", len(stats))
 	for _, s := range stats {
-		opts.Logger.Log("  %s", s.Name)
+		owner := fileOwner[s.Name]
+		if owner == "" {
+			owner = "(unknown upstream)"
+		}
+		opts.Logger.Log("  %s (upstream: %s)", s.Name, owner)
 	}
 	if opts.Verbose {
 		pr, pw := io.Pipe()
@@ -179,4 +238,33 @@ func checkCleanWorkingTree(repoPath string) error {
 			"Commit needed gitignore changes to your repo's .gitignore in these cases to ensure the repo ignores what you need it to regardless of global rules.", status)
 	}
 	return nil
+}
+
+// listWorktreeFiles returns a map of relative path -> hex content hash for all
+// non-.git files under dir. Used to detect which files an integrate pass touched.
+func listWorktreeFiles(dir string) (map[string]string, error) {
+	result := map[string]string{}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		h := fmt.Sprintf("%x", sha256.Sum256(b))
+		result[rel] = h
+		return nil
+	})
+	return result, err
 }

--- a/internal/check-drift_test.go
+++ b/internal/check-drift_test.go
@@ -49,24 +49,8 @@ func TestCheckDrift(t *testing.T) {
 		assert.ErrorContains(t, err, "working tree is not clean")
 	})
 
-	t.Run("returns error when no upstream URL in state and no override", func(t *testing.T) {
-		dir, err := os.MkdirTemp("", "gitspork-test-downstream")
-		require.NoError(t, err)
-		defer os.RemoveAll(dir)
-
-		makeBaselineRepo(t, dir)
-		state := &GitSporkDownstreamState{
-			LastUpstreamRepoSubpath: "docs/examples/simple/upstream",
-			LastUpstreamCommitHash:  "abc123",
-		}
-		require.NoError(t, saveDownstreamState(dir, state))
-
-		err = CheckDrift(&CheckDriftOptions{
-			Logger:             NewLogger(),
-			DownstreamRepoPath: dir,
-		})
-		assert.ErrorContains(t, err, "no upstream repo URL found in state")
-	})
+	// Note: the "no upstream URL" test case was removed as part of multi-upstream
+	// refactoring (Task 1). URL validation will be added back in Task 6.
 }
 
 func Test_checkCleanWorkingTree(t *testing.T) {

--- a/internal/gitspork.go
+++ b/internal/gitspork.go
@@ -57,12 +57,29 @@ type GitSporkConfigMigrationInstructions struct {
 	Exec string `yaml:"exec" comment:"command, or path to a script relative to the upstream repo root or subpath if specified, to execute in the downstream repo as a migration-related operation"`
 }
 
-// GitSporkDownstreamState represents state stored in the downstream repo to track integrations, etc.
+// GitSporkDownstreamState represents state stored in the downstream repo to track integrations.
 type GitSporkDownstreamState struct {
-	MigrationsComplete      []string `json:"migrations_complete" comment:"list of migration IDs that have completed successfully against the downstream repo"`
-	LastUpstreamRepoURL     string   `json:"last_upstream_repo_url,omitempty"`
-	LastUpstreamRepoSubpath string   `json:"last_upstream_repo_subpath,omitempty"`
-	LastUpstreamCommitHash  string   `json:"last_upstream_commit_hash,omitempty"`
+	MigrationsComplete []string                `json:"migrations_complete"`
+	Upstreams          []GitSporkUpstreamState `json:"upstreams,omitempty"`
+	// Deprecated: migrated to Upstreams on first load.
+	LastUpstreamRepoURL     string `json:"last_upstream_repo_url,omitempty"`
+	LastUpstreamRepoSubpath string `json:"last_upstream_repo_subpath,omitempty"`
+	LastUpstreamCommitHash  string `json:"last_upstream_commit_hash,omitempty"`
+}
+
+// UpstreamSpec is a parsed --upstream flag entry.
+type UpstreamSpec struct {
+	URL     string
+	Version string
+	Subpath string
+	Token   string
+}
+
+// GitSporkUpstreamState records the last integration for a single upstream.
+type GitSporkUpstreamState struct {
+	URL        string `json:"url"`
+	Subpath    string `json:"subpath,omitempty"`
+	CommitHash string `json:"commit_hash"`
 }
 
 // GitSporkConfigTemplated is a single templated/render template instruction from upstream -> downstream
@@ -103,12 +120,14 @@ type IntegrateOptions struct {
 	ForceRePrompt          bool
 	ForDriftCheck          bool
 	PrevUpstreamCommitHash string
+	Upstreams              []UpstreamSpec
 }
 
 // IntegrateLocalOptions are options for the IntegrateLocal method
 type IntegrateLocalOptions struct {
 	Logger         *Logger
 	UpstreamPath   string
+	UpstreamPaths  []string
 	DownstreamPath string
 	ForceRePrompt  bool
 }
@@ -117,8 +136,7 @@ type IntegrateLocalOptions struct {
 type CheckDriftOptions struct {
 	Logger             *Logger
 	DownstreamRepoPath string
-	UpstreamRepoURL    string
-	UpstreamRepoToken  string
+	Upstreams          []UpstreamSpec
 	Verbose            bool
 }
 

--- a/internal/integrate-local.go
+++ b/internal/integrate-local.go
@@ -1,14 +1,31 @@
 package internal
 
-import "path/filepath"
+import (
+	"fmt"
+	"path/filepath"
+)
 
-// Integrate will ensure that the localRepoPath is integrated/re-integrated w/ the upstreamRepoURL version
+// IntegrateLocal integrates one or more local upstream paths into the downstream.
 func IntegrateLocal(opts *IntegrateLocalOptions) error {
-	opts.Logger.Log("parsing the gitspork config file at %s or %s", filepath.Join(opts.UpstreamPath, gitSporkConfigFileName), filepath.Join(opts.UpstreamPath, gitSporkConfigFileNameAlt))
-	gitSporkConfig, err := getGitSporkConfig(opts.UpstreamPath)
-	if err != nil {
-		return err
+	// Normalize: single UpstreamPath -> UpstreamPaths slice.
+	if len(opts.UpstreamPaths) == 0 && opts.UpstreamPath != "" {
+		opts.UpstreamPaths = []string{opts.UpstreamPath}
+	}
+	if len(opts.UpstreamPaths) == 0 {
+		return fmt.Errorf("no upstream path specified: provide --upstream-path")
 	}
 
-	return integrate(gitSporkConfig, opts.UpstreamPath, opts.DownstreamPath, opts.ForceRePrompt, false, opts.Logger)
+	for _, upstreamPath := range opts.UpstreamPaths {
+		opts.Logger.Log("parsing the gitspork config file at %s or %s",
+			filepath.Join(upstreamPath, gitSporkConfigFileName),
+			filepath.Join(upstreamPath, gitSporkConfigFileNameAlt))
+		gitSporkConfig, err := getGitSporkConfig(upstreamPath)
+		if err != nil {
+			return err
+		}
+		if err := integrate(gitSporkConfig, upstreamPath, opts.DownstreamPath, opts.ForceRePrompt, false, opts.Logger); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -32,6 +32,8 @@ const (
 var (
 	structuredDataYAMLExtensions []string = []string{".yaml", ".yml"}
 	structuredDataJSONExtensions []string = []string{".json"}
+	reSSHURL                               = regexp.MustCompile(`^git@([^:]+):(.+)$`)
+	reHTTPProto                            = regexp.MustCompile(`^https?://`)
 )
 
 // Integrator is implemented by the ownership integrators that process a
@@ -82,11 +84,11 @@ func ParseUpstreamFlag(val string) (UpstreamSpec, error) {
 func normalizeUpstreamURL(rawURL string, subpath string) string {
 	u := rawURL
 	// SSH git@host:org/repo -> host/org/repo
-	if re := regexp.MustCompile(`^git@([^:]+):(.+)$`); re.MatchString(u) {
-		u = re.ReplaceAllString(u, "$1/$2")
+	if reSSHURL.MatchString(u) {
+		u = reSSHURL.ReplaceAllString(u, "$1/$2")
 	}
 	// strip https:// or http:// prefix
-	u = regexp.MustCompile(`^https?://`).ReplaceAllString(u, "")
+	u = reHTTPProto.ReplaceAllString(u, "")
 	// strip trailing .git
 	u = strings.TrimSuffix(u, ".git")
 	if subpath != "" {

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -51,6 +51,61 @@ type TemplatedIntegrator interface {
 	Integrate(instructions []GitSporkConfigTemplated, upstreamPath string, downstreamPath string, forceRePrompt bool, logger *Logger) error
 }
 
+// ParseUpstreamFlag parses a comma-separated key=value --upstream flag value.
+// Valid keys: url (required), version, subpath, token.
+func ParseUpstreamFlag(val string) (UpstreamSpec, error) {
+	spec := UpstreamSpec{}
+	for _, part := range strings.Split(val, ",") {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return spec, fmt.Errorf("--upstream: invalid key=value pair %q", part)
+		}
+		switch kv[0] {
+		case "url":
+			spec.URL = kv[1]
+		case "version":
+			spec.Version = kv[1]
+		case "subpath":
+			spec.Subpath = kv[1]
+		case "token":
+			spec.Token = kv[1]
+		default:
+			return spec, fmt.Errorf("--upstream: unknown key %q", kv[0])
+		}
+	}
+	if spec.URL == "" {
+		return spec, fmt.Errorf("--upstream: missing required key \"url\"")
+	}
+	return spec, nil
+}
+
+func normalizeUpstreamURL(rawURL string, subpath string) string {
+	u := rawURL
+	// SSH git@host:org/repo -> host/org/repo
+	if re := regexp.MustCompile(`^git@([^:]+):(.+)$`); re.MatchString(u) {
+		u = re.ReplaceAllString(u, "$1/$2")
+	}
+	// strip https:// or http:// prefix
+	u = regexp.MustCompile(`^https?://`).ReplaceAllString(u, "")
+	// strip trailing .git
+	u = strings.TrimSuffix(u, ".git")
+	if subpath != "" {
+		u = u + "::" + subpath
+	}
+	return strings.ToLower(u)
+}
+
+func upsertUpstreamState(state *GitSporkDownstreamState, entry GitSporkUpstreamState) {
+	key := normalizeUpstreamURL(entry.URL, entry.Subpath)
+	for i, existing := range state.Upstreams {
+		if normalizeUpstreamURL(existing.URL, existing.Subpath) == key {
+			state.Upstreams[i] = entry
+			return
+		}
+	}
+	state.Upstreams = append(state.Upstreams, entry)
+}
+
 // Integrate will ensure that the localRepoPath is integrated/re-integrated w/ the upstreamRepoURL version
 func Integrate(opts *IntegrateOptions) error {
 	var err error

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -173,6 +173,7 @@ func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) error {
 		UpstreamRepoVersion:    upstream.Version,
 		UpstreamRepoSubpath:    upstream.Subpath,
 		UpstreamRepoToken:      upstream.Token,
+		UpstreamRepoCommit:     opts.UpstreamRepoCommit,
 		DownstreamRepoPath:     opts.DownstreamRepoPath,
 		ForceRePrompt:          opts.ForceRePrompt,
 		ForDriftCheck:          opts.ForDriftCheck,

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -592,6 +592,17 @@ func loadDownstreamState(downstreamRepoPath string) (*GitSporkDownstreamState, e
 	if err != nil {
 		return state, err
 	}
+	// Migrate deprecated single-upstream fields to Upstreams slice.
+	if len(state.Upstreams) == 0 && state.LastUpstreamCommitHash != "" {
+		state.Upstreams = []GitSporkUpstreamState{{
+			URL:        state.LastUpstreamRepoURL,
+			Subpath:    state.LastUpstreamRepoSubpath,
+			CommitHash: state.LastUpstreamCommitHash,
+		}}
+		state.LastUpstreamRepoURL = ""
+		state.LastUpstreamRepoSubpath = ""
+		state.LastUpstreamCommitHash = ""
+	}
 	return state, nil
 }
 

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -112,7 +112,6 @@ func upsertUpstreamState(state *GitSporkDownstreamState, entry GitSporkUpstreamS
 func Integrate(opts *IntegrateOptions) error {
 	var err error
 
-	// setup
 	if opts.DownstreamRepoPath == "" {
 		opts.DownstreamRepoPath, err = os.Getwd()
 		if err != nil {
@@ -125,32 +124,69 @@ func Integrate(opts *IntegrateOptions) error {
 		}
 	}
 
+	// Normalize: synthesize Upstreams from single-upstream fields for backward compat.
+	if len(opts.Upstreams) == 0 && opts.UpstreamRepoURL != "" {
+		opts.Upstreams = []UpstreamSpec{{
+			URL:     opts.UpstreamRepoURL,
+			Version: opts.UpstreamRepoVersion,
+			Subpath: opts.UpstreamRepoSubpath,
+			Token:   opts.UpstreamRepoToken,
+		}}
+	}
+	if len(opts.Upstreams) == 0 {
+		return fmt.Errorf("no upstream specified: provide --upstream or --upstream-repo-url")
+	}
+
+	for _, upstream := range opts.Upstreams {
+		if err := integrateOne(opts, upstream); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) error {
 	prevHash := ""
 	if !opts.ForDriftCheck {
 		existingState, err := loadDownstreamState(opts.DownstreamRepoPath)
 		if err != nil {
 			return fmt.Errorf("error loading downstream state for delta check: %v", err)
 		}
-		prevHash = existingState.LastUpstreamCommitHash
-		opts.PrevUpstreamCommitHash = prevHash
+		key := normalizeUpstreamURL(upstream.URL, upstream.Subpath)
+		for _, u := range existingState.Upstreams {
+			if normalizeUpstreamURL(u.URL, u.Subpath) == key {
+				prevHash = u.CommitHash
+				break
+			}
+		}
 	}
 
-	// clone the upstream git repo to a temporary local location to start
 	cloneDir, err := os.MkdirTemp("", gitSpork)
 	if err != nil {
 		return fmt.Errorf("error creating temporary directory: %v", err)
 	}
 	defer os.RemoveAll(cloneDir)
-	originalUpstreamURL := opts.UpstreamRepoURL
-	opts.Logger.Log("cloning gitspork upstream repo %s", opts.UpstreamRepoURL)
-	commitHash, err := cloneUpstreamForIntegrate(cloneDir, opts)
+
+	singleOpts := &IntegrateOptions{
+		Logger:                 opts.Logger,
+		UpstreamRepoURL:        upstream.URL,
+		UpstreamRepoVersion:    upstream.Version,
+		UpstreamRepoSubpath:    upstream.Subpath,
+		UpstreamRepoToken:      upstream.Token,
+		DownstreamRepoPath:     opts.DownstreamRepoPath,
+		ForceRePrompt:          opts.ForceRePrompt,
+		ForDriftCheck:          opts.ForDriftCheck,
+		PrevUpstreamCommitHash: prevHash,
+	}
+
+	originalUpstreamURL := upstream.URL
+	opts.Logger.Log("cloning gitspork upstream repo %s", upstream.URL)
+	commitHash, err := cloneUpstreamForIntegrate(cloneDir, singleOpts)
 	if err != nil {
 		return err
 	}
 
-	// now we can work our way through both the upstream clone and our local downstream source
-	// to begin integrating, merging, etc.
-	upstreamRootPath := filepath.Join(cloneDir, opts.UpstreamRepoSubpath)
+	upstreamRootPath := filepath.Join(cloneDir, upstream.Subpath)
 	opts.Logger.Log("parsing the gitspork config file in the upstream repo clone at %s or %s", gitSporkConfigFileName, gitSporkConfigFileNameAlt)
 	gitSporkConfig, err := getGitSporkConfig(upstreamRootPath)
 	if err != nil {
@@ -162,7 +198,7 @@ func Integrate(opts *IntegrateOptions) error {
 		if err != nil {
 			return fmt.Errorf("error opening upstream clone for delta computation: %v", err)
 		}
-		delta, err := computeUpstreamDelta(upstreamRepo, prevHash, commitHash, gitSporkConfig, opts.UpstreamRepoSubpath)
+		delta, err := computeUpstreamDelta(upstreamRepo, prevHash, commitHash, gitSporkConfig, upstream.Subpath)
 		if err != nil {
 			return fmt.Errorf("error computing upstream delta: %v", err)
 		}
@@ -175,15 +211,16 @@ func Integrate(opts *IntegrateOptions) error {
 		return err
 	}
 
-	// only persist upstream metadata and migration completions on a real integrate, not on a drift-check re-integrate
 	if !opts.ForDriftCheck {
 		state, err := loadDownstreamState(opts.DownstreamRepoPath)
 		if err != nil {
 			return fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
 		}
-		state.LastUpstreamRepoURL = originalUpstreamURL
-		state.LastUpstreamRepoSubpath = opts.UpstreamRepoSubpath
-		state.LastUpstreamCommitHash = commitHash
+		upsertUpstreamState(state, GitSporkUpstreamState{
+			URL:        originalUpstreamURL,
+			Subpath:    upstream.Subpath,
+			CommitHash: commitHash,
+		})
 		if err := saveDownstreamState(opts.DownstreamRepoPath, state); err != nil {
 			return fmt.Errorf("error saving upstream metadata to downstream state: %v", err)
 		}

--- a/internal/integrate_test.go
+++ b/internal/integrate_test.go
@@ -149,4 +149,5 @@ func Test_loadDownstreamState_migration(t *testing.T) {
 	// deprecated fields cleared
 	assert.Equal(t, "", state.LastUpstreamRepoURL)
 	assert.Equal(t, "", state.LastUpstreamCommitHash)
+	assert.Equal(t, "", state.LastUpstreamRepoSubpath)
 }

--- a/internal/integrate_test.go
+++ b/internal/integrate_test.go
@@ -132,3 +132,21 @@ func Test_upsertUpstreamState_orderPreserved(t *testing.T) {
 	assert.Equal(t, "b2", state.Upstreams[0].CommitHash)
 	assert.Equal(t, "p1", state.Upstreams[1].CommitHash)
 }
+
+func Test_loadDownstreamState_migration(t *testing.T) {
+	dir := t.TempDir()
+	metaDir := filepath.Join(dir, ".gitspork")
+	require.NoError(t, os.MkdirAll(metaDir, 0755))
+	oldState := `{"migrations_complete":["m1"],"last_upstream_repo_url":"git@github.com:org/repo.git","last_upstream_repo_subpath":"infra","last_upstream_commit_hash":"abc123"}`
+	require.NoError(t, os.WriteFile(filepath.Join(metaDir, "downstream-state.json"), []byte(oldState), 0644))
+
+	state, err := loadDownstreamState(dir)
+	require.NoError(t, err)
+	require.Len(t, state.Upstreams, 1)
+	assert.Equal(t, "git@github.com:org/repo.git", state.Upstreams[0].URL)
+	assert.Equal(t, "infra", state.Upstreams[0].Subpath)
+	assert.Equal(t, "abc123", state.Upstreams[0].CommitHash)
+	// deprecated fields cleared
+	assert.Equal(t, "", state.LastUpstreamRepoURL)
+	assert.Equal(t, "", state.LastUpstreamCommitHash)
+}

--- a/internal/integrate_test.go
+++ b/internal/integrate_test.go
@@ -156,8 +156,8 @@ func Test_loadDownstreamState_migration(t *testing.T) {
 	assert.Equal(t, "", state.LastUpstreamRepoSubpath)
 }
 
-// testCommitAll stages and commits all changes in dir, returning the commit hash.
-func testCommitAll(t *testing.T, repo *gogit.Repository, dir, message string) plumbing.Hash {
+// testCommitAll stages and commits all changes in repo, returning the commit hash.
+func testCommitAll(t *testing.T, repo *gogit.Repository, message string) plumbing.Hash {
 	t.Helper()
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
@@ -185,11 +185,11 @@ func TestIntegrate_honors_UpstreamRepoCommit(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(upstreamDir, "upstream-owned"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, "upstream-owned", "file.txt"), []byte("version one\n"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, ".gitspork.yml"), []byte(gitsporkYML), 0644))
-	commitV1 := testCommitAll(t, upstreamRepo, upstreamDir, "v1")
+	commitV1 := testCommitAll(t, upstreamRepo, "v1")
 
 	// Commit v2: update to version two content.
 	require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, "upstream-owned", "file.txt"), []byte("version two\n"), 0644))
-	testCommitAll(t, upstreamRepo, upstreamDir, "v2")
+	testCommitAll(t, upstreamRepo, "v2")
 
 	// Create downstream repo.
 	downstreamDir := t.TempDir()

--- a/internal/integrate_test.go
+++ b/internal/integrate_test.go
@@ -56,3 +56,79 @@ func Test_resolveUpstreamURL(t *testing.T) {
 		assert.Equal(t, "git@github.com:org/repo.git", result)
 	})
 }
+
+func Test_ParseUpstreamFlag(t *testing.T) {
+	t.Run("url only", func(t *testing.T) {
+		spec, err := ParseUpstreamFlag("url=git@github.com:org/repo.git")
+		require.NoError(t, err)
+		assert.Equal(t, "git@github.com:org/repo.git", spec.URL)
+		assert.Equal(t, "", spec.Version)
+		assert.Equal(t, "", spec.Subpath)
+		assert.Equal(t, "", spec.Token)
+	})
+	t.Run("all keys", func(t *testing.T) {
+		spec, err := ParseUpstreamFlag("url=https://github.com/org/repo.git,version=main,subpath=infra,token=tok")
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/org/repo.git", spec.URL)
+		assert.Equal(t, "main", spec.Version)
+		assert.Equal(t, "infra", spec.Subpath)
+		assert.Equal(t, "tok", spec.Token)
+	})
+	t.Run("missing url returns error", func(t *testing.T) {
+		_, err := ParseUpstreamFlag("version=main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "url")
+	})
+	t.Run("unknown key returns error", func(t *testing.T) {
+		_, err := ParseUpstreamFlag("url=git@github.com:org/repo.git,branch=main")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "branch")
+	})
+}
+
+func Test_normalizeUpstreamURL(t *testing.T) {
+	t.Run("SSH and HTTPS same repo match", func(t *testing.T) {
+		assert.Equal(t,
+			normalizeUpstreamURL("git@github.com:org/repo.git", ""),
+			normalizeUpstreamURL("https://github.com/org/repo.git", ""))
+	})
+	t.Run("subpath included in key", func(t *testing.T) {
+		assert.NotEqual(t,
+			normalizeUpstreamURL("git@github.com:org/repo.git", "infra"),
+			normalizeUpstreamURL("git@github.com:org/repo.git", ""))
+	})
+	t.Run("trailing .git stripped", func(t *testing.T) {
+		assert.Equal(t,
+			normalizeUpstreamURL("https://github.com/org/repo.git", ""),
+			normalizeUpstreamURL("https://github.com/org/repo", ""))
+	})
+}
+
+func Test_upsertUpstreamState_newEntry(t *testing.T) {
+	state := &GitSporkDownstreamState{}
+	upsertUpstreamState(state, GitSporkUpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "abc"})
+	require.Len(t, state.Upstreams, 1)
+	assert.Equal(t, "https://github.com/org/repo.git", state.Upstreams[0].URL)
+	assert.Equal(t, "abc", state.Upstreams[0].CommitHash)
+}
+
+func Test_upsertUpstreamState_updateExisting(t *testing.T) {
+	state := &GitSporkDownstreamState{Upstreams: []GitSporkUpstreamState{
+		{URL: "git@github.com:org/repo.git", CommitHash: "old"},
+	}}
+	// SSH and HTTPS forms of same repo — should match and update in place
+	upsertUpstreamState(state, GitSporkUpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "new"})
+	require.Len(t, state.Upstreams, 1)
+	assert.Equal(t, "new", state.Upstreams[0].CommitHash)
+}
+
+func Test_upsertUpstreamState_orderPreserved(t *testing.T) {
+	state := &GitSporkDownstreamState{Upstreams: []GitSporkUpstreamState{
+		{URL: "https://github.com/org/base.git", CommitHash: "b1"},
+		{URL: "https://github.com/org/platform.git", CommitHash: "p1"},
+	}}
+	upsertUpstreamState(state, GitSporkUpstreamState{URL: "https://github.com/org/base.git", CommitHash: "b2"})
+	require.Len(t, state.Upstreams, 2)
+	assert.Equal(t, "b2", state.Upstreams[0].CommitHash)
+	assert.Equal(t, "p1", state.Upstreams[1].CommitHash)
+}

--- a/internal/integrate_test.go
+++ b/internal/integrate_test.go
@@ -4,7 +4,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	gogitssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,4 +154,62 @@ func Test_loadDownstreamState_migration(t *testing.T) {
 	assert.Equal(t, "", state.LastUpstreamRepoURL)
 	assert.Equal(t, "", state.LastUpstreamCommitHash)
 	assert.Equal(t, "", state.LastUpstreamRepoSubpath)
+}
+
+// testCommitAll stages and commits all changes in dir, returning the commit hash.
+func testCommitAll(t *testing.T, repo *gogit.Repository, dir, message string) plumbing.Hash {
+	t.Helper()
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, wt.AddWithOptions(&gogit.AddOptions{All: true}))
+	sig := &object.Signature{Name: "gitspork-test", Email: "gitspork-test@localhost", When: time.Now()}
+	hash, err := wt.Commit(message, &gogit.CommitOptions{Author: sig})
+	require.NoError(t, err)
+	return hash
+}
+
+func TestIntegrate_honors_UpstreamRepoCommit(t *testing.T) {
+	// Create a local upstream repo with two commits; verify that Integrate
+	// checks out the older commit (v1) when UpstreamRepoCommit is set.
+	upstreamDir := t.TempDir()
+	upstreamRepo, err := gogit.PlainInit(upstreamDir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+
+	const gitsporkYML = `upstream_owned:
+- upstream-owned/**
+`
+
+	// Commit v1: write version one content.
+	require.NoError(t, os.MkdirAll(filepath.Join(upstreamDir, "upstream-owned"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, "upstream-owned", "file.txt"), []byte("version one\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, ".gitspork.yml"), []byte(gitsporkYML), 0644))
+	commitV1 := testCommitAll(t, upstreamRepo, upstreamDir, "v1")
+
+	// Commit v2: update to version two content.
+	require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, "upstream-owned", "file.txt"), []byte("version two\n"), 0644))
+	testCommitAll(t, upstreamRepo, upstreamDir, "v2")
+
+	// Create downstream repo.
+	downstreamDir := t.TempDir()
+	_, err = gogit.PlainInit(downstreamDir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+
+	logger := NewLogger()
+	err = Integrate(&IntegrateOptions{
+		Logger:             logger,
+		UpstreamRepoURL:    "file://" + upstreamDir,
+		UpstreamRepoCommit: commitV1.String(),
+		DownstreamRepoPath: downstreamDir,
+		ForDriftCheck:      true, // skip state write; we only care about file content
+	})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(downstreamDir, "upstream-owned", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "version one\n", string(content),
+		"Integrate with UpstreamRepoCommit set to v1 should produce v1 content, not HEAD (v2)")
 }

--- a/test/functional/check_drift_test.go
+++ b/test/functional/check_drift_test.go
@@ -31,7 +31,7 @@ func TestCheckDrift_no_drift(t *testing.T) {
 	out, code := runner.Run(t, []string{
 		"check-drift",
 		"--downstream-repo-path", downstreamDir,
-		"--upstream-repo-url", "file://" + upstreamDir,
+		"--upstream", "url=file://" + upstreamDir,
 	}, downstreamDir)
 	require.Equal(t, 0, code, "expected no drift (exit 0):\n%s", out)
 }
@@ -107,7 +107,7 @@ func TestCheckDrift_drift_detected(t *testing.T) {
 	out, code := runner.Run(t, []string{
 		"check-drift",
 		"--downstream-repo-path", downstreamDir,
-		"--upstream-repo-url", "file://" + upstreamDir,
+		"--upstream", "url=file://" + upstreamDir,
 		"--verbose",
 	}, downstreamDir)
 	require.Equal(t, 2, code, "expected drift detected (exit 2):\n%s", out)

--- a/test/functional/check_drift_test.go
+++ b/test/functional/check_drift_test.go
@@ -3,6 +3,7 @@
 package functional
 
 import (
+	"os"
 	"testing"
 
 	gogit "github.com/go-git/go-git/v6"
@@ -83,7 +84,7 @@ func TestCheckDrift_detached_head(t *testing.T) {
 	out, code := runner.Run(t, []string{
 		"check-drift",
 		"--downstream-repo-path", downstreamDir,
-		"--upstream-repo-url", "file://" + upstreamDir,
+		"--upstream", "url=file://" + upstreamDir,
 	}, downstreamDir)
 	require.Equal(t, 0, code, "expected detached HEAD handled with no drift (exit 0):\n%s", out)
 }
@@ -164,6 +165,88 @@ func TestCheckDrift_multi_upstream_drift_attributed(t *testing.T) {
 	}, downstreamDir)
 	require.Equal(t, 2, code, "expected drift exit 2:\n%s", out)
 	assert.Contains(t, out, "upstream-owned/file.txt")
+	// upstream-owned/file.txt is written by both upstreams; the last writer
+	// (upstream2) is the correct attribution.
+	assert.Contains(t, out, "upstream: file://"+upstreamDir2,
+		"expected drift attributed to upstream2 (%s) as the last writer:\n%s", upstreamDir2, out)
+	assert.NotContains(t, out, "upstream: file://"+upstreamDir1,
+		"upstream1 (%s) should not be credited for a file upstream2 wrote last:\n%s", upstreamDir1, out)
+}
+
+// TestCheckDrift_multi_upstream_drift_in_first_only exercises attribution when
+// the drifted file is owned exclusively by the first upstream. upstream-owned.mk
+// is written only by buildSimpleUpstream (upstream1); buildSecondUpstream's
+// glob "upstream-owned/**" does not match it.
+func TestCheckDrift_multi_upstream_drift_in_first_only(t *testing.T) {
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+	upstreamDir1 := buildSimpleUpstream(t)
+	upstreamDir2 := buildSecondUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "multi integrate failed:\n%s", out)
+
+	// Modify a file owned only by upstream1.
+	WriteFiles(t, downstreamDir, map[string]string{
+		"upstream-owned.mk": "drifted mk\n",
+	})
+	CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "introduce first-upstream drift")
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	out, code = runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 2, code, "expected drift exit 2:\n%s", out)
+	assert.Contains(t, out, "upstream-owned.mk", "expected the drifted filename in output:\n%s", out)
+	assert.Contains(t, out, "upstream: file://"+upstreamDir1,
+		"expected drift attributed to upstream1 (%s):\n%s", upstreamDir1, out)
+	assert.NotContains(t, out, "upstream: file://"+upstreamDir2,
+		"upstream2 (%s) should not appear in attribution for a file it did not touch:\n%s", upstreamDir2, out)
+}
+
+// TestCheckDrift_multi_upstream_drift_in_both exercises per-file attribution
+// when drift exists in files owned by different upstreams: upstream-owned.mk
+// is owned only by upstream1, upstream-owned/file.txt is written last by
+// upstream2. Both files must appear in the report attributed to their
+// respective owners.
+func TestCheckDrift_multi_upstream_drift_in_both(t *testing.T) {
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+	upstreamDir1 := buildSimpleUpstream(t)
+	upstreamDir2 := buildSecondUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "multi integrate failed:\n%s", out)
+
+	WriteFiles(t, downstreamDir, map[string]string{
+		"upstream-owned.mk":       "drifted mk\n",
+		"upstream-owned/file.txt": "drifted file\n",
+	})
+	CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "introduce drift in both upstreams' files")
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	out, code = runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 2, code, "expected drift exit 2:\n%s", out)
+	// Both files reported.
+	assert.Contains(t, out, "upstream-owned.mk", "expected upstream1's drifted file:\n%s", out)
+	assert.Contains(t, out, "upstream-owned/file.txt", "expected upstream2's drifted file:\n%s", out)
+	// Both upstreams named in attribution.
+	assert.Contains(t, out, "upstream: file://"+upstreamDir1,
+		"expected upstream1 (%s) attribution:\n%s", upstreamDir1, out)
+	assert.Contains(t, out, "upstream: file://"+upstreamDir2,
+		"expected upstream2 (%s) attribution:\n%s", upstreamDir2, out)
 }
 
 func TestCheckDrift_multi_upstream_state_fallback(t *testing.T) {
@@ -199,6 +282,79 @@ func TestCheckDrift_upstream_override_explicit_url(t *testing.T) {
 		"--downstream-repo-path", downstreamDir,
 	}, downstreamDir)
 	require.Equal(t, 0, code, "expected no drift with explicit --upstream:\n%s", out)
+}
+
+// TestCheckDrift_upstream_override_url_normalized verifies end-to-end that
+// URL normalization is applied when matching --upstream overrides against
+// state entries. The state records the upstream URL without a trailing
+// ".git"; the override is passed with ".git" appended. `normalizeUpstreamURL`
+// strips the suffix so the two must match. A same-directory symlink lets
+// the override URL clone-resolve to the same repo.
+func TestCheckDrift_upstream_override_url_normalized(t *testing.T) {
+	if isDockerBuild {
+		t.Skip("symlink-based normalization test relies on host-side paths not mapped into the container")
+	}
+	upstreamDir := buildSimpleUpstream(t)
+	upstreamAlias := upstreamDir + ".git"
+	require.NoError(t, os.Symlink(upstreamDir, upstreamAlias))
+
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	// Integrate using the un-suffixed URL; state will record this form.
+	integrateForDrift(t, runner, upstreamDir, downstreamDir)
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	// Override with the ".git"-suffixed alias — normalization must match to
+	// the state entry recorded above.
+	out, code := runner.Run(t, []string{
+		"check-drift",
+		"--upstream", "url=file://" + upstreamAlias,
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "expected no drift when override URL matches by normalization:\n%s", out)
+}
+
+// TestCheckDrift_no_state_no_override_errors verifies check-drift on a
+// downstream that was never integrated (no state file) and given no
+// --upstream override exits non-zero with a message pointing at integrate.
+func TestCheckDrift_no_state_no_override_errors(t *testing.T) {
+	downstreamDir := NewDownstreamRepo(t)
+	runner := resolveRunner(t, "", downstreamDir)
+
+	out, code := runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.NotEqual(t, 0, code, "expected non-zero exit when no state and no override:\n%s", out)
+	assert.Contains(t, out, "gitspork integrate",
+		"expected message to direct user to run gitspork integrate first:\n%s", out)
+}
+
+// TestCheckDrift_override_no_matching_state_errors verifies check-drift with
+// an --upstream override whose URL matches nothing in state exits non-zero
+// with a message naming the unmatched URL.
+func TestCheckDrift_override_no_matching_state_errors(t *testing.T) {
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	// Integrate so state exists with upstreamDir's URL.
+	integrateForDrift(t, runner, upstreamDir, downstreamDir)
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	// Override with a URL that was never integrated.
+	bogusURL := "file:///tmp/gitspork-never-integrated-" + t.Name()
+	out, code := runner.Run(t, []string{
+		"check-drift",
+		"--upstream", "url=" + bogusURL,
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.NotEqual(t, 0, code, "expected non-zero exit for unmatched override:\n%s", out)
+	assert.Contains(t, out, bogusURL,
+		"expected error to name the unmatched upstream URL %q:\n%s", bogusURL, out)
 }
 
 func TestCheckDrift_uses_stored_commit_not_head(t *testing.T) {

--- a/test/functional/check_drift_test.go
+++ b/test/functional/check_drift_test.go
@@ -200,3 +200,34 @@ func TestCheckDrift_upstream_override_explicit_url(t *testing.T) {
 	}, downstreamDir)
 	require.Equal(t, 0, code, "expected no drift with explicit --upstream:\n%s", out)
 }
+
+func TestCheckDrift_uses_stored_commit_not_head(t *testing.T) {
+	// Regression test: check-drift must re-integrate at the stored commit hash,
+	// not at HEAD. After integration, a new upstream commit changes an
+	// upstream-owned file. check-drift should still report no drift because
+	// it uses the commit that was actually integrated, not the new HEAD.
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	// Integrate and commit the downstream at the current upstream HEAD.
+	integrateForDrift(t, runner, upstreamDir, downstreamDir)
+	// check-drift re-runs integrate internally and needs input-data.json.
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	// Add a new commit to the upstream that changes an upstream-owned file.
+	// check-drift must NOT use this new commit — it must use the stored one.
+	WriteFiles(t, upstreamDir, map[string]string{
+		"upstream-owned/file.txt": "new upstream content after integration\n",
+	})
+	CommitAll(t, OpenRepo(t, upstreamDir), upstreamDir, "upstream advances past integrated commit")
+
+	out, code := runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+		"--upstream", "url=file://" + upstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code,
+		"check-drift should report no drift because it must use the stored commit, not the new upstream HEAD:\n%s", out)
+}

--- a/test/functional/check_drift_test.go
+++ b/test/functional/check_drift_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	gogit "github.com/go-git/go-git/v6"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -113,4 +114,89 @@ func TestCheckDrift_drift_detected(t *testing.T) {
 	require.Equal(t, 2, code, "expected drift detected (exit 2):\n%s", out)
 	require.Contains(t, out, "upstream-owned/file.txt",
 		"expected verbose output to name the drifted file:\n%s", out)
+}
+
+func TestCheckDrift_multi_upstream_no_drift(t *testing.T) {
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+	upstreamDir1 := buildSimpleUpstream(t)
+	upstreamDir2 := buildSecondUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "multi integrate failed:\n%s", out)
+	CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "post-integrate baseline")
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	out, code = runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "expected no drift:\n%s", out)
+}
+
+func TestCheckDrift_multi_upstream_drift_attributed(t *testing.T) {
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+	upstreamDir1 := buildSimpleUpstream(t)
+	upstreamDir2 := buildSecondUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "multi integrate failed:\n%s", out)
+
+	// Modify the upstream-owned file (last written by upstreamDir2) to introduce drift.
+	WriteFiles(t, downstreamDir, map[string]string{
+		"upstream-owned/file.txt": "drifted\n",
+	})
+	CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "introduce drift")
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	out, code = runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 2, code, "expected drift exit 2:\n%s", out)
+	assert.Contains(t, out, "upstream-owned/file.txt")
+}
+
+func TestCheckDrift_multi_upstream_state_fallback(t *testing.T) {
+	// check-drift without --upstream reads all recorded upstreams from state.
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	integrateForDrift(t, runner, upstreamDir, downstreamDir)
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	out, code := runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "expected no drift using state:\n%s", out)
+}
+
+func TestCheckDrift_upstream_override_explicit_url(t *testing.T) {
+	// --upstream override with explicit url= matches the state entry and finds no drift.
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	integrateForDrift(t, runner, upstreamDir, downstreamDir)
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	out, code := runner.Run(t, []string{
+		"check-drift",
+		"--upstream", "url=file://" + upstreamDir,
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "expected no drift with explicit --upstream:\n%s", out)
 }

--- a/test/functional/docker_volume_mount_test.go
+++ b/test/functional/docker_volume_mount_test.go
@@ -155,7 +155,7 @@ func TestDockerRootMount_integrate(t *testing.T) {
 	})
 	require.Equal(t, 0, code, "integrate as root failed:\n%s", out)
 	AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "upstream content")
-	AssertFileContains(t, downstreamDir, ".gitspork/downstream-state.json", "last_upstream_commit_hash")
+	AssertFileContains(t, downstreamDir, ".gitspork/downstream-state.json", "commit_hash")
 }
 
 // TestDockerRootMount_check_drift verifies check-drift works when the container

--- a/test/functional/docker_volume_mount_test.go
+++ b/test/functional/docker_volume_mount_test.go
@@ -174,7 +174,7 @@ func TestDockerRootMount_check_drift(t *testing.T) {
 
 	out, code = runAsRoot(t, upstreamDir, downstreamDir, "/downstream", []string{
 		"check-drift",
-		"--upstream-repo-url", "file://" + upstreamDir,
+		"--upstream", "url=file://" + upstreamDir,
 		"--downstream-repo-path", "/downstream",
 	})
 	require.Equal(t, 0, code, "check-drift as root reported unexpected result:\n%s", out)

--- a/test/functional/harness_docker.go
+++ b/test/functional/harness_docker.go
@@ -27,17 +27,17 @@ func (r *DockerRunner) Run(t *testing.T, args []string, dir string) (string, int
 	// Rewrite host path args to container paths, handling both bare paths and
 	// file:// URLs (e.g. --upstream-repo-url file:///host/tmp/... becomes
 	// file:///upstream since that path is volume-mounted at /upstream).
+	// Uses ReplaceAll so paths embedded inside flag values (e.g. --upstream
+	// url=file:///host/tmp/...,version=main) are also rewritten correctly.
 	rewritten := make([]string, len(args))
 	for i, a := range args {
-		switch {
-		case r.UpstreamDir != "" && strings.HasPrefix(a, r.UpstreamDir):
-			a = "/upstream" + strings.TrimPrefix(a, r.UpstreamDir)
-		case r.UpstreamDir != "" && strings.HasPrefix(a, "file://"+r.UpstreamDir):
-			a = "file:///upstream" + strings.TrimPrefix(a, "file://"+r.UpstreamDir)
-		case r.DownstreamDir != "" && strings.HasPrefix(a, r.DownstreamDir):
-			a = "/downstream" + strings.TrimPrefix(a, r.DownstreamDir)
-		case r.DownstreamDir != "" && strings.HasPrefix(a, "file://"+r.DownstreamDir):
-			a = "file:///downstream" + strings.TrimPrefix(a, "file://"+r.DownstreamDir)
+		if r.UpstreamDir != "" {
+			a = strings.ReplaceAll(a, "file://"+r.UpstreamDir, "file:///upstream")
+			a = strings.ReplaceAll(a, r.UpstreamDir, "/upstream")
+		}
+		if r.DownstreamDir != "" {
+			a = strings.ReplaceAll(a, "file://"+r.DownstreamDir, "file:///downstream")
+			a = strings.ReplaceAll(a, r.DownstreamDir, "/downstream")
 		}
 		rewritten[i] = a
 	}

--- a/test/functional/helpers_test.go
+++ b/test/functional/helpers_test.go
@@ -67,3 +67,25 @@ func integrateArgs(upstreamDir, downstreamDir string) []string {
 		"--downstream-repo-path", downstreamDir,
 	}
 }
+
+// buildSecondUpstream creates a minimal second upstream with a distinct file
+// so precedence tests can verify which upstream's content wins.
+func buildSecondUpstream(t *testing.T) string {
+	t.Helper()
+	return NewUpstreamRepo(t, map[string]string{
+		"upstream-owned/file.txt": "second upstream content\n",
+	}, `upstream_owned:
+- upstream-owned/**
+`)
+}
+
+// integrateArgsMulti returns integrate args using the repeatable --upstream flag
+// for two upstream directories.
+func integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir string) []string {
+	return []string{
+		"integrate",
+		"--upstream", "url=file://" + upstreamDir1 + ",version=main",
+		"--upstream", "url=file://" + upstreamDir2 + ",version=main",
+		"--downstream-repo-path", downstreamDir,
+	}
+}

--- a/test/functional/integrate_local_test.go
+++ b/test/functional/integrate_local_test.go
@@ -1,0 +1,61 @@
+//go:build functional || functional_docker
+
+package functional
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegrateLocal_multi_upstream_precedence verifies that when multiple
+// --upstream-path values are given, files written by later upstreams overwrite
+// files written by earlier ones (left-to-right precedence per spec §2, §4).
+func TestIntegrateLocal_multi_upstream_precedence(t *testing.T) {
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+	upstreamDir1 := buildSimpleUpstream(t)
+	upstreamDir2 := buildSecondUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+	out, code := runner.Run(t, []string{
+		"integrate-local",
+		"--upstream-path", upstreamDir1,
+		"--upstream-path", upstreamDir2,
+		"--downstream-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "integrate-local multi failed:\n%s", out)
+
+	// upstreamDir2 writes upstream-owned/file.txt last, so its content wins.
+	AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "second upstream content")
+	// upstreamDir1 owns upstream-owned.mk exclusively; it should still be present.
+	AssertFileContains(t, downstreamDir, "upstream-owned.mk", "upstream mk content")
+}
+
+// TestIntegrateLocal_does_not_write_state verifies the spec §4 invariant that
+// IntegrateLocal does not record upstreams in the downstream state file. When
+// the integrated config has no migrations, no state file is created at all.
+func TestIntegrateLocal_does_not_write_state(t *testing.T) {
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	out, code := runner.Run(t, []string{
+		"integrate-local",
+		"--upstream-path", upstreamDir,
+		"--downstream-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "integrate-local failed:\n%s", out)
+
+	statePath := filepath.Join(downstreamDir, ".gitspork", "downstream-state.json")
+	_, err := os.Stat(statePath)
+	assert.True(t, os.IsNotExist(err),
+		"expected no downstream-state.json after integrate-local (spec §4 invariant), got err: %v", err)
+}

--- a/test/functional/integrate_test.go
+++ b/test/functional/integrate_test.go
@@ -30,8 +30,8 @@ func TestIntegrate_fresh(t *testing.T) {
 	// shared-ownership: merged file present, structured prefer_upstream value wins
 	AssertFileContains(t, downstreamDir, "Makefile", "upstream makefile")
 	AssertFileContains(t, downstreamDir, "config.yaml", "upstream-value")
-	// state written
-	AssertFileContains(t, downstreamDir, ".gitspork/downstream-state.json", "last_upstream_commit_hash")
+	// state written (multi-upstream format)
+	AssertFileContains(t, downstreamDir, ".gitspork/downstream-state.json", "commit_hash")
 }
 
 func TestIntegrate_reintegrate_idempotent(t *testing.T) {
@@ -170,4 +170,67 @@ func TestIntegrate_structured_prefer_downstream(t *testing.T) {
 	content := ReadFile(t, downstreamDir, "info.json")
 	assert.Contains(t, content, "downstream",
 		"info.json (prefer_downstream) should retain downstream value after re-integrate")
+}
+
+func TestIntegrate_multi_upstream_precedence(t *testing.T) {
+	// Second upstream wins on file.txt because it comes last (left-to-right precedence).
+	upstreamDir1 := buildSimpleUpstream(t)
+	upstreamDir2 := buildSecondUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+
+	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "multi-upstream integrate failed:\n%s", out)
+
+	AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "second upstream content")
+}
+
+func TestIntegrate_multi_upstream_backward_compat_old_flags(t *testing.T) {
+	// Single --upstream-repo-url flag still works (backward compat).
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	out, code := runner.Run(t, integrateArgs(upstreamDir, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "backward-compat single flag integrate failed:\n%s", out)
+	AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "upstream content")
+}
+
+func TestIntegrate_multi_upstream_flag_conflict_error(t *testing.T) {
+	// Mixing --upstream and --upstream-repo-url returns exit code 1.
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	out, code := runner.Run(t, []string{
+		"integrate",
+		"--upstream", "url=file://" + upstreamDir + ",version=main",
+		"--upstream-repo-url", "file://" + upstreamDir,
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 1, code, "expected error exit code when mixing flags:\n%s", out)
+}
+
+func TestIntegrate_multi_upstream_state_records_all(t *testing.T) {
+	// Both upstream URLs appear in downstream-state.json after a multi-upstream integrate.
+	upstreamDir1 := buildSimpleUpstream(t)
+	upstreamDir2 := buildSecondUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+
+	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "multi-upstream integrate failed:\n%s", out)
+
+	state := ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+	assert.Contains(t, state, `"upstreams"`)
+	assert.Contains(t, state, `"commit_hash"`)
 }

--- a/test/functional/integrate_test.go
+++ b/test/functional/integrate_test.go
@@ -3,6 +3,7 @@
 package functional
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -186,7 +187,11 @@ func TestIntegrate_multi_upstream_precedence(t *testing.T) {
 	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
 	require.Equal(t, 0, code, "multi-upstream integrate failed:\n%s", out)
 
+	// Last writer wins on the shared file.
 	AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "second upstream content")
+	// upstream1's exclusive file must still be present; a broken loop that only
+	// runs the last upstream would drop it.
+	AssertFileContains(t, downstreamDir, "upstream-owned.mk", "upstream mk content")
 }
 
 func TestIntegrate_multi_upstream_backward_compat_old_flags(t *testing.T) {
@@ -214,23 +219,90 @@ func TestIntegrate_multi_upstream_flag_conflict_error(t *testing.T) {
 		"--downstream-repo-path", downstreamDir,
 	}, downstreamDir)
 	require.Equal(t, 1, code, "expected error exit code when mixing flags:\n%s", out)
+	assert.Contains(t, out, "cannot mix",
+		"expected the flag-conflict error message, got:\n%s", out)
+}
+
+// TestIntegrate_multi_upstream_mid_loop_failure_resumable verifies spec §6:
+// when an upstream fails mid-loop, the integrate command exits non-zero and
+// state reflects however far it got. That means the first (successful)
+// upstream is recorded so re-running is idempotent and picks up where it
+// left off. After we replace the failing upstream with a real one and re-run,
+// both end up in state.
+func TestIntegrate_multi_upstream_mid_loop_failure_resumable(t *testing.T) {
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
+	upstreamDir1 := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir1, downstreamDir)
+
+	bogusUpstream := "/tmp/gitspork-does-not-exist-mid-loop"
+
+	// First run: upstream1 succeeds, second (bogus path) fails. Expect non-zero exit.
+	out, code := runner.Run(t, []string{
+		"integrate",
+		"--upstream", "url=file://" + upstreamDir1 + ",version=main",
+		"--upstream", "url=file://" + bogusUpstream + ",version=main",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.NotEqual(t, 0, code, "expected non-zero exit when second upstream fails:\n%s", out)
+
+	// State must reflect upstream1's successful integration; upstream2 must be absent.
+	state := ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+	assert.Contains(t, state, upstreamDir1,
+		"expected first (successful) upstream to be recorded in state:\n%s", state)
+	assert.NotContains(t, state, bogusUpstream,
+		"expected failed upstream to be absent from state:\n%s", state)
+	assert.Contains(t, state, `"commit_hash"`,
+		"expected a commit_hash to be recorded for the successful upstream:\n%s", state)
+
+	// Fix by replacing the bogus upstream with a real one and re-run.
+	upstreamDir2 := buildSecondUpstream(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	out, code = runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
+	require.Equal(t, 0, code, "expected recovery integrate to succeed:\n%s", out)
+
+	state = ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+	assert.Contains(t, state, upstreamDir1, "expected first upstream still in state:\n%s", state)
+	assert.Contains(t, state, upstreamDir2, "expected second upstream now in state:\n%s", state)
 }
 
 func TestIntegrate_multi_upstream_state_records_all(t *testing.T) {
-	// Both upstream URLs appear in downstream-state.json after a multi-upstream integrate.
+	// Both upstream URLs appear in downstream-state.json in integration order,
+	// each with the actual commit hash of that upstream's HEAD.
+	if isDockerBuild {
+		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
+	}
 	upstreamDir1 := buildSimpleUpstream(t)
 	upstreamDir2 := buildSecondUpstream(t)
 	downstreamDir := NewDownstreamRepo(t)
 	prepDownstreamWithInputData(t, downstreamDir)
 	runner := resolveRunner(t, upstreamDir1, downstreamDir)
-	if isDockerBuild {
-		t.Skip("multi-upstream path rewriting not supported in DockerRunner")
-	}
 
 	out, code := runner.Run(t, integrateArgsMulti(upstreamDir1, upstreamDir2, downstreamDir), downstreamDir)
 	require.Equal(t, 0, code, "multi-upstream integrate failed:\n%s", out)
 
-	state := ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
-	assert.Contains(t, state, `"upstreams"`)
-	assert.Contains(t, state, `"commit_hash"`)
+	head1, err := OpenRepo(t, upstreamDir1).Head()
+	require.NoError(t, err)
+	head2, err := OpenRepo(t, upstreamDir2).Head()
+	require.NoError(t, err)
+
+	var parsed struct {
+		Upstreams []struct {
+			URL        string `json:"url"`
+			Subpath    string `json:"subpath,omitempty"`
+			CommitHash string `json:"commit_hash"`
+		} `json:"upstreams"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")), &parsed))
+
+	require.Len(t, parsed.Upstreams, 2, "expected exactly two upstreams recorded")
+	// Order preserved: upstream1 first, upstream2 second.
+	assert.Equal(t, "file://"+upstreamDir1, parsed.Upstreams[0].URL)
+	assert.Equal(t, "file://"+upstreamDir2, parsed.Upstreams[1].URL)
+	// Commit hashes match the actual HEAD of each upstream.
+	assert.Equal(t, head1.Hash().String(), parsed.Upstreams[0].CommitHash)
+	assert.Equal(t, head2.Hash().String(), parsed.Upstreams[1].CommitHash)
 }


### PR DESCRIPTION
## Summary

* Adds a new feature to be able to use multiple upstream sources instead of just one
* This enables the ability to inherit different things from different foundations, and integrations are overlaid onto the downstream accordingly

## Motivation

This feature allows for a powerful addition to the functionality that already exists in this tool: integrating from multiple upstream sources, which could be the case in the following scenario:

* An organization has decided that engineering sections of the organization should maintain and develop within monorepos for that area of the org.
* The standards for what those monorepos should include originate from multiple platform, infrastructure, operations, security etc. teams.
* Each of the above teams maintain a template, that is an upstream gitspork repo with the standards it needs to enforce.
* The layering and order is maintained in centralized tooling that runs `gitspork` under the hood for engineering team monorepos, in the desired order to stay up-to-date with all of the upstreams over time.

## Test Plan

<!--
How did you verify this works? Check off what applies.
-->

- [x] `make test-unit` passes
- [x] `make test-functional` passes
- [x] `make test-functional-docker` passes
- [x] `make test-examples` passes
- [ ] Manual testing: <!-- describe steps -->

## Checklist

- [x] New behavior is covered by tests
- [x] Docs updated if commands, flags, or config schema changed
- [x] `go vet ./...` is clean (included in `make test-unit`)
