### PR TITLE
build lockdown: ECR image routing + Buildkite queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,6 @@
+agents:
+  queue: build-platform-corp
+
+steps:
+  - label: ":pipeline:"
+    command: "buildkite-agent pipeline upload"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        REGISTRY_PREFIX: ""

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,33 +64,33 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     use: buildx
-    build_flag_templates: ["--platform=linux/amd64", "--provenance=false"]
+    build_flag_templates: ["--platform=linux/amd64", "--provenance=false", "--build-arg=REGISTRY_PREFIX={{ .Env.REGISTRY_PREFIX }}"]
   - ids: [linux]
     image_templates: ["rockholla/gitspork:{{ .Tag }}-arm64"]
     goarch: arm64
     dockerfile: Dockerfile
     use: buildx
-    build_flag_templates: ["--platform=linux/arm64", "--provenance=false"]
+    build_flag_templates: ["--platform=linux/arm64", "--provenance=false", "--build-arg=REGISTRY_PREFIX={{ .Env.REGISTRY_PREFIX }}"]
   - ids: [linux]
     image_templates: ["rockholla/gitspork:{{ .Tag }}-armv7"]
     goarch: arm
     goarm: "7"
     dockerfile: Dockerfile
     use: buildx
-    build_flag_templates: ["--platform=linux/arm/v7", "--provenance=false"]
+    build_flag_templates: ["--platform=linux/arm/v7", "--provenance=false", "--build-arg=REGISTRY_PREFIX={{ .Env.REGISTRY_PREFIX }}"]
   - ids: [linux]
     image_templates: ["rockholla/gitspork:{{ .Tag }}-armv6"]
     goarch: arm
     goarm: "6"
     dockerfile: Dockerfile
     use: buildx
-    build_flag_templates: ["--platform=linux/arm/v6", "--provenance=false"]
+    build_flag_templates: ["--platform=linux/arm/v6", "--provenance=false", "--build-arg=REGISTRY_PREFIX={{ .Env.REGISTRY_PREFIX }}"]
   - ids: [linux]
     image_templates: ["rockholla/gitspork:{{ .Tag }}-386"]
     goarch: "386"
     dockerfile: Dockerfile
     use: buildx
-    build_flag_templates: ["--platform=linux/386", "--provenance=false"]
+    build_flag_templates: ["--platform=linux/386", "--provenance=false", "--build-arg=REGISTRY_PREFIX={{ .Env.REGISTRY_PREFIX }}"]
 
 docker_manifests:
   - name_template: "rockholla/gitspork:{{ .Tag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.23.4
+ARG REGISTRY_PREFIX=""
+FROM ${REGISTRY_PREFIX}docker.io/library/alpine:3.23.4
 COPY gitspork /usr/local/bin/gitspork
 RUN apk update && apk upgrade --no-cache && apk add --no-cache bash git
 ENTRYPOINT ["gitspork"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build: ## Builds gitspork to dist/gitspork and builds Docker image tagged gitspo
 	@go build -o dist/gitspork .
 	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/.docker-build/gitspork .
 	@cp Dockerfile dist/.docker-build/Dockerfile
-	@docker build -t gitspork:local dist/.docker-build/
+	@docker build --build-arg REGISTRY_PREFIX="$(REGISTRY_PREFIX)" -t gitspork:local dist/.docker-build/
 	@rm -rf dist/.docker-build
 
 .PHONY: test-unit

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: gitspork
+  description: CLI tool for managing upstream/downstream git repo relationships
+  annotations:
+    buildkite.com/project-slug: twilio/gitspork
+spec:
+  type: tool
+  lifecycle: production
+  owner: devprod

--- a/test/functional/docker_volume_mount_test.go
+++ b/test/functional/docker_volume_mount_test.go
@@ -101,7 +101,7 @@ func runAsRootWithSSH(t *testing.T, upstreamDir, downstreamDir, workdir string, 
 		t.Cleanup(func() {
 			_ = exec.Command("docker", "run", "--rm",
 				"-v", d+":/mnt",
-				"alpine:3.23.4",
+				"docker.io/library/alpine:3.23.4",
 				"chown", "-R", fmt.Sprintf("%d:%d", uid, gid), "/mnt",
 			).Run()
 		})


### PR DESCRIPTION
## Goal

Route all Docker image pulls through ECR and add the Buildkite + Backstage plumbing required for the build lockdown early-adopter process.

## Review Guide

**ECR image routing (`REGISTRY_PREFIX` pattern):**
- `Dockerfile` — added `ARG REGISTRY_PREFIX=""` so CI can pass `--build-arg REGISTRY_PREFIX=<ecr-host>/` without changing the image for local dev. Image is now fully qualified as `docker.io/library/alpine:3.23.4` (present in `images.txt`).
- `Makefile` — threads `REGISTRY_PREFIX` through `docker build` so `make build REGISTRY_PREFIX=...` works.
- `.goreleaser.yaml` — adds `--build-arg=REGISTRY_PREFIX=...` to all five `build_flag_templates` blocks; reads from `REGISTRY_PREFIX` env var.
- `.github/workflows/release.yml` — sets `REGISTRY_PREFIX: ""` in the goreleaser env block (empty = docker.io, override in ECR environments).
- `test/functional/docker_volume_mount_test.go` — bare `alpine:3.23.4` reference in the chown cleanup helper fully qualified to `docker.io/library/alpine:3.23.4`.

**Build lockdown scaffolding:**
- `.buildkite/pipeline.yml` — new file, queue set to `build-platform-corp`.
- `catalog-info.yaml` — new file with `buildkite.com/project-slug: twilio/gitspork` annotation as required by the process.

To verify locally: `make build` should still work unchanged. With ECR: `make build REGISTRY_PREFIX=018537234677.dkr.ecr.us-east-1.amazonaws.com/`.

## Repo Specific

No release tag needed for this change.