### PR TITLE
ensure templated.merged for config can be truly optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: schema
+schema: ## Outputs the current working schema for the version of source
+	@go run main.go schema
+
 .PHONY: build
 build: ## Builds gitspork to dist/gitspork and builds Docker image tagged gitspork:local
 	@mkdir -p dist dist/.docker-build

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ templated: # list of instruction for templated source files in the upstream that
     previous_input: # (optional, one-of-required) reference to an input already known from this template or another template defined before this one
       template: "meta.txt.go.tmpl" # Name of a previous template defined in the gitspork config from which to pull the value
       name: "input_one" # Name of the input from that template from which to pull the value
-  merged: # instruction for merging with pre-existing file in the destination, if present, post-render
+  merged: # optional instruction for merging with pre-existing file in the destination, if present, post-render
     structured: "prefer-downstream" # instruction for a structured merged post-render, either 'prefer-upstream' or 'prefer-downstream'
 migrations: # list of YAML file paths in the upstream repo, relative to the upstream repo root or subpath if specified, containing downstream repo migration instructions
 - ".gitspork/migrations/0001/migration.yml"

--- a/internal/gitspork.go
+++ b/internal/gitspork.go
@@ -70,7 +70,7 @@ type GitSporkConfigTemplated struct {
 	Template    string                         `yaml:"template" comment:"source path of the Go template file to use in the upstream"`
 	Destination string                         `yaml:"destination" comment:"destination path and file name in the dowstream where the template will be rendered"`
 	Inputs      []GitSporkConfigTemplatedInput `yaml:"inputs" comment:"list of inputs to provide to the template, and how to determine them"`
-	Merged      *GitSporkConfigTemplatedMerged `yaml:"merged" comment:"instruction for merging with pre-existing file in the destination, if present, post-render"`
+	Merged      *GitSporkConfigTemplatedMerged `yaml:"merged,omitempty" comment:"optional instruction for merging with pre-existing file in the destination, if present, post-render"`
 }
 
 // GitSporkConfigTemplatedInput

--- a/test/functional/mv_rm_test.go
+++ b/test/functional/mv_rm_test.go
@@ -27,6 +27,27 @@ const mvMultiSourceGitsporkYML = `upstream_owned:
 - docs/keep.md
 `
 
+const templatedNoMergedGitsporkYML = `templated:
+- template: .gitspork-templates/one.txt.go.tmpl
+  destination: one.txt
+  inputs:
+  - name: value
+    prompt: enter a value
+`
+
+const templatedTwoNoMergedGitsporkYML = `templated:
+- template: .gitspork-templates/one.txt.go.tmpl
+  destination: one.txt
+  inputs:
+  - name: value
+    prompt: enter a value
+- template: .gitspork-templates/two.txt.go.tmpl
+  destination: two.txt
+  inputs:
+  - name: value
+    prompt: enter a value
+`
+
 func TestMv_updates_config_and_stages(t *testing.T) {
 	upstreamDir := NewUpstreamRepo(t, map[string]string{
 		"docs/old.md":  "# old doc\n",
@@ -206,6 +227,52 @@ func TestMv_downstream_exact(t *testing.T) {
 
 	AssertFileAbsent(t, downstreamDir, "docs/old.md")
 	AssertFileContains(t, downstreamDir, "docs/new.md", "old doc")
+}
+
+// TestMv_templated_without_merged_omits_merged_key ensures that when a templated
+// entry has no `merged` field, `gitspork mv` rewrites .gitspork.yml without introducing
+// a `merged: null` (or similar) line for that entry.
+func TestMv_templated_without_merged_omits_merged_key(t *testing.T) {
+	upstreamDir := NewUpstreamRepo(t, map[string]string{
+		".gitspork-templates/one.txt.go.tmpl": "value={{ index .Inputs \"value\" }}\n",
+	}, templatedNoMergedGitsporkYML)
+
+	runner := resolveRunner(t, upstreamDir, "")
+
+	out, code := runner.Run(t, []string{"mv",
+		".gitspork-templates/one.txt.go.tmpl",
+		".gitspork-templates/renamed.txt.go.tmpl",
+	}, upstreamDir)
+	require.Equal(t, 0, code, "gitspork mv failed:\n%s", out)
+
+	cfg := ReadFile(t, upstreamDir, ".gitspork.yml")
+	assert.Contains(t, cfg, ".gitspork-templates/renamed.txt.go.tmpl")
+	assert.NotContains(t, cfg, ".gitspork-templates/one.txt.go.tmpl")
+	assert.NotContains(t, cfg, "merged: null",
+		"rewritten templated entry should omit the merged key entirely, got:\n%s", cfg)
+}
+
+// TestRm_templated_without_merged_omits_merged_key ensures that when a templated
+// entry has no `merged` field, `gitspork rm` rewrites .gitspork.yml without introducing
+// a `merged: null` (or similar) line for the surviving entry.
+func TestRm_templated_without_merged_omits_merged_key(t *testing.T) {
+	upstreamDir := NewUpstreamRepo(t, map[string]string{
+		".gitspork-templates/one.txt.go.tmpl": "value={{ index .Inputs \"value\" }}\n",
+		".gitspork-templates/two.txt.go.tmpl": "value={{ index .Inputs \"value\" }}\n",
+	}, templatedTwoNoMergedGitsporkYML)
+
+	runner := resolveRunner(t, upstreamDir, "")
+
+	out, code := runner.Run(t, []string{"rm",
+		".gitspork-templates/two.txt.go.tmpl",
+	}, upstreamDir)
+	require.Equal(t, 0, code, "gitspork rm failed:\n%s", out)
+
+	cfg := ReadFile(t, upstreamDir, ".gitspork.yml")
+	assert.Contains(t, cfg, ".gitspork-templates/one.txt.go.tmpl")
+	assert.NotContains(t, cfg, ".gitspork-templates/two.txt.go.tmpl")
+	assert.NotContains(t, cfg, "merged: null",
+		"rewritten templated entry should omit the merged key entirely, got:\n%s", cfg)
 }
 
 // TestMv_downstream_glob runs gitspork mv on a directory covered by a glob entry,


### PR DESCRIPTION
## Summary

Namely making the `templated.merged` `omitempty` and updating the schema docs around it to clarify it as an optional setting.

## Motivation

It was just unclear, and config mgmt via struct could render `merged: null` in cases where we just want it absent

## Test Plan

<!--
How did you verify this works? Check off what applies.
-->

- [x] `make test-unit` passes
- [x] `make test-functional` passes
- [x] `make test-functional-docker` passes
- [x] `make test-examples` passes
- [ ] Manual testing: <!-- describe steps -->

## Checklist

- [x] New behavior is covered by tests
- [x] Docs updated if commands, flags, or config schema changed
- [x] `go vet ./...` is clean (included in `make test-unit`)
