### PR TITLE
capture more in cases of non-clean working tree

### DIFF
--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -172,8 +172,11 @@ func checkCleanWorkingTree(repoPath string) error {
 	if err != nil {
 		return fmt.Errorf("error checking working tree status: %v", err)
 	}
-	if strings.TrimSpace(string(out)) != "" {
-		return fmt.Errorf("working tree is not clean — commit or stash changes before running check-drift")
+	if status := strings.TrimSpace(string(out)); status != "" {
+		return fmt.Errorf("working tree is not clean — commit or stash changes before running check-drift:\n%s\n\n"+
+			"note: this may be running in a container with different global gitignore rules than your local git environment, "+
+			"which can explain differences you see versus a local `git status`. "+
+			"Commit needed gitignore changes to your repo's .gitignore in these cases to ensure the repo ignores what you need it to regardless of global rules.", status)
 	}
 	return nil
 }

--- a/internal/check-drift_test.go
+++ b/internal/check-drift_test.go
@@ -86,7 +86,9 @@ func Test_checkCleanWorkingTree(t *testing.T) {
 
 		makeBaselineRepo(t, dir)
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("x"), 0644))
-		assert.ErrorContains(t, checkCleanWorkingTree(dir), "working tree is not clean")
+		err = checkCleanWorkingTree(dir)
+		assert.ErrorContains(t, err, "working tree is not clean")
+		assert.ErrorContains(t, err, "untracked.txt")
 	})
 
 	t.Run("modified tracked file fails", func(t *testing.T) {
@@ -96,7 +98,9 @@ func Test_checkCleanWorkingTree(t *testing.T) {
 
 		makeBaselineRepo(t, dir)
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("modified"), 0644))
-		assert.ErrorContains(t, checkCleanWorkingTree(dir), "working tree is not clean")
+		err = checkCleanWorkingTree(dir)
+		assert.ErrorContains(t, err, "working tree is not clean")
+		assert.ErrorContains(t, err, "file.txt")
 	})
 }
 


### PR DESCRIPTION
## Summary

<!--
What does this PR do? 2-3 bullets is enough.
- 
- 
-->

Give more detail about what is triggering the non-clean working tree failure state.

## Motivation

<!-- Why is this change needed? Link to an issue if one exists. -->

We saw these cases in practice while running in a containerized version, and the scenario and what the cause was wasn't clear. So we want to add some better UX here.

## Test Plan

<!--
How did you verify this works? Check off what applies.
-->

- [x] `make test-unit` passes
- [x] `make test-functional` passes
- [x] `make test-functional-docker` passes
- [x] `make test-examples` passes
- [ ] Manual testing: <!-- describe steps -->

## Checklist

- [x] New behavior is covered by tests
- [x] Docs updated if commands, flags, or config schema changed
- [x] `go vet ./...` is clean (included in `make test-unit`)
