### PR TITLE
SDK Phase 1: structural result types for Integrate/IntegrateLocal/CheckDrift

### DIFF
--- a/cmd/check-drift.go
+++ b/cmd/check-drift.go
@@ -45,7 +45,6 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 			opts := &internal.CheckDriftOptions{
 				Logger:             logger,
 				DownstreamRepoPath: downstreamRepoPath,
-				Verbose:            verbose,
 			}
 			for _, f := range upstreamFlags {
 				spec, err := internal.ParseUpstreamFlag(f)
@@ -70,7 +69,14 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 				}
 				logger.Log("  %s (upstream: %s)", f.Path, attribution)
 			}
-			// verbose/diff output moves to Task 4
+			if verbose {
+				for _, f := range report.Files {
+					if f.Diff == "" {
+						continue
+					}
+					fmt.Print(f.Diff)
+				}
+			}
 			os.Exit(2)
 			return nil // unreachable but keeps Go happy
 		},

--- a/cmd/check-drift.go
+++ b/cmd/check-drift.go
@@ -54,11 +54,25 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 				}
 				opts.Upstreams = append(opts.Upstreams, spec)
 			}
-			err := internal.CheckDrift(opts)
-			if errors.Is(err, internal.ErrDriftDetected) {
-				os.Exit(2)
+			report, err := internal.CheckDrift(opts)
+			if err != nil && !errors.Is(err, internal.ErrDriftDetected) {
+				return err
 			}
-			return err
+			if !report.HasDrift {
+				logger.Log("no drift detected")
+				return nil
+			}
+			logger.Log("drift detected: %d file(s) changed", len(report.Files))
+			for _, f := range report.Files {
+				attribution := f.AttributedURL
+				if attribution == "" {
+					attribution = "(unknown upstream)"
+				}
+				logger.Log("  %s (upstream: %s)", f.Path, attribution)
+			}
+			// verbose/diff output moves to Task 4
+			os.Exit(2)
+			return nil // unreachable but keeps Go happy
 		},
 	}
 

--- a/cmd/integrate-local.go
+++ b/cmd/integrate-local.go
@@ -31,12 +31,15 @@ func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
 		Short: integrateLocalHelpShort,
 		Long:  fmt.Sprintf("%s\n\n%s", integrateLocalHelpShort, integrateLocalHelpLong),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return internal.IntegrateLocal(&internal.IntegrateLocalOptions{
+			if _, err := internal.IntegrateLocal(&internal.IntegrateLocalOptions{
 				Logger:         logger,
 				UpstreamPaths:  upstreamPaths,
 				DownstreamPath: downstreamPath,
 				ForceRePrompt:  forceRePrompt,
-			})
+			}); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/integrate.go
+++ b/cmd/integrate.go
@@ -55,7 +55,10 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 				}
 				opts.Upstreams = append(opts.Upstreams, spec)
 			}
-			return internal.Integrate(opts)
+			if _, err := internal.Integrate(opts); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/docs/superpowers/plans/2026-07-03-sdk-phase-1-structural-results.md
+++ b/docs/superpowers/plans/2026-07-03-sdk-phase-1-structural-results.md
@@ -1,0 +1,806 @@
+# SDK Phase 1: Structural Results Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reshape `Integrate`, `IntegrateLocal`, and `CheckDrift` to return structural result types (`*IntegrateResult`, `*DriftReport`). Move user-facing check-drift output (per-file lines, summary, verbose diffs) from `internal/` into the CLI's cobra RunE. Preserve current CLI behavior functionally — existing functional tests pass unchanged.
+
+**Architecture:** Phase 1 of three toward a golang SDK. All types stay in `internal/gitspork.go`; they move to a public package in Phase 3. Progress narration ("cloning upstream X…") stays on `Logger`; drift-shaped structural data moves to the returned `*DriftReport`. The CLI walks the report to reproduce today's output.
+
+**Tech Stack:** Go, existing `github.com/go-git/go-git/v6` (`plumbing/format/diff.UnifiedEncoder` for per-file patch encoding), `github.com/spf13/cobra`.
+
+---
+
+## File Structure
+
+Modified files:
+
+- `internal/gitspork.go` — add `IntegrateResult`, `IntegratedUpstream`, `DriftReport`, `DriftedFile`; remove `Verbose` field from `CheckDriftOptions`
+- `internal/integrate.go` — change `Integrate` signature to `(*IntegrateResult, error)`; populate the result; update internal `integrateOne` to return `IntegratedUpstream`
+- `internal/integrate-local.go` — change `IntegrateLocal` signature to `(*IntegrateResult, error)`; populate with paths (URL slot holds the local path)
+- `internal/check-drift.go` — change `CheckDrift` signature to `(*DriftReport, error)`; build `DriftReport` in place of per-file `Logger.Log` calls; extract per-file diff into `DriftedFile.Diff`
+- `internal/logger.go` — remove the `Diff(io.Reader) error` method (no longer used from internal)
+- `internal/integrate_test.go` — update tests to assert on returned `*IntegrateResult`
+- `internal/check-drift_test.go` — update tests to inspect `*DriftReport`
+- `cmd/integrate.go` — call new signature (result discarded; CLI has no use for it beyond error handling)
+- `cmd/integrate-local.go` — same
+- `cmd/check-drift.go` — call new signature; walk `DriftReport`; print per-file lines, summary, and verbose diffs from the report; drive verbose from a CLI-local flag rather than the removed `CheckDriftOptions.Verbose`
+
+New files: none in this phase.
+
+---
+
+## Task 1: Add `IntegrateResult` types and reshape `Integrate`
+
+**Files:**
+- Modify: `internal/gitspork.go` (types)
+- Modify: `internal/integrate.go` (signature + population)
+- Modify: `internal/integrate_test.go` (existing tests updated + one new test asserting result shape)
+- Modify: `internal/check-drift.go` (internal callsite to `Integrate` at ~line 131)
+- Modify: `cmd/integrate.go` (RunE update to match new signature)
+
+- [ ] **Step 1: Add shared setup helpers** — the existing test file has `testCommitAll` (line ~160 of `internal/integrate_test.go`) but no upstream/downstream fixture builders. Add these helpers to `internal/integrate_test.go` just before the existing `testCommitAll`:
+
+```go
+// testMinimalUpstream initialises a local upstream git repo with a minimal
+// .gitspork.yml (upstream_owned only, no templated block) and one file. Returns
+// the temp dir and the initial commit hash.
+func testMinimalUpstream(t *testing.T) (string, plumbing.Hash) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "upstream-owned"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "upstream-owned", "file.txt"), []byte("upstream content\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitspork.yml"), []byte("upstream_owned:\n- upstream-owned/**\n"), 0644))
+	hash := testCommitAll(t, repo, "initial")
+	return dir, hash
+}
+
+// testEmptyDownstream initialises a bare local downstream git repo ready for
+// Integrate to write into.
+func testEmptyDownstream(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	_, err := gogit.PlainInit(dir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+	return dir
+}
+```
+
+- [ ] **Step 2: Write the failing test** — append to `internal/integrate_test.go`:
+
+```go
+func TestIntegrate_returns_result_with_upstream_url_and_hash(t *testing.T) {
+	upstreamDir, upstreamHash := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+
+	result, err := Integrate(&IntegrateOptions{
+		Logger:             NewLogger(),
+		Upstreams:          []UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, "file://"+upstreamDir, result.Upstreams[0].URL)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+	assert.Equal(t, "", result.Upstreams[0].Subpath)
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails** — expect a compile error (the type `*IntegrateResult` doesn't exist yet).
+
+```bash
+go test ./internal/... -run TestIntegrate_returns_result_with_upstream_url_and_hash
+```
+
+Expected: `# github.com/rockholla/gitspork/internal ... undefined: IntegrateResult` — compile failure.
+
+- [ ] **Step 4: Add result types to `internal/gitspork.go`** — add after the existing `GitSporkDownstreamState` type declaration:
+
+```go
+// IntegrateResult is the structural return value of Integrate and IntegrateLocal.
+// It records what was successfully integrated (in order); on partial failure
+// the successful upstreams so far are still present in this result alongside
+// the returned error.
+type IntegrateResult struct {
+	Upstreams []IntegratedUpstream
+}
+
+// IntegratedUpstream identifies a single successfully integrated upstream.
+type IntegratedUpstream struct {
+	URL        string
+	Subpath    string
+	CommitHash string
+}
+
+// DriftReport is the structural return value of CheckDrift. HasDrift is false
+// when the downstream matches the recorded integration state; true when
+// differences were found. Files enumerates the drifted entries with per-file
+// attribution to whichever upstream last wrote each path.
+type DriftReport struct {
+	HasDrift bool
+	Files    []DriftedFile
+}
+
+// DriftedFile is a single entry in a DriftReport.
+type DriftedFile struct {
+	Path          string
+	AttributedURL string // upstream URL responsible for this file; empty means unattributed
+	Diff          string // unified-diff text for just this file; empty for binary or unattributable
+}
+```
+
+- [ ] **Step 5: Update `Integrate` signature and body** in `internal/integrate.go`. Replace lines 112–146 (the `Integrate` function) with:
+
+```go
+// Integrate will ensure that the downstream at opts.DownstreamRepoPath is
+// integrated with each upstream in opts.Upstreams, in order.
+func Integrate(opts *IntegrateOptions) (*IntegrateResult, error) {
+	var err error
+	result := &IntegrateResult{}
+
+	if opts.DownstreamRepoPath == "" {
+		opts.DownstreamRepoPath, err = os.Getwd()
+		if err != nil {
+			return result, fmt.Errorf("unable to get the present working directory: %v", err)
+		}
+	} else {
+		opts.DownstreamRepoPath, err = filepath.Abs(opts.DownstreamRepoPath)
+		if err != nil {
+			return result, fmt.Errorf("unable to determine local downstream repo path: %v", err)
+		}
+	}
+
+	// Normalize: synthesize Upstreams from single-upstream fields for backward compat.
+	if len(opts.Upstreams) == 0 && opts.UpstreamRepoURL != "" {
+		opts.Upstreams = []UpstreamSpec{{
+			URL:     opts.UpstreamRepoURL,
+			Version: opts.UpstreamRepoVersion,
+			Subpath: opts.UpstreamRepoSubpath,
+			Token:   opts.UpstreamRepoToken,
+		}}
+	}
+	if len(opts.Upstreams) == 0 {
+		return result, fmt.Errorf("no upstream specified: provide --upstream or --upstream-repo-url")
+	}
+
+	for _, upstream := range opts.Upstreams {
+		integrated, err := integrateOne(opts, upstream)
+		if err != nil {
+			return result, err
+		}
+		result.Upstreams = append(result.Upstreams, integrated)
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 6: Update `integrateOne` signature and body** in `internal/integrate.go`. Change the function signature and its return path so it produces an `IntegratedUpstream`. Only the signature and the `return` statements change:
+
+```go
+func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) (IntegratedUpstream, error) {
+	// ... existing body unchanged until the trailing return ...
+```
+
+At every `return err` inside `integrateOne`, change to `return IntegratedUpstream{}, err`. At the trailing `return nil` (currently line ~230), replace with:
+
+```go
+	return IntegratedUpstream{
+		URL:        originalUpstreamURL,
+		Subpath:    upstream.Subpath,
+		CommitHash: commitHash,
+	}, nil
+```
+
+`commitHash` is already in scope from the `cloneUpstreamForIntegrate` call earlier in the function.
+
+- [ ] **Step 7: Update the callsite inside `CheckDrift`** at `internal/check-drift.go` around line 131. Change:
+
+```go
+if err := Integrate(&IntegrateOptions{ ... }); err != nil {
+```
+
+to:
+
+```go
+if _, err := Integrate(&IntegrateOptions{ ... }); err != nil {
+```
+
+(The `IntegrateResult` from a drift-check re-integration is not useful; discard it.)
+
+- [ ] **Step 8: Update the CLI callsite** in `cmd/integrate.go` — update the `RunE`. Find the `internal.Integrate(...)` call inside `RunE` and change it to discard the result:
+
+```go
+if _, err := internal.Integrate(&internal.IntegrateOptions{ ... }); err != nil {
+    return err
+}
+return nil
+```
+
+- [ ] **Step 9: Run the failing test — expect it to pass now**
+
+```bash
+go test ./internal/... -run TestIntegrate_returns_result_with_upstream_url_and_hash
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Run the full unit suite to catch collateral compile errors**
+
+```bash
+make test-unit
+```
+
+Expected: all PASS. Any test that previously called `Integrate` and got a single `error` return now needs `_, err := Integrate(...)`. Fix each callsite inline.
+
+- [ ] **Step 11: Run the functional suite for CLI-parity**
+
+```bash
+make test-functional
+```
+
+Expected: all PASS (byte-equivalent output).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/gitspork.go internal/integrate.go internal/integrate_test.go internal/check-drift.go cmd/integrate.go
+git commit -m "feat: Integrate returns *IntegrateResult with per-upstream URL/hash records"
+```
+
+---
+
+## Task 2: Reshape `IntegrateLocal` to return `*IntegrateResult`
+
+**Files:**
+- Modify: `internal/integrate-local.go` (signature + population)
+- Modify: `cmd/integrate-local.go` (RunE update)
+- Modify: test files that call `IntegrateLocal` (if any exist — likely none in `internal/`; the functional tests exercise the CLI, so their contract is unchanged)
+
+- [ ] **Step 1: Write the failing test** — append to `internal/integrate_test.go`. Reuses `testMinimalUpstream` and `testEmptyDownstream` from Task 1 Step 1:
+
+```go
+func TestIntegrateLocal_returns_result_with_upstream_paths(t *testing.T) {
+	upstreamDir, _ := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+
+	result, err := IntegrateLocal(&IntegrateLocalOptions{
+		Logger:         NewLogger(),
+		UpstreamPaths:  []string{upstreamDir},
+		DownstreamPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Upstreams, 1)
+	// IntegrateLocal has no URL — record the path in the URL slot with no scheme.
+	assert.Equal(t, upstreamDir, result.Upstreams[0].URL)
+	assert.Equal(t, "", result.Upstreams[0].CommitHash)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails** — expect compile error (signature mismatch).
+
+```bash
+go test ./internal/... -run TestIntegrateLocal_returns_result_with_upstream_paths
+```
+
+Expected: compile failure (`IntegrateLocal returns only error, cannot assign 2 values`).
+
+- [ ] **Step 3: Update `IntegrateLocal` signature and body** in `internal/integrate-local.go`. Replace the entire function:
+
+```go
+// IntegrateLocal integrates one or more local upstream paths into the downstream.
+func IntegrateLocal(opts *IntegrateLocalOptions) (*IntegrateResult, error) {
+	result := &IntegrateResult{}
+
+	// Normalize: single UpstreamPath -> UpstreamPaths slice.
+	if len(opts.UpstreamPaths) == 0 && opts.UpstreamPath != "" {
+		opts.UpstreamPaths = []string{opts.UpstreamPath}
+	}
+	if len(opts.UpstreamPaths) == 0 {
+		return result, fmt.Errorf("no upstream path specified: provide --upstream-path")
+	}
+
+	for _, upstreamPath := range opts.UpstreamPaths {
+		opts.Logger.Log("parsing the gitspork config file at %s or %s",
+			filepath.Join(upstreamPath, gitSporkConfigFileName),
+			filepath.Join(upstreamPath, gitSporkConfigFileNameAlt))
+		gitSporkConfig, err := getGitSporkConfig(upstreamPath)
+		if err != nil {
+			return result, err
+		}
+		if err := integrate(gitSporkConfig, upstreamPath, opts.DownstreamPath, opts.ForceRePrompt, false, opts.Logger); err != nil {
+			return result, err
+		}
+		result.Upstreams = append(result.Upstreams, IntegratedUpstream{
+			URL: upstreamPath, // local path recorded in URL slot; no CommitHash concept for local
+		})
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 4: Update `cmd/integrate-local.go` RunE**:
+
+```go
+if _, err := internal.IntegrateLocal(&internal.IntegrateLocalOptions{ ... }); err != nil {
+    return err
+}
+return nil
+```
+
+- [ ] **Step 5: Run the failing test — expect PASS**
+
+```bash
+go test ./internal/... -run TestIntegrateLocal_returns_result_with_upstream_paths
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full unit + functional suites**
+
+```bash
+make test-unit && make test-functional
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/integrate-local.go internal/integrate_test.go cmd/integrate-local.go
+git commit -m "feat: IntegrateLocal returns *IntegrateResult"
+```
+
+---
+
+## Task 3: Add `DriftReport`, reshape `CheckDrift` signature and structural output (no drift, per-file, summary)
+
+This task is deliberately atomic: internal produces the report, CLI prints from it. Between these two changes the functional test suite's expected output would break, so both changes ship together.
+
+**Files:**
+- Modify: `internal/check-drift.go` (signature, build DriftReport, remove three Logger.Log calls for user-facing structural output; keep progress-narration calls)
+- Modify: `internal/check-drift_test.go` (update tests to assert on DriftReport)
+- Modify: `cmd/check-drift.go` (walk DriftReport, print equivalent output)
+
+- [ ] **Step 1: Add drift-setup helpers** — append to `internal/check-drift_test.go` (below `makeBaselineRepo`):
+
+```go
+// testIntegrateAndCommitBaseline integrates upstreamDir into downstreamDir and
+// commits the resulting downstream state so the working tree is clean and
+// CheckDrift can operate. Returns the post-integrate commit hash.
+func testIntegrateAndCommitBaseline(t *testing.T, upstreamDir, downstreamDir string) plumbing.Hash {
+	t.Helper()
+	_, err := Integrate(&IntegrateOptions{
+		Logger:             NewLogger(),
+		Upstreams:          []UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	repo, err := gogit.PlainOpen(downstreamDir)
+	require.NoError(t, err)
+	return testCommitAll(t, repo, "post-integrate baseline")
+}
+
+// testWriteAndCommitInDownstream writes content to a file inside downstreamDir
+// and commits, simulating a downstream-side edit that check-drift should detect.
+func testWriteAndCommitInDownstream(t *testing.T, downstreamDir, relPath, content string) {
+	t.Helper()
+	full := filepath.Join(downstreamDir, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	repo, err := gogit.PlainOpen(downstreamDir)
+	require.NoError(t, err)
+	testCommitAll(t, repo, "drift edit: "+relPath)
+}
+```
+
+Add any missing imports to `internal/check-drift_test.go`: `plumbing` from go-git may already be imported (used by `makeBaselineRepo`); `testCommitAll` is defined in `internal/integrate_test.go` in the same package so it's directly callable.
+
+- [ ] **Step 2: Write the failing tests** — append to `internal/check-drift_test.go`. Reuses `testMinimalUpstream` and `testEmptyDownstream` from Task 1 Step 1 (same package, same test file directory — directly callable):
+
+```go
+func TestCheckDrift_returns_report_no_drift(t *testing.T) {
+	upstreamDir, _ := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
+
+	report, err := CheckDrift(&CheckDriftOptions{
+		Logger:             NewLogger(),
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.False(t, report.HasDrift)
+	assert.Empty(t, report.Files)
+}
+
+func TestCheckDrift_returns_report_with_drifted_file_and_attribution(t *testing.T) {
+	upstreamDir, _ := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
+	testWriteAndCommitInDownstream(t, downstreamDir, "upstream-owned/file.txt", "drifted\n")
+
+	report, err := CheckDrift(&CheckDriftOptions{
+		Logger:             NewLogger(),
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.ErrorIs(t, err, ErrDriftDetected)
+	require.NotNil(t, report)
+	assert.True(t, report.HasDrift)
+	require.Len(t, report.Files, 1)
+	assert.Equal(t, "upstream-owned/file.txt", report.Files[0].Path)
+	assert.Equal(t, "file://"+upstreamDir, report.Files[0].AttributedURL)
+}
+```
+
+- [ ] **Step 3: Run the failing tests** — expect compile errors (CheckDrift returns only `error`).
+
+```bash
+go test ./internal/... -run 'TestCheckDrift_returns_report'
+```
+
+Expected: compile failure.
+
+- [ ] **Step 4: Update `CheckDrift` signature** in `internal/check-drift.go` — change:
+
+```go
+func CheckDrift(opts *CheckDriftOptions) error {
+```
+
+to:
+
+```go
+func CheckDrift(opts *CheckDriftOptions) (*DriftReport, error) {
+```
+
+Add `report := &DriftReport{}` as the first statement inside the function. Change EVERY early `return err` in the function to `return report, err`. Change `return nil` to `return report, nil`.
+
+- [ ] **Step 5: Build `DriftReport.Files` in place of per-file `Logger.Log`** — locate the block currently at approximately lines 165–187 that reads:
+
+```go
+if patch == nil {
+    opts.Logger.Log("no drift detected")
+    return nil
+}
+
+stats := patch.Stats()
+opts.Logger.Log("drift detected: %d file(s) changed", len(stats))
+for _, s := range stats {
+    owner := fileOwner[s.Name]
+    if owner == "" {
+        owner = "(unknown upstream)"
+    }
+    opts.Logger.Log("  %s (upstream: %s)", s.Name, owner)
+}
+if opts.Verbose {
+    pr, pw := io.Pipe()
+    go func() { pw.CloseWithError(patch.Encode(pw)) }()
+    if err := opts.Logger.Diff(pr); err != nil {
+        return fmt.Errorf("error encoding diff: %v", err)
+    }
+}
+
+return ErrDriftDetected
+```
+
+Replace with:
+
+```go
+if patch == nil {
+    return report, nil
+}
+
+report.HasDrift = true
+stats := patch.Stats()
+for _, s := range stats {
+    report.Files = append(report.Files, DriftedFile{
+        Path:          s.Name,
+        AttributedURL: fileOwner[s.Name], // empty string means unattributed
+        // Diff populated in Task 4
+    })
+}
+
+return report, ErrDriftDetected
+```
+
+Note: `opts.Verbose` handling is deliberately dropped in this task — Task 4 handles per-file Diff population and removes the field. For now leave `Verbose` on `CheckDriftOptions`; the field stays until Task 4.
+
+- [ ] **Step 6: Update the CLI to walk the report** in `cmd/check-drift.go`. Modify the `RunE` closure to consume the return values and reproduce the pre-refactor output. Replace the current call:
+
+```go
+err := internal.CheckDrift(opts)
+if errors.Is(err, internal.ErrDriftDetected) {
+    os.Exit(2)
+}
+return err
+```
+
+with:
+
+```go
+report, err := internal.CheckDrift(opts)
+if err != nil && !errors.Is(err, internal.ErrDriftDetected) {
+    return err
+}
+if !report.HasDrift {
+    logger.Log("no drift detected")
+    return nil
+}
+logger.Log("drift detected: %d file(s) changed", len(report.Files))
+for _, f := range report.Files {
+    attribution := f.AttributedURL
+    if attribution == "" {
+        attribution = "(unknown upstream)"
+    }
+    logger.Log("  %s (upstream: %s)", f.Path, attribution)
+}
+// verbose/diff output moves to Task 4
+os.Exit(2)
+return nil // unreachable but keeps Go happy
+```
+
+- [ ] **Step 7: Run the two new tests — expect PASS**
+
+```bash
+go test ./internal/... -run 'TestCheckDrift_returns_report'
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Update the existing `TestCheckDrift`** at `internal/check-drift_test.go:16`. Its two `t.Run` blocks currently call `err = CheckDrift(...)` — change both to `_, err = CheckDrift(...)` to match the new signature. Assertions on the error message content are unchanged (both existing sub-tests assert on error text, not on log output, so no other updates needed).
+
+- [ ] **Step 9: Run full unit + functional suites**
+
+```bash
+make test-unit && make test-functional
+```
+
+Expected: all PASS. If a functional test assertion mismatches on output, verify the CLI print statement in Step 5 matches the exact previous format (including leading whitespace on per-file lines).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/gitspork.go internal/check-drift.go internal/check-drift_test.go cmd/check-drift.go
+git commit -m "feat: CheckDrift returns *DriftReport; CLI walks report for structural output"
+```
+
+---
+
+## Task 4: Populate per-file `DriftedFile.Diff`; move verbose output to CLI; remove `Logger.Diff` and `CheckDriftOptions.Verbose`
+
+**Files:**
+- Modify: `internal/check-drift.go` (populate Diff via per-file unified encoder; drop io/logger.Diff usage)
+- Modify: `internal/gitspork.go` (remove `Verbose bool` from `CheckDriftOptions`)
+- Modify: `internal/logger.go` (delete `Diff(io.Reader) error` method)
+- Modify: `internal/check-drift_test.go` (add test asserting `DriftedFile.Diff` populated with unified diff header/hunks)
+- Modify: `cmd/check-drift.go` (add local `verbose` var driven by the existing `--verbose` flag; iterate `report.Files[].Diff` for verbose output)
+
+- [ ] **Step 1: Write the failing test** — append to `internal/check-drift_test.go`:
+
+```go
+func TestCheckDrift_report_files_include_unified_diff(t *testing.T) {
+	upstreamDir, _ := testCreateUpstreamAndCommit(t)
+	downstreamDir := testCreateDownstreamRepo(t)
+	testPrepDownstreamInputData(t, downstreamDir)
+	testDoInitialIntegrate(t, upstreamDir, downstreamDir)
+	testWriteAndCommitFile(t, downstreamDir, "upstream-owned/file.txt", "drifted\n")
+	testPrepDownstreamInputData(t, downstreamDir)
+
+	report, err := CheckDrift(&CheckDriftOptions{
+		Logger:             NewLogger(),
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.ErrorIs(t, err, ErrDriftDetected)
+	require.Len(t, report.Files, 1)
+	diff := report.Files[0].Diff
+	assert.Contains(t, diff, "upstream-owned/file.txt",
+		"expected the unified diff to reference the path, got:\n%s", diff)
+	assert.Contains(t, diff, "-upstream content", "expected removed-line marker for old content")
+	assert.Contains(t, diff, "+drifted", "expected added-line marker for new content")
+}
+```
+
+- [ ] **Step 2: Run the failing test** — expect assertion failure (Diff is empty from Task 3).
+
+```bash
+go test ./internal/... -run TestCheckDrift_report_files_include_unified_diff
+```
+
+Expected: FAIL on `assert.Contains(t, diff, "upstream-owned/file.txt")`.
+
+- [ ] **Step 3: Add a per-file patch encoder helper** in `internal/check-drift.go` — add above the existing `checkCleanWorkingTree` function:
+
+```go
+// singleFilePatch adapts a single fdiff.FilePatch to the fdiff.Patch interface
+// so it can be run through UnifiedEncoder to produce a per-file unified diff.
+type singleFilePatch struct {
+    fp fdiff.FilePatch
+}
+
+func (s *singleFilePatch) FilePatches() []fdiff.FilePatch { return []fdiff.FilePatch{s.fp} }
+func (s *singleFilePatch) Message() string                 { return "" }
+
+// encodeFilePatch renders one file's unified diff to a string.
+func encodeFilePatch(fp fdiff.FilePatch) (string, error) {
+    var buf bytes.Buffer
+    enc := fdiff.NewUnifiedEncoder(&buf, fdiff.DefaultContextLines)
+    if err := enc.Encode(&singleFilePatch{fp: fp}); err != nil {
+        return "", err
+    }
+    return buf.String(), nil
+}
+```
+
+Add imports to `internal/check-drift.go`:
+
+```go
+"bytes"
+
+fdiff "github.com/go-git/go-git/v6/plumbing/format/diff"
+```
+
+If `fdiff` (aliased or not) is not already imported, use that alias to avoid stuttering. Remove the now-unused `"io"` import if applicable (it was only there for `io.Pipe` in the verbose branch, which is being removed).
+
+- [ ] **Step 4: Populate `DriftedFile.Diff` per file** — modify the loop from Task 3 that builds `report.Files`. Replace the simple `stats` loop with an iteration over `patch.FilePatches()`:
+
+```go
+report.HasDrift = true
+for _, fp := range patch.FilePatches() {
+    from, to := fp.Files()
+    var name string
+    switch {
+    case to != nil:
+        name = to.Path()
+    case from != nil:
+        name = from.Path()
+    default:
+        continue
+    }
+    diffText, err := encodeFilePatch(fp)
+    if err != nil {
+        return report, fmt.Errorf("error encoding per-file diff for %s: %v", name, err)
+    }
+    report.Files = append(report.Files, DriftedFile{
+        Path:          name,
+        AttributedURL: fileOwner[name],
+        Diff:          diffText,
+    })
+}
+```
+
+Delete the now-unused `stats := patch.Stats()` line and the block that used it.
+
+- [ ] **Step 5: Remove `Verbose` from `CheckDriftOptions`** in `internal/gitspork.go`. Find:
+
+```go
+type CheckDriftOptions struct {
+    Logger             *Logger
+    DownstreamRepoPath string
+    Upstreams          []UpstreamSpec
+    Verbose            bool
+}
+```
+
+Delete the `Verbose` field. The struct becomes:
+
+```go
+type CheckDriftOptions struct {
+    Logger             *Logger
+    DownstreamRepoPath string
+    Upstreams          []UpstreamSpec
+}
+```
+
+- [ ] **Step 6: Remove `Logger.Diff` method** in `internal/logger.go`. Delete the entire method:
+
+```go
+func (l *Logger) Diff(r io.Reader) error {
+    // ... existing body ...
+}
+```
+
+Remove the `io` import from `internal/logger.go` if no other symbol in that file uses it.
+
+- [ ] **Step 7: Update `cmd/check-drift.go`** to drive verbose from a CLI-local flag and print `DriftedFile.Diff`. The `verbose` local variable already exists (it's the cobra flag). Where the CLI stopped its output block in Task 3 (before the `os.Exit(2)`), add:
+
+```go
+if verbose {
+    for _, f := range report.Files {
+        if f.Diff == "" {
+            continue
+        }
+        fmt.Print(f.Diff)
+    }
+}
+```
+
+Add `"fmt"` import if not already present. Remove any code path that set `opts.Verbose = verbose` — that field no longer exists on `CheckDriftOptions`.
+
+- [ ] **Step 8: Run the failing test — expect PASS**
+
+```bash
+go test ./internal/... -run TestCheckDrift_report_files_include_unified_diff
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Verify no callers of `Logger.Diff` remain**
+
+```bash
+grep -rn "\.Diff(" internal/ cmd/
+```
+
+Expected: no matches referencing `Logger.Diff`. (Matches like `DriftedFile.Diff` are fine — that's a struct field, not the removed method.)
+
+- [ ] **Step 10: Run all four test suites**
+
+```bash
+make test-unit && make test-functional && make test-functional-docker && make test-examples
+```
+
+Expected: all PASS. If the functional `--verbose` drift test asserts specific diff content, verify it still matches — the format shifts slightly from `patch.Encode` (whole-patch header once) to per-file `UnifiedEncoder.Encode` (per-file header prefixes). If a test breaks on this, update the assertion to match the new but still-valid unified-diff format.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add internal/check-drift.go internal/check-drift_test.go internal/gitspork.go internal/logger.go cmd/check-drift.go
+git commit -m "feat: populate DriftedFile.Diff per file; remove Verbose option and Logger.Diff"
+```
+
+---
+
+## Task 5: Final verification and cleanup
+
+- [ ] **Step 1: Run every test suite locally**
+
+```bash
+make test-unit
+make test-functional
+make test-functional-docker
+make test-examples
+```
+
+Expected: all PASS. If any suite fails, treat as a regression from earlier tasks — don't proceed until fixed.
+
+- [ ] **Step 2: Grep for stale references**
+
+```bash
+grep -rn "opts.Verbose\|options.Verbose\|CheckDriftOptions{.*Verbose" internal/ cmd/
+```
+
+Expected: no matches — the field is gone and nothing references it.
+
+```bash
+grep -rn "func (l \*Logger) Diff\|logger.Diff" internal/ cmd/
+```
+
+Expected: no matches for the Logger method (matches for `report.Files[i].Diff` or `DriftedFile.Diff` are struct-field references and are fine).
+
+- [ ] **Step 3: Sanity-check the CLI end-to-end manually** with a real integrate + check-drift roundtrip:
+
+```bash
+go build -o /tmp/gitspork-phase1 .
+# Set up a small upstream/downstream pair however you like, then:
+/tmp/gitspork-phase1 check-drift --downstream-repo-path <dir>
+/tmp/gitspork-phase1 check-drift --downstream-repo-path <dir> --verbose
+```
+
+Expected: output looks the same as pre-refactor. Compare against `main` build if in doubt.
+
+- [ ] **Step 4: Commit any final tweaks**
+
+If Steps 1–3 exposed any missed spots, fix them and commit as `fix: post-refactor cleanup for phase 1` (or similar). Do NOT amend earlier commits — new commits keep the review-diff traceable.
+
+---
+
+## Backward Compatibility
+
+- CLI invocations unchanged. Every flag, exit code, and functionally-equivalent output preserved.
+- Downstream state files (`.gitspork/downstream-state.json`) unchanged — Phase 1 only touches return signatures and CLI-visible output paths.
+- Public API: no library exposure yet. `IntegrateResult`, `DriftReport`, and friends live in `internal/` and get promoted in Phase 3.

--- a/docs/superpowers/specs/2026-07-03-golang-sdk-design.md
+++ b/docs/superpowers/specs/2026-07-03-golang-sdk-design.md
@@ -221,6 +221,18 @@ Three phases, each shipping as its own PR. Between phases the CLI's user-facing 
 
 **Acceptance:** every CLI invocation and every existing consumer path works identically. `import "github.com/rockholla/gitspork/v2"` works from an external Go module. Tagged as v2.0.0 by maintainer.
 
+#### Phase 3 follow-ups carried forward from Phase 1
+
+Items surfaced by Phase 1 code reviews that fit naturally in Phase 3 (when the SDK surface goes public and gets its dedicated tests). These belong in the Phase 3 plan when we write it:
+
+- **Document `IntegratedUpstream.URL` local-path overload.** `IntegrateLocal` stores an absolute filesystem path in the `URL` field (no scheme). The field's doc-comment on `internal/gitspork.go` doesn't call this out. When the type moves to `package gitspork`, add a one-line note: `// URL is the upstream URL, or the local filesystem path for IntegrateLocal (no scheme).`
+- **Document non-nil invariant for `IntegrateResult` / `DriftReport`.** All three entry-point functions guarantee a non-nil pointer return even on error (Phase 1 established this). Add doc-comments on both types and the return signatures so SDK consumers don't add defensive `if result != nil` guards.
+- **Add SDK-tier unit test for multi-upstream `IntegrateResult.Upstreams` ordering.** Phase 1's `TestIntegrate_returns_result_with_upstream_url_and_hash` only covers single-upstream. Multi-upstream ordering is functionally tested via state-file inspection in `TestIntegrate_multi_upstream_state_records_all`, but the new `test/sdk/` tier should assert `result.Upstreams` order directly.
+- **Restore colored verbose diff output in the CLI.** Phase 1 removed `Logger.Diff(io.Reader)` which colorized `+`/`-`/`@@`/header lines with ANSI. `cmd/check-drift.go` now prints `DriftedFile.Diff` as plain text. Add a CLI-side colorizer that iterates lines and applies the old prefix-based coloring when `!color.NoColor`. Keep the SDK `DriftedFile.Diff` plain so machine consumers get clean data.
+- **Honor `Logger == nil` as silent throughout the internal codebase.** Phase 3 promises `nil = silent` at the SDK boundary. Today `internal/integrate.go` has multiple `fmt.Println("")` blank-line writes (~lines 278, 290, 296, 302, 308, 314, 320, 327, 339) and go-git's clone `Progress: os.Stdout` at ~line 407 that bypass the Logger entirely. Route these through the Logger interface (or wrap the Progress writer) so a nil-logger SDK caller sees no stdout output.
+- **Move `IntegrateOptions` internal fields to an unexported sibling.** `ForDriftCheck`, `PrevUpstreamCommitHash`, and the deprecated single-upstream fields (`UpstreamRepoURL`, `UpstreamRepoVersion`, `UpstreamRepoCommit`, `UpstreamRepoSubpath`, `UpstreamRepoToken`) live on the public-facing `IntegrateOptions` today. When it becomes SDK-facing, introduce an unexported `integrateRequest` struct inside `internal/integrate/` and have the public entry point copy the exported fields into it.
+- **Document last-writer-wins attribution semantics on `DriftReport`.** When two upstreams write the same file, `DriftedFile.AttributedURL` records whichever wrote it last. This is a deliberate design choice already reflected in the multi-upstream check-drift tests, but not documented on the type. Add a sentence when promoting the type.
+
 ---
 
 ## Section 4: Testing Strategy

--- a/docs/superpowers/specs/2026-07-03-golang-sdk-design.md
+++ b/docs/superpowers/specs/2026-07-03-golang-sdk-design.md
@@ -1,0 +1,273 @@
+# Golang SDK Design
+
+## Goal
+
+Expose gitspork's top-level operations (`integrate`, `integrate-local`, `check-drift`) as a public Go library so downstream Go projects can invoke them programmatically instead of shelling out to the CLI. Reshape the internals so callers receive structural results (drift reports, integration outcomes) rather than parsing log output. Preserve current CLI behavior — every existing invocation must continue producing the same exit codes, downstream filesystem effects, and functionally-equivalent stdout content.
+
+## Architecture
+
+The change is a three-phase refactor. Phase 1 reshapes return signatures inside today's `internal/` package so callers get structural data — no files move. Phase 2 splits the monolithic `internal/` into cohesive subpackages, relocates `cmd/` under `internal/cli/`, and parks the future SDK vocabulary in `internal/types/`. Phase 3 promotes those vocabulary types up to a new `package gitspork` at the module root, relocates `main.go` under `cmd/gitspork/`, and bumps the module path to `/v2` for the v2.0.0 release.
+
+The CLI is preserved end-to-end throughout. At every phase boundary the existing `test/functional/` suite passes unchanged, meaning stdout, exit codes, and downstream filesystem effects match the pre-refactor tool.
+
+## Tech Stack
+
+Go, existing dependencies unchanged. Module path changes from `github.com/rockholla/gitspork` to `github.com/rockholla/gitspork/v2` in Phase 3 (Go module semantic import versioning requirement for major version ≥ 2).
+
+---
+
+## Section 1: Public API Surface
+
+Root package `gitspork` exports only what these two use cases need:
+
+- **Orchestrator/fleet tools** — a parent Go binary running integrate/check-drift across many downstreams.
+- **Custom CI checks / drift bots** — embedding check-drift and consuming drift results structurally.
+
+### Entry-point functions
+
+```go
+package gitspork
+
+func Integrate(opts *IntegrateOptions) (*IntegrateResult, error)
+func IntegrateLocal(opts *IntegrateLocalOptions) (*IntegrateResult, error)
+func CheckDrift(opts *CheckDriftOptions) (*DriftReport, error)
+```
+
+### Options structs
+
+```go
+type IntegrateOptions struct {
+    Upstreams          []UpstreamSpec
+    DownstreamRepoPath string
+    ForceRePrompt      bool
+    Logger             Logger // nil = silent
+}
+
+type IntegrateLocalOptions struct {
+    UpstreamPaths  []string
+    DownstreamPath string
+    ForceRePrompt  bool
+    Logger         Logger
+}
+
+type CheckDriftOptions struct {
+    Upstreams          []UpstreamSpec // optional overrides; empty = read from state
+    DownstreamRepoPath string
+    Logger             Logger
+}
+
+type UpstreamSpec struct {
+    URL     string
+    Version string
+    Subpath string
+    Token   string
+}
+```
+
+Internal-only fields on today's Options structs (`PrevUpstreamCommitHash`, `ForDriftCheck`, deprecated single-upstream fields like `UpstreamRepoURL`) move to unexported sibling structs. SDK callers cannot set them.
+
+### Result types
+
+```go
+type IntegrateResult struct {
+    Upstreams []IntegratedUpstream // one entry per successfully integrated upstream, in order
+}
+
+type IntegratedUpstream struct {
+    URL        string
+    Subpath    string
+    CommitHash string
+}
+
+type DriftReport struct {
+    HasDrift bool
+    Files    []DriftedFile
+}
+
+type DriftedFile struct {
+    Path          string
+    AttributedURL string // upstream URL that last wrote this file
+    Diff          string // patch text; empty if drift-check ran without verbose diff capture
+}
+
+var ErrDriftDetected = errors.New("drift detected")
+```
+
+`CheckDrift` returns both a populated `*DriftReport` and `ErrDriftDetected` when drift is found — callers can branch on either. `Integrate` returns a populated `*IntegrateResult` even on partial failure (upstreams recorded so far) alongside the error.
+
+### Logger interface
+
+```go
+type Logger interface {
+    Log(msg string, args ...any)
+    Error(msg string, args ...any)
+}
+```
+
+Two methods are all the internal code needs for progress narration. `nil` is a valid value meaning silent. The concrete color-writing `CLILogger` used by the binary today lives in `internal/logutil/` and satisfies this interface.
+
+### Explicitly not exported
+
+Config parsing/writing (`ParseGitSporkConfig`, `WriteGitSporkConfig`, `FindGitSporkConfig`), schema rendering (`GetGitSporkConfigSchema`), upstream maintenance helpers (`UpstreamMv`, `UpstreamRm`, and their `Compute*` variants), `Init`, `ColorizeYAML`, `OwnedEntry`, and the concrete `Logger` implementation. If a future consumer needs any of these, adding them is a backward-compatible minor version bump.
+
+---
+
+## Section 2: Repo Layout
+
+### Current (v1.1.x)
+
+```
+├── main.go                  # package main; 6 lines
+├── cmd/                     # package cmd; cobra subcommands
+├── internal/                # package internal; all business logic
+│   ├── gitspork.go          # types
+│   ├── integrate*.go
+│   ├── check-drift.go
+│   ├── logger.go            # concrete color-writing Logger
+│   ├── integrator_*.go
+│   ├── upstream-*.go
+│   ├── owned-entry.go
+│   ├── input/               # prompt helpers
+│   └── testharness/         # shared test setup
+└── test/
+```
+
+### Target after Phase 3 (v2.0.0)
+
+```
+├── gitspork.go              # package gitspork; Integrate, IntegrateLocal, CheckDrift entry points
+├── options.go               # package gitspork; Options structs, UpstreamSpec
+├── results.go               # package gitspork; IntegrateResult, IntegratedUpstream, DriftReport, DriftedFile
+├── logger.go                # package gitspork; Logger interface only
+├── errors.go                # package gitspork; ErrDriftDetected sentinel
+├── doc.go                   # package gitspork; package-level docs and usage example
+├── cmd/
+│   └── gitspork/
+│       └── main.go          # package main; 6-line CLI entry point
+├── internal/
+│   ├── cli/                 # package cli; the cobra subcommands (moved from cmd/)
+│   ├── config/              # GitSporkConfig, Parse/Write, schema, OwnedEntry, mv/rm helpers
+│   ├── integrate/           # integrateOne, integrators/, upstream-delta, url normalization
+│   ├── drift/               # CheckDrift internals: worktree diff, listWorktreeFiles, attribution
+│   ├── logutil/             # concrete CLILogger (satisfies gitspork.Logger)
+│   ├── input/               # unchanged
+│   └── testharness/         # unchanged
+└── test/
+    ├── functional/          # unchanged: CLI end-to-end
+    ├── examples/            # unchanged: docs/examples fixture-based
+    └── sdk/                 # new in Phase 3: black-box SDK tests
+```
+
+The three exported entry-point functions at the module root are thin coordinators — they build internal request objects and call into `internal/integrate` and `internal/drift`. No business logic lives at the root.
+
+---
+
+## Section 3: Phase Breakdown
+
+Three phases, each shipping as its own PR. Between phases the CLI's user-facing behavior stays identical, so each is independently mergeable.
+
+### Phase 1: Refactor to structural results
+
+**Goal:** reshape `Integrate` / `IntegrateLocal` / `CheckDrift` to return result structs, and pull user-facing output out of the business logic. No files move; this is a pure semantic refactor inside today's `internal/`.
+
+- Add `IntegrateResult`, `IntegratedUpstream`, `DriftReport`, `DriftedFile` types in `internal/gitspork.go`.
+- Change signatures to `(*Result, error)`; internal functions populate the result while running.
+- Split user-facing output cleanly:
+  - **Progress narration** (e.g., "cloning upstream X at commit Y") stays on `Logger` (still the concrete `internal.Logger` in this phase).
+  - **Result-shaped output** (per-file drift lines, drift summary counts, verbose diff dumps) moves out of internal. The CLI (`cmd/check-drift.go`) walks the returned `DriftReport` and prints the same output it produces today.
+- Remove `Logger.Diff(io.Reader)`; verbose full-patch printing becomes the CLI iterating over `DriftReport.Files[].Diff`.
+- Update all `internal/*_test.go` tests to inspect the returned struct rather than a captured Logger.
+- CLI user-visible output must remain functionally equivalent to pre-refactor (existing `test/functional/` substring assertions continue to pass).
+
+**Acceptance:** `make test-unit`, `make test-functional`, `make test-functional-docker`, `make test-examples` all pass.
+
+### Phase 2: Physical repo split
+
+**Goal:** carve `internal/` into subpackages and relocate `cmd/`. No new code, no API changes.
+
+- Create subpackages under `internal/`:
+  - `internal/config/` — receives `GitSporkConfig`, all its sub-types, `ParseGitSporkConfig`, `WriteGitSporkConfig`, `GetGitSporkConfigSchema`, `FindGitSporkConfig`, `OwnedEntry`, `ComputeUpstreamMv`/`ComputeUpstreamRm`/`UpstreamMv`/`UpstreamRm`, `Init`, `ColorizeYAML`
+  - `internal/integrate/` — receives `Integrate`, `IntegrateLocal`, `integrateOne`, all integrators (`integrator_*.go`), `upstream-delta.go`, URL normalization, state helpers, migrations
+  - `internal/drift/` — receives `CheckDrift`, `listWorktreeFiles`, `diffWorktreeAgainstHEAD`, attribution logic, `ErrDriftDetected`
+  - `internal/logutil/` — receives the concrete color-writing Logger implementation (renamed `CLILogger`)
+- Create `internal/types/` — parked home for the future SDK vocabulary during Phase 2:
+  - `IntegrateOptions`, `IntegrateLocalOptions`, `CheckDriftOptions`, `UpstreamSpec`
+  - `IntegrateResult`, `IntegratedUpstream`, `DriftReport`, `DriftedFile`
+  - `Logger` interface (as a new abstraction; `logutil.CLILogger` implements it)
+  - `ErrDriftDetected` sentinel
+  - This package deliberately has minimal dependencies so any subpackage can import it without cycles.
+- Move `cmd/*.go` → `internal/cli/` (`package cli`). `ParseUpstreamFlag` (currently in `internal/integrate.go`) is a CLI-flag parser used only by cobra subcommands, so it moves to `internal/cli/` too. Update `main.go` at repo root to call `cli.Execute(version)`.
+- Update imports throughout `internal/`, the test suites, and `main.go`.
+
+**Acceptance:** module root, `main.go`, and build system are unchanged from Phase 1's end state (aside from the `cmd` import path). All four test suites still pass with no behavioral change.
+
+### Phase 3: Expose the SDK
+
+**Goal:** create `package gitspork` at the repo root, move the CLI binary under `cmd/gitspork/`, bump the module path to `/v2` for the v2.0.0 release.
+
+- **Promote `internal/types/` → `package gitspork` at the module root.** Split into `gitspork.go`, `options.go`, `results.go`, `logger.go`, `errors.go`, `doc.go`. Delete `internal/types/`.
+- Add public entry-point functions in `package gitspork` (`Integrate`, `IntegrateLocal`, `CheckDrift`) as thin coordinators that call into `internal/integrate` and `internal/drift`.
+- `internal/integrate`, `internal/drift`, `internal/logutil`, `internal/cli` now import `github.com/rockholla/gitspork/v2` for the shared vocabulary types.
+- Move `main.go` → `cmd/gitspork/main.go` (still `package main`, still 6 lines, still calls `cli.Execute(version)`).
+- Update `go.mod`: `module github.com/rockholla/gitspork/v2`.
+- Rewrite all internal imports from `github.com/rockholla/gitspork/...` to `github.com/rockholla/gitspork/v2/...`.
+- Build-system updates:
+  - `.goreleaser.yaml`: add `main: ./cmd/gitspork` to each `builds:` entry
+  - `Dockerfile`: adjust `COPY` and `go build` paths
+  - `Makefile`: any `go build .` targets become `go build ./cmd/gitspork`
+  - `test/functional/main_test.go`: the binary-building setup changes from `go build .` to `go build ./cmd/gitspork`
+- Add `doc.go` with a package-level example showing both use cases (orchestrator, drift bot).
+- Add the new `test/sdk/` tier (see Section 4).
+
+**Acceptance:** every CLI invocation and every existing consumer path works identically. `import "github.com/rockholla/gitspork/v2"` works from an external Go module. Tagged as v2.0.0 by maintainer.
+
+---
+
+## Section 4: Testing Strategy
+
+Three tiers, each with a clear job.
+
+### Tier 1: Unit tests
+
+Every `internal/*_test.go` file today gets moved with its production code in Phase 2. Once split:
+- `internal/config/*_test.go` — parse/write/round-trip, schema rendering, `OwnedEntry`, `UpstreamMv`/`UpstreamRm`
+- `internal/integrate/*_test.go` — `integrateOne`, URL normalization, state upsert/migration, delta propagation, per-integrator behavior, migrations
+- `internal/drift/*_test.go` — `listWorktreeFiles`, `diffWorktreeAgainstHEAD`, per-upstream attribution
+- `internal/logutil/*_test.go` — the concrete CLI logger's formatting
+
+Pure relocation; assertions unchanged.
+
+### Tier 2: Functional CLI tests
+
+`test/functional/` (native + docker) is the CLI-parity safety net. Its assertions target the compiled binary's exit codes, stdout, and downstream filesystem effects. **Unchanged across all three phases.** If the same functional suite passes at each phase's tip, CLI behavior is preserved end-to-end.
+
+The only test-infrastructure change is in Phase 3: `test/functional/main_test.go`'s build step updates from `go build .` to `go build ./cmd/gitspork`.
+
+### Tier 3: SDK tests (new in Phase 3)
+
+New directory `test/sdk/`, sibling to `functional/` and `examples/`. Tests import `github.com/rockholla/gitspork/v2` **as an external caller would** — black-box, from an outside package. This proves the public API works from Go code, not just via the CLI.
+
+Coverage areas:
+- **`Integrate`** — single upstream; multi-upstream precedence; `IntegrateResult.Upstreams` order and commit hashes match actual upstream HEADs; state persisted correctly.
+- **`IntegrateLocal`** — multi-path precedence; `IntegrateResult` shape; no downstream state file written (spec §4 invariant from multi-upstream feature).
+- **`CheckDrift`** — no-drift returns `HasDrift: false` and nil error; drift returns populated `DriftReport.Files` with correct `AttributedURL` per file and `ErrDriftDetected` sentinel; verbose diffs populated in `DriftedFile.Diff`.
+- **Logger contract** — `nil` logger is silent (no output at all captured); custom `Logger` impl captures the progress calls the internals make; `internal/logutil.CLILogger` satisfies the `gitspork.Logger` interface (compile-time assertion).
+- **Error paths** — no upstreams + no state; override upstream not in state; both must return the same errors the CLI returns, callable programmatically.
+
+Tests reuse the existing `internal/testharness` helpers for building upstream/downstream fixtures. New build tag `sdk` (mirrors `functional`/`functional_docker`/`examples`). New Makefile target `make test-sdk`. New CI job `sdk-tests` alongside the existing four.
+
+### CLI parity acceptance per phase
+
+Every PR's CI must have all applicable suites green: unit + functional + functional-docker + examples (Phases 1 and 2); those plus sdk (Phase 3). No PR merges with any suite failing.
+
+---
+
+## Backward Compatibility
+
+| Scenario | Behavior after v2.0.0 |
+|---|---|
+| Existing CLI invocations (all flags including backward-compat single-upstream forms) | Identical output, exit codes, and filesystem effects. |
+| Existing downstream state files (`.gitspork/downstream-state.json`) | Read and used unchanged; auto-migration of legacy single-upstream fields (already present in v1.1) continues to work. |
+| Third-party Go code that imported `github.com/rockholla/gitspork/internal/...` | Never supported — Go's `internal/` restriction prevented this. No breakage risk. |
+| Third-party Go code that will use the v2 SDK | Imports `github.com/rockholla/gitspork/v2` and calls the three exported entry points. Semver-stable from v2.0.0 forward. |
+| Third-party Go code that wants config parsing, mv/rm, init, or schema | Not exposed in v2.0.0. Additive minor version if requested later. |

--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -128,7 +128,7 @@ func CheckDrift(opts *CheckDriftOptions) error {
 			return fmt.Errorf("error listing worktree files before integrate: %v", err)
 		}
 
-		if err := Integrate(&IntegrateOptions{
+		if _, err := Integrate(&IntegrateOptions{
 			Logger:              opts.Logger,
 			UpstreamRepoURL:     entry.spec.URL,
 			UpstreamRepoSubpath: entry.spec.Subpath,

--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,24 +21,25 @@ const driftCheckBranch = "_gitspork-check-drift"
 var ErrDriftDetected = errors.New("drift detected")
 
 // CheckDrift detects whether the downstream has drifted from its last integrated upstream state
-func CheckDrift(opts *CheckDriftOptions) error {
+func CheckDrift(opts *CheckDriftOptions) (*DriftReport, error) {
+	report := &DriftReport{}
 	var err error
 
 	if opts.DownstreamRepoPath == "" {
 		opts.DownstreamRepoPath, err = os.Getwd()
 		if err != nil {
-			return fmt.Errorf("unable to get the present working directory: %v", err)
+			return report, fmt.Errorf("unable to get the present working directory: %v", err)
 		}
 	} else {
 		opts.DownstreamRepoPath, err = filepath.Abs(opts.DownstreamRepoPath)
 		if err != nil {
-			return fmt.Errorf("unable to determine local downstream repo path: %v", err)
+			return report, fmt.Errorf("unable to determine local downstream repo path: %v", err)
 		}
 	}
 
 	state, err := loadDownstreamState(opts.DownstreamRepoPath)
 	if err != nil {
-		return fmt.Errorf("error loading downstream state: %v", err)
+		return report, fmt.Errorf("error loading downstream state: %v", err)
 	}
 
 	// Resolve which upstreams to check and their recorded commit hashes.
@@ -62,12 +62,12 @@ func CheckDrift(opts *CheckDriftOptions) error {
 				}
 			}
 			if !found {
-				return fmt.Errorf("--upstream override %q has no matching state entry — run 'gitspork integrate' first", override.URL)
+				return report, fmt.Errorf("--upstream override %q has no matching state entry — run 'gitspork integrate' first", override.URL)
 			}
 		}
 	} else {
 		if len(state.Upstreams) == 0 {
-			return fmt.Errorf("no previous integration found in downstream state — run 'gitspork integrate' first")
+			return report, fmt.Errorf("no previous integration found in downstream state — run 'gitspork integrate' first")
 		}
 		for _, su := range state.Upstreams {
 			entries = append(entries, upstreamCheckEntry{
@@ -79,20 +79,20 @@ func CheckDrift(opts *CheckDriftOptions) error {
 
 	repo, err := gogit.PlainOpen(opts.DownstreamRepoPath)
 	if err != nil {
-		return fmt.Errorf("error opening downstream repo: %v", err)
+		return report, fmt.Errorf("error opening downstream repo: %v", err)
 	}
 	wt, err := repo.Worktree()
 	if err != nil {
-		return fmt.Errorf("error accessing downstream worktree: %v", err)
+		return report, fmt.Errorf("error accessing downstream worktree: %v", err)
 	}
 
 	if err := checkCleanWorkingTree(opts.DownstreamRepoPath); err != nil {
-		return err
+		return report, err
 	}
 
 	headRef, err := repo.Head()
 	if err != nil {
-		return fmt.Errorf("error resolving HEAD: %v", err)
+		return report, fmt.Errorf("error resolving HEAD: %v", err)
 	}
 
 	// Remember how to restore HEAD once the drift check finishes. CI runners
@@ -106,10 +106,10 @@ func CheckDrift(opts *CheckDriftOptions) error {
 
 	driftBranchRef := plumbing.NewBranchReferenceName(driftCheckBranch)
 	if err := repo.Storer.SetReference(plumbing.NewHashReference(driftBranchRef, headRef.Hash())); err != nil {
-		return fmt.Errorf("error creating/resetting drift-check branch: %v", err)
+		return report, fmt.Errorf("error creating/resetting drift-check branch: %v", err)
 	}
 	if err := wt.Checkout(&gogit.CheckoutOptions{Branch: driftBranchRef}); err != nil {
-		return fmt.Errorf("error checking out drift-check branch: %v", err)
+		return report, fmt.Errorf("error checking out drift-check branch: %v", err)
 	}
 	defer func() {
 		_ = wt.Checkout(restore)
@@ -125,7 +125,7 @@ func CheckDrift(opts *CheckDriftOptions) error {
 
 		beforeFiles, err := listWorktreeFiles(opts.DownstreamRepoPath)
 		if err != nil {
-			return fmt.Errorf("error listing worktree files before integrate: %v", err)
+			return report, fmt.Errorf("error listing worktree files before integrate: %v", err)
 		}
 
 		if _, err := Integrate(&IntegrateOptions{
@@ -137,12 +137,12 @@ func CheckDrift(opts *CheckDriftOptions) error {
 			DownstreamRepoPath:  opts.DownstreamRepoPath,
 			ForDriftCheck:       true,
 		}); err != nil {
-			return fmt.Errorf("error running integration for drift check: %v", err)
+			return report, fmt.Errorf("error running integration for drift check: %v", err)
 		}
 
 		afterFiles, err := listWorktreeFiles(opts.DownstreamRepoPath)
 		if err != nil {
-			return fmt.Errorf("error listing worktree files after integrate: %v", err)
+			return report, fmt.Errorf("error listing worktree files after integrate: %v", err)
 		}
 
 		// Any file that appeared or changed is attributed to this upstream.
@@ -160,31 +160,23 @@ func CheckDrift(opts *CheckDriftOptions) error {
 
 	patch, err := diffWorktreeAgainstHEAD(repo, wt)
 	if err != nil {
-		return fmt.Errorf("error diffing downstream against HEAD: %v", err)
+		return report, fmt.Errorf("error diffing downstream against HEAD: %v", err)
 	}
 	if patch == nil {
-		opts.Logger.Log("no drift detected")
-		return nil
+		return report, nil
 	}
 
+	report.HasDrift = true
 	stats := patch.Stats()
-	opts.Logger.Log("drift detected: %d file(s) changed", len(stats))
 	for _, s := range stats {
-		owner := fileOwner[s.Name]
-		if owner == "" {
-			owner = "(unknown upstream)"
-		}
-		opts.Logger.Log("  %s (upstream: %s)", s.Name, owner)
-	}
-	if opts.Verbose {
-		pr, pw := io.Pipe()
-		go func() { pw.CloseWithError(patch.Encode(pw)) }()
-		if err := opts.Logger.Diff(pr); err != nil {
-			return fmt.Errorf("error encoding diff: %v", err)
-		}
+		report.Files = append(report.Files, DriftedFile{
+			Path:          s.Name,
+			AttributedURL: fileOwner[s.Name], // empty string means unattributed
+			// Diff populated in Task 4
+		})
 	}
 
-	return ErrDriftDetected
+	return report, ErrDriftDetected
 }
 
 // diffWorktreeAgainstHEAD stages all changes and compares against HEAD.

--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -239,6 +239,8 @@ type singleFilePatch struct {
 	fp fdiff.FilePatch
 }
 
+var _ fdiff.Patch = (*singleFilePatch)(nil)
+
 func (s *singleFilePatch) FilePatches() []fdiff.FilePatch { return []fdiff.FilePatch{s.fp} }
 func (s *singleFilePatch) Message() string                { return "" }
 

--- a/internal/check-drift.go
+++ b/internal/check-drift.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	fdiff "github.com/go-git/go-git/v6/plumbing/format/diff"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -167,12 +169,25 @@ func CheckDrift(opts *CheckDriftOptions) (*DriftReport, error) {
 	}
 
 	report.HasDrift = true
-	stats := patch.Stats()
-	for _, s := range stats {
+	for _, fp := range patch.FilePatches() {
+		from, to := fp.Files()
+		var name string
+		switch {
+		case to != nil:
+			name = to.Path()
+		case from != nil:
+			name = from.Path()
+		default:
+			continue
+		}
+		diffText, err := encodeFilePatch(fp)
+		if err != nil {
+			return report, fmt.Errorf("error encoding per-file diff for %s: %v", name, err)
+		}
 		report.Files = append(report.Files, DriftedFile{
-			Path:          s.Name,
-			AttributedURL: fileOwner[s.Name], // empty string means unattributed
-			// Diff populated in Task 4
+			Path:          name,
+			AttributedURL: fileOwner[name], // empty string means unattributed
+			Diff:          diffText,
 		})
 	}
 
@@ -216,6 +231,25 @@ func diffWorktreeAgainstHEAD(repo *gogit.Repository, wt *gogit.Worktree) (*objec
 		return nil, fmt.Errorf("error computing patch: %v", err)
 	}
 	return patch, nil
+}
+
+// singleFilePatch adapts a single fdiff.FilePatch to the fdiff.Patch interface
+// so it can be run through UnifiedEncoder to produce a per-file unified diff.
+type singleFilePatch struct {
+	fp fdiff.FilePatch
+}
+
+func (s *singleFilePatch) FilePatches() []fdiff.FilePatch { return []fdiff.FilePatch{s.fp} }
+func (s *singleFilePatch) Message() string                { return "" }
+
+// encodeFilePatch renders one file's unified diff to a string.
+func encodeFilePatch(fp fdiff.FilePatch) (string, error) {
+	var buf bytes.Buffer
+	enc := fdiff.NewUnifiedEncoder(&buf, fdiff.DefaultContextLines)
+	if err := enc.Encode(&singleFilePatch{fp: fp}); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 func checkCleanWorkingTree(repoPath string) error {

--- a/internal/check-drift_test.go
+++ b/internal/check-drift_test.go
@@ -19,7 +19,7 @@ func TestCheckDrift(t *testing.T) {
 		require.NoError(t, err)
 		defer os.RemoveAll(dir)
 
-		err = CheckDrift(&CheckDriftOptions{
+		_, err = CheckDrift(&CheckDriftOptions{
 			Logger:             NewLogger(),
 			DownstreamRepoPath: dir,
 		})
@@ -42,7 +42,7 @@ func TestCheckDrift(t *testing.T) {
 		}
 		require.NoError(t, saveDownstreamState(dir, state))
 
-		err = CheckDrift(&CheckDriftOptions{
+		_, err = CheckDrift(&CheckDriftOptions{
 			Logger:             NewLogger(),
 			DownstreamRepoPath: dir,
 		})
@@ -161,4 +161,65 @@ func makeBaselineRepo(t *testing.T, dir string) *gogit.Worktree {
 	_, err = wt.Commit("baseline", &gogit.CommitOptions{Author: sig})
 	require.NoError(t, err)
 	return wt
+}
+
+func TestCheckDrift_returns_report_no_drift(t *testing.T) {
+	upstreamDir, _ := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
+
+	report, err := CheckDrift(&CheckDriftOptions{
+		Logger:             NewLogger(),
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.False(t, report.HasDrift)
+	assert.Empty(t, report.Files)
+}
+
+func TestCheckDrift_returns_report_with_drifted_file_and_attribution(t *testing.T) {
+	upstreamDir, _ := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
+	testWriteAndCommitInDownstream(t, downstreamDir, "upstream-owned/file.txt", "drifted\n")
+
+	report, err := CheckDrift(&CheckDriftOptions{
+		Logger:             NewLogger(),
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.ErrorIs(t, err, ErrDriftDetected)
+	require.NotNil(t, report)
+	assert.True(t, report.HasDrift)
+	require.Len(t, report.Files, 1)
+	assert.Equal(t, "upstream-owned/file.txt", report.Files[0].Path)
+	assert.Equal(t, "file://"+upstreamDir, report.Files[0].AttributedURL)
+}
+
+// testIntegrateAndCommitBaseline integrates upstreamDir into downstreamDir and
+// commits the resulting downstream state so the working tree is clean and
+// CheckDrift can operate. Returns the post-integrate commit hash.
+func testIntegrateAndCommitBaseline(t *testing.T, upstreamDir, downstreamDir string) plumbing.Hash {
+	t.Helper()
+	_, err := Integrate(&IntegrateOptions{
+		Logger:             NewLogger(),
+		Upstreams:          []UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	repo, err := gogit.PlainOpen(downstreamDir)
+	require.NoError(t, err)
+	return testCommitAll(t, repo, "post-integrate baseline")
+}
+
+// testWriteAndCommitInDownstream writes content to a file inside downstreamDir
+// and commits, simulating a downstream-side edit that check-drift should detect.
+func testWriteAndCommitInDownstream(t *testing.T, downstreamDir, relPath, content string) {
+	t.Helper()
+	full := filepath.Join(downstreamDir, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	repo, err := gogit.PlainOpen(downstreamDir)
+	require.NoError(t, err)
+	testCommitAll(t, repo, "drift edit: "+relPath)
 }

--- a/internal/check-drift_test.go
+++ b/internal/check-drift_test.go
@@ -223,3 +223,22 @@ func testWriteAndCommitInDownstream(t *testing.T, downstreamDir, relPath, conten
 	require.NoError(t, err)
 	testCommitAll(t, repo, "drift edit: "+relPath)
 }
+
+func TestCheckDrift_report_files_include_unified_diff(t *testing.T) {
+	upstreamDir, _ := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
+	testWriteAndCommitInDownstream(t, downstreamDir, "upstream-owned/file.txt", "drifted\n")
+
+	report, err := CheckDrift(&CheckDriftOptions{
+		Logger:             NewLogger(),
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.ErrorIs(t, err, ErrDriftDetected)
+	require.Len(t, report.Files, 1)
+	diff := report.Files[0].Diff
+	assert.Contains(t, diff, "upstream-owned/file.txt",
+		"expected the unified diff to reference the path, got:\n%s", diff)
+	assert.Contains(t, diff, "-upstream content", "expected removed-line marker for old content")
+	assert.Contains(t, diff, "+drifted", "expected added-line marker for new content")
+}

--- a/internal/gitspork.go
+++ b/internal/gitspork.go
@@ -67,6 +67,37 @@ type GitSporkDownstreamState struct {
 	LastUpstreamCommitHash  string `json:"last_upstream_commit_hash,omitempty"`
 }
 
+// IntegrateResult is the structural return value of Integrate and IntegrateLocal.
+// It records what was successfully integrated (in order); on partial failure
+// the successful upstreams so far are still present in this result alongside
+// the returned error.
+type IntegrateResult struct {
+	Upstreams []IntegratedUpstream
+}
+
+// IntegratedUpstream identifies a single successfully integrated upstream.
+type IntegratedUpstream struct {
+	URL        string
+	Subpath    string
+	CommitHash string
+}
+
+// DriftReport is the structural return value of CheckDrift. HasDrift is false
+// when the downstream matches the recorded integration state; true when
+// differences were found. Files enumerates the drifted entries with per-file
+// attribution to whichever upstream last wrote each path.
+type DriftReport struct {
+	HasDrift bool
+	Files    []DriftedFile
+}
+
+// DriftedFile is a single entry in a DriftReport.
+type DriftedFile struct {
+	Path          string
+	AttributedURL string // upstream URL responsible for this file; empty means unattributed
+	Diff          string // unified-diff text for just this file; empty for binary or unattributable
+}
+
 // UpstreamSpec is a parsed --upstream flag entry.
 type UpstreamSpec struct {
 	URL     string

--- a/internal/gitspork.go
+++ b/internal/gitspork.go
@@ -168,7 +168,6 @@ type CheckDriftOptions struct {
 	Logger             *Logger
 	DownstreamRepoPath string
 	Upstreams          []UpstreamSpec
-	Verbose            bool
 }
 
 // ParseGitSporkConfig will parse a .gitspork.yml config file at the provided path

--- a/internal/gitspork.go
+++ b/internal/gitspork.go
@@ -95,7 +95,7 @@ type DriftReport struct {
 type DriftedFile struct {
 	Path          string
 	AttributedURL string // upstream URL responsible for this file; empty means unattributed
-	Diff          string // unified-diff text for just this file; empty for binary or unattributable
+	Diff          string // unified-diff text for this file; a `Binary files ... differ` marker line when the file is binary
 }
 
 // UpstreamSpec is a parsed --upstream flag entry.

--- a/internal/gitspork_test.go
+++ b/internal/gitspork_test.go
@@ -25,7 +25,7 @@ func TestIntegrate(t *testing.T) {
 
 		makeUpstreamRepo(t, upstreamDir)
 
-		err = Integrate(&IntegrateOptions{
+		_, err = Integrate(&IntegrateOptions{
 			Logger:              NewLogger(),
 			UpstreamRepoURL:     upstreamDir,
 			UpstreamRepoVersion: "master",

--- a/internal/integrate-local.go
+++ b/internal/integrate-local.go
@@ -6,13 +6,15 @@ import (
 )
 
 // IntegrateLocal integrates one or more local upstream paths into the downstream.
-func IntegrateLocal(opts *IntegrateLocalOptions) error {
+func IntegrateLocal(opts *IntegrateLocalOptions) (*IntegrateResult, error) {
+	result := &IntegrateResult{}
+
 	// Normalize: single UpstreamPath -> UpstreamPaths slice.
 	if len(opts.UpstreamPaths) == 0 && opts.UpstreamPath != "" {
 		opts.UpstreamPaths = []string{opts.UpstreamPath}
 	}
 	if len(opts.UpstreamPaths) == 0 {
-		return fmt.Errorf("no upstream path specified: provide --upstream-path")
+		return result, fmt.Errorf("no upstream path specified: provide --upstream-path")
 	}
 
 	for _, upstreamPath := range opts.UpstreamPaths {
@@ -21,11 +23,14 @@ func IntegrateLocal(opts *IntegrateLocalOptions) error {
 			filepath.Join(upstreamPath, gitSporkConfigFileNameAlt))
 		gitSporkConfig, err := getGitSporkConfig(upstreamPath)
 		if err != nil {
-			return err
+			return result, err
 		}
 		if err := integrate(gitSporkConfig, upstreamPath, opts.DownstreamPath, opts.ForceRePrompt, false, opts.Logger); err != nil {
-			return err
+			return result, err
 		}
+		result.Upstreams = append(result.Upstreams, IntegratedUpstream{
+			URL: upstreamPath, // local path recorded in URL slot; no CommitHash concept for local
+		})
 	}
-	return nil
+	return result, nil
 }

--- a/internal/integrate.go
+++ b/internal/integrate.go
@@ -108,19 +108,21 @@ func upsertUpstreamState(state *GitSporkDownstreamState, entry GitSporkUpstreamS
 	state.Upstreams = append(state.Upstreams, entry)
 }
 
-// Integrate will ensure that the localRepoPath is integrated/re-integrated w/ the upstreamRepoURL version
-func Integrate(opts *IntegrateOptions) error {
+// Integrate will ensure that the downstream at opts.DownstreamRepoPath is
+// integrated with each upstream in opts.Upstreams, in order.
+func Integrate(opts *IntegrateOptions) (*IntegrateResult, error) {
 	var err error
+	result := &IntegrateResult{}
 
 	if opts.DownstreamRepoPath == "" {
 		opts.DownstreamRepoPath, err = os.Getwd()
 		if err != nil {
-			return fmt.Errorf("unable to get the present working directory: %v", err)
+			return result, fmt.Errorf("unable to get the present working directory: %v", err)
 		}
 	} else {
 		opts.DownstreamRepoPath, err = filepath.Abs(opts.DownstreamRepoPath)
 		if err != nil {
-			return fmt.Errorf("unable to determine local downstream repo path: %v", err)
+			return result, fmt.Errorf("unable to determine local downstream repo path: %v", err)
 		}
 	}
 
@@ -134,23 +136,25 @@ func Integrate(opts *IntegrateOptions) error {
 		}}
 	}
 	if len(opts.Upstreams) == 0 {
-		return fmt.Errorf("no upstream specified: provide --upstream or --upstream-repo-url")
+		return result, fmt.Errorf("no upstream specified: provide --upstream or --upstream-repo-url")
 	}
 
 	for _, upstream := range opts.Upstreams {
-		if err := integrateOne(opts, upstream); err != nil {
-			return err
+		integrated, err := integrateOne(opts, upstream)
+		if err != nil {
+			return result, err
 		}
+		result.Upstreams = append(result.Upstreams, integrated)
 	}
-	return nil
+	return result, nil
 }
 
-func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) error {
+func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) (IntegratedUpstream, error) {
 	prevHash := ""
 	if !opts.ForDriftCheck {
 		existingState, err := loadDownstreamState(opts.DownstreamRepoPath)
 		if err != nil {
-			return fmt.Errorf("error loading downstream state for delta check: %v", err)
+			return IntegratedUpstream{}, fmt.Errorf("error loading downstream state for delta check: %v", err)
 		}
 		key := normalizeUpstreamURL(upstream.URL, upstream.Subpath)
 		for _, u := range existingState.Upstreams {
@@ -163,7 +167,7 @@ func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) error {
 
 	cloneDir, err := os.MkdirTemp("", gitSpork)
 	if err != nil {
-		return fmt.Errorf("error creating temporary directory: %v", err)
+		return IntegratedUpstream{}, fmt.Errorf("error creating temporary directory: %v", err)
 	}
 	defer os.RemoveAll(cloneDir)
 
@@ -184,38 +188,38 @@ func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) error {
 	opts.Logger.Log("cloning gitspork upstream repo %s", upstream.URL)
 	commitHash, err := cloneUpstreamForIntegrate(cloneDir, singleOpts)
 	if err != nil {
-		return err
+		return IntegratedUpstream{}, err
 	}
 
 	upstreamRootPath := filepath.Join(cloneDir, upstream.Subpath)
 	opts.Logger.Log("parsing the gitspork config file in the upstream repo clone at %s or %s", gitSporkConfigFileName, gitSporkConfigFileNameAlt)
 	gitSporkConfig, err := getGitSporkConfig(upstreamRootPath)
 	if err != nil {
-		return err
+		return IntegratedUpstream{}, err
 	}
 
 	if !opts.ForDriftCheck && prevHash != "" {
 		upstreamRepo, err := git.PlainOpen(cloneDir)
 		if err != nil {
-			return fmt.Errorf("error opening upstream clone for delta computation: %v", err)
+			return IntegratedUpstream{}, fmt.Errorf("error opening upstream clone for delta computation: %v", err)
 		}
 		delta, err := computeUpstreamDelta(upstreamRepo, prevHash, commitHash, gitSporkConfig, upstream.Subpath)
 		if err != nil {
-			return fmt.Errorf("error computing upstream delta: %v", err)
+			return IntegratedUpstream{}, fmt.Errorf("error computing upstream delta: %v", err)
 		}
 		if err := applyUpstreamDelta(delta, opts.DownstreamRepoPath, opts.Logger); err != nil {
-			return fmt.Errorf("error applying upstream delta to downstream: %v", err)
+			return IntegratedUpstream{}, fmt.Errorf("error applying upstream delta to downstream: %v", err)
 		}
 	}
 
 	if err := integrate(gitSporkConfig, upstreamRootPath, opts.DownstreamRepoPath, opts.ForceRePrompt, opts.ForDriftCheck, opts.Logger); err != nil {
-		return err
+		return IntegratedUpstream{}, err
 	}
 
 	if !opts.ForDriftCheck {
 		state, err := loadDownstreamState(opts.DownstreamRepoPath)
 		if err != nil {
-			return fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
+			return IntegratedUpstream{}, fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
 		}
 		upsertUpstreamState(state, GitSporkUpstreamState{
 			URL:        originalUpstreamURL,
@@ -223,11 +227,15 @@ func integrateOne(opts *IntegrateOptions, upstream UpstreamSpec) error {
 			CommitHash: commitHash,
 		})
 		if err := saveDownstreamState(opts.DownstreamRepoPath, state); err != nil {
-			return fmt.Errorf("error saving upstream metadata to downstream state: %v", err)
+			return IntegratedUpstream{}, fmt.Errorf("error saving upstream metadata to downstream state: %v", err)
 		}
 	}
 
-	return nil
+	return IntegratedUpstream{
+		URL:        originalUpstreamURL,
+		Subpath:    upstream.Subpath,
+		CommitHash: commitHash,
+	}, nil
 }
 
 func integrate(gitSporkConfig *GitSporkConfig, upstreamPath string, downstreamPath string, forceRePrompt bool, forDriftCheck bool, logger *Logger) error {

--- a/internal/integrate_test.go
+++ b/internal/integrate_test.go
@@ -156,6 +156,35 @@ func Test_loadDownstreamState_migration(t *testing.T) {
 	assert.Equal(t, "", state.LastUpstreamRepoSubpath)
 }
 
+// testMinimalUpstream initialises a local upstream git repo with a minimal
+// .gitspork.yml (upstream_owned only, no templated block) and one file. Returns
+// the temp dir and the initial commit hash.
+func testMinimalUpstream(t *testing.T) (string, plumbing.Hash) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "upstream-owned"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "upstream-owned", "file.txt"), []byte("upstream content\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitspork.yml"), []byte("upstream_owned:\n- upstream-owned/**\n"), 0644))
+	hash := testCommitAll(t, repo, "initial")
+	return dir, hash
+}
+
+// testEmptyDownstream initialises a bare local downstream git repo ready for
+// Integrate to write into.
+func testEmptyDownstream(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	_, err := gogit.PlainInit(dir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+	return dir
+}
+
 // testCommitAll stages and commits all changes in repo, returning the commit hash.
 func testCommitAll(t *testing.T, repo *gogit.Repository, message string) plumbing.Hash {
 	t.Helper()
@@ -199,7 +228,7 @@ func TestIntegrate_honors_UpstreamRepoCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := NewLogger()
-	err = Integrate(&IntegrateOptions{
+	_, err = Integrate(&IntegrateOptions{
 		Logger:             logger,
 		UpstreamRepoURL:    "file://" + upstreamDir,
 		UpstreamRepoCommit: commitV1.String(),
@@ -212,4 +241,21 @@ func TestIntegrate_honors_UpstreamRepoCommit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "version one\n", string(content),
 		"Integrate with UpstreamRepoCommit set to v1 should produce v1 content, not HEAD (v2)")
+}
+
+func TestIntegrate_returns_result_with_upstream_url_and_hash(t *testing.T) {
+	upstreamDir, upstreamHash := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+
+	result, err := Integrate(&IntegrateOptions{
+		Logger:             NewLogger(),
+		Upstreams:          []UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, "file://"+upstreamDir, result.Upstreams[0].URL)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+	assert.Equal(t, "", result.Upstreams[0].Subpath)
 }

--- a/internal/integrate_test.go
+++ b/internal/integrate_test.go
@@ -259,3 +259,20 @@ func TestIntegrate_returns_result_with_upstream_url_and_hash(t *testing.T) {
 	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
 	assert.Equal(t, "", result.Upstreams[0].Subpath)
 }
+
+func TestIntegrateLocal_returns_result_with_upstream_paths(t *testing.T) {
+	upstreamDir, _ := testMinimalUpstream(t)
+	downstreamDir := testEmptyDownstream(t)
+
+	result, err := IntegrateLocal(&IntegrateLocalOptions{
+		Logger:         NewLogger(),
+		UpstreamPaths:  []string{upstreamDir},
+		DownstreamPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Upstreams, 1)
+	// IntegrateLocal has no URL — record the path in the URL slot with no scheme.
+	assert.Equal(t, upstreamDir, result.Upstreams[0].URL)
+	assert.Equal(t, "", result.Upstreams[0].CommitHash)
+}

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -1,9 +1,6 @@
 package internal
 
 import (
-	"bufio"
-	"fmt"
-	"io"
 	"log"
 	"os"
 	"strings"
@@ -32,30 +29,6 @@ func (l *Logger) Error(msg string, v ...any) {
 // Fatal will log an error message and use underlying log lib to exit w/ an error
 func (l *Logger) Fatal(msg string, v ...any) {
 	l.errorLogger.Fatalf(msg, v...)
-}
-
-// Diff reads a unified diff from r and writes it to stdout with color highlighting.
-// Addition lines (+) are green, removal lines (-) are red, hunk headers (@@) are cyan,
-// and file header lines (---, +++) are bold. All other lines are printed as-is.
-func (l *Logger) Diff(r io.Reader) error {
-	bold := color.New(color.Bold)
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		line := scanner.Text()
-		switch {
-		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
-			bold.Println(line)
-		case strings.HasPrefix(line, "@@"):
-			color.Cyan("%s\n", line)
-		case strings.HasPrefix(line, "+"):
-			color.Green("%s\n", line)
-		case strings.HasPrefix(line, "-"):
-			color.Red("%s\n", line)
-		default:
-			fmt.Println(line)
-		}
-	}
-	return scanner.Err()
 }
 
 // ColorizeYAML applies syntax highlighting to a YAML string using the go-yaml lexer


### PR DESCRIPTION
## Summary

- First of three phases toward exposing gitspork as a Go SDK (culminating in `github.com/rockholla/gitspork/v2` at Phase 3).
- Reshapes `Integrate`, `IntegrateLocal`, and `CheckDrift` to return structural result types (`*IntegrateResult`, `*DriftReport`) instead of only errors.
- Moves check-drift's user-facing structural output (no-drift line, drift summary, per-file attribution, verbose diffs) from `internal/` into the CLI layer; internal narration ("cloning upstream X...") stays on the Logger.
- Removes `CheckDriftOptions.Verbose` and `Logger.Diff(io.Reader)` — the CLI's `--verbose` flag now drives per-file `DriftedFile.Diff` iteration.
- Introduces `IntegratedUpstream` (URL/Subpath/CommitHash) and `DriftedFile` (Path/AttributedURL/Diff) types alongside the result envelopes.
- CLI behavior is preserved end-to-end — all functional tests pass unchanged.

Design spec: `docs/superpowers/specs/2026-07-03-golang-sdk-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-03-sdk-phase-1-structural-results.md`

## Follow-ups for Phase 3

Recorded in the spec's Phase 3 section: doc the `URL` field's local-path overload for `IntegrateLocal`, doc the non-nil-result invariant, add SDK-tier ordering test for multi-upstream `IntegrateResult`, restore colored `--verbose` diff output CLI-side (Phase 1 dropped the ANSI colorization; SDK output stays plain), honor `Logger == nil` as silent throughout (several `fmt.Println("")` sites and go-git's `Progress: os.Stdout` need routing), move `IntegrateOptions` internal-only fields to an unexported sibling before promotion, doc last-writer-wins attribution on `DriftReport`.

## Test plan

- [x] \`make test-unit\` passes
- [x] \`make test-functional\` passes
- [x] \`make test-functional-docker\` passes
- [x] \`make test-examples\` passes
- [ ] Manual sanity: \`gitspork check-drift\` and \`gitspork check-drift --verbose\` output looks the same as pre-refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)