### PR TITLE
allow check-drift to operate on a detached head state, ensure drift c…

### DIFF
--- a/cmd/check-drift.go
+++ b/cmd/check-drift.go
@@ -37,6 +37,11 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 		Use:   "check-drift",
 		Short: checkDriftHelpShort,
 		Long:  fmt.Sprintf("%s\n\n%s", checkDriftHelpShort, checkDriftHelpLong),
+		// Drift (and other failures) are operational errors, not usage errors:
+		// don't dump the help/usage block, and let root's Fatal print the message
+		// once instead of cobra also printing its own "Error:" line.
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := internal.CheckDrift(&internal.CheckDriftOptions{
 				Logger:             logger,

--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -69,10 +69,15 @@ func CheckDrift(opts *CheckDriftOptions) error {
 	if err != nil {
 		return fmt.Errorf("error resolving HEAD: %v", err)
 	}
-	if !headRef.Name().IsBranch() {
-		return fmt.Errorf("downstream repo is in detached HEAD state — check out a branch before running check-drift")
+
+	// Remember how to restore HEAD once the drift check finishes. CI runners
+	// (e.g. Buildkite) typically check out a specific commit, leaving a detached
+	// HEAD with no branch to return to; in that case restore by hash, otherwise
+	// restore the original branch.
+	restore := &gogit.CheckoutOptions{Hash: headRef.Hash()}
+	if headRef.Name().IsBranch() {
+		restore = &gogit.CheckoutOptions{Branch: headRef.Name()}
 	}
-	originalBranch := headRef.Name()
 
 	// create or reset the drift-check branch to the current HEAD
 	driftBranchRef := plumbing.NewBranchReferenceName(driftCheckBranch)
@@ -85,7 +90,7 @@ func CheckDrift(opts *CheckDriftOptions) error {
 	}
 
 	defer func() {
-		_ = wt.Checkout(&gogit.CheckoutOptions{Branch: originalBranch})
+		_ = wt.Checkout(restore)
 		_ = repo.DeleteBranch(driftCheckBranch)
 	}()
 

--- a/test/functional/check_drift_test.go
+++ b/test/functional/check_drift_test.go
@@ -5,6 +5,7 @@ package functional
 import (
 	"testing"
 
+	gogit "github.com/go-git/go-git/v6"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,6 +53,38 @@ func TestCheckDrift_no_drift_state_url(t *testing.T) {
 		"--downstream-repo-path", downstreamDir,
 	}, downstreamDir)
 	require.Equal(t, 0, code, "expected no drift using state URL (exit 0):\n%s", out)
+}
+
+// TestCheckDrift_detached_head verifies check-drift works when the downstream is
+// in a detached HEAD state, as CI runners (e.g. Buildkite) leave it after
+// checking out a specific commit rather than a branch.
+func TestCheckDrift_detached_head(t *testing.T) {
+	upstreamDir := buildSimpleUpstream(t)
+	downstreamDir := NewDownstreamRepo(t)
+	prepDownstreamWithInputData(t, downstreamDir)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	integrateForDrift(t, runner, upstreamDir, downstreamDir)
+	// check-drift re-runs integrate internally and needs input-data.json
+	prepDownstreamWithInputData(t, downstreamDir)
+
+	// Simulate the CI checkout: detach HEAD at the current commit (no branch).
+	repo := OpenRepo(t, downstreamDir)
+	head, err := repo.Head()
+	require.NoError(t, err)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, wt.Checkout(&gogit.CheckoutOptions{Hash: head.Hash()}))
+	detached, err := repo.Head()
+	require.NoError(t, err)
+	require.False(t, detached.Name().IsBranch(), "test setup should leave a detached HEAD")
+
+	out, code := runner.Run(t, []string{
+		"check-drift",
+		"--downstream-repo-path", downstreamDir,
+		"--upstream-repo-url", "file://" + upstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "expected detached HEAD handled with no drift (exit 0):\n%s", out)
 }
 
 func TestCheckDrift_drift_detected(t *testing.T) {


### PR DESCRIPTION
…heck errors don't show usage/help

## Summary

* Correcting a UX issue: drift check failures shouldn't show usage/help
* Allow drift check to operate against a detached head state

## Motivation

Just issues to fix as they came up in using the tool

## Test Plan

<!--
How did you verify this works? Check off what applies.
-->

- [x] `make test-unit` passes
- [x] `make test-functional` passes
- [x] `make test-functional-docker` passes
- [x] `make test-examples` passes
- [ ] Manual testing: <!-- describe steps -->

## Checklist

- [x] New behavior is covered by tests
- [x] Docs updated if commands, flags, or config schema changed
- [x] `go vet ./...` is clean (included in `make test-unit`)
