### PR TITLE
SDK Phase 3: expose SDK at github.com/rockholla/gitspork/v2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@ How did you verify this works? Check off what applies.
 - [ ] `make test-functional` passes
 - [ ] `make test-functional-docker` passes
 - [ ] `make test-examples` passes
+- [ ] `make test-sdk` passes
 - [ ] Manual testing: <!-- describe steps -->
 
 ## Checklist

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 
 ## Module and key dependencies
 
-- Module: `github.com/rockholla/gitspork`
+- Module: `github.com/rockholla/gitspork/v2`
 - Go 1.26
 - `github.com/go-git/go-git/v6` — all git operations
 - `github.com/gobwas/glob` — glob pattern matching for file ownership rules
@@ -18,21 +18,23 @@
 ## Layout
 
 ```
-cmd/                    # Cobra subcommands (one file per command)
-internal/               # All business logic
-  gitspork.go           # Core types: GitSporkConfig, GitSporkDownstreamState, options structs
-  integrate.go          # Integrate and cloneUpstreamForIntegrate
-  integrate-local.go    # IntegrateLocal
-  check-drift.go        # CheckDrift
-  upstream-delta.go     # computeUpstreamDelta / applyUpstreamDelta
-  upstream-mv-rm.go     # UpstreamMv / UpstreamRm
-  integrator_*.go       # Per-ownership-type integration logic
-  logger.go             # Logger, Diff colorizer, ColorizeYAML
+gitspork.go             # Root SDK package: Integrate, IntegrateLocal, CheckDrift entry-points and re-exported type aliases
+doc.go                  # Package-level godoc for the root SDK
+cmd/
+  gitspork/             # main.go — CLI entry point
+internal/               # All business logic (unexported to SDK consumers)
+  cli/                  # Cobra subcommands (root, integrate, integrate-local, check-drift, mv, rm, init, schema)
+  config/               # GitSporkConfig types, YAML load/save, init scaffold, mv/rm config rewrite (UpstreamMv / UpstreamRm)
+  drift/                # CheckDrift orchestrator
+  integrate/            # Integrate, IntegrateLocal, IntegrateForDriftCheck, integrator_*.go per-ownership logic, upstream_delta.go (computeUpstreamDelta / applyUpstreamDelta)
+  logutil/              # Default Logger, diff colorizer, ColorizeYAML
+  sdktypes/             # Shared SDK types (options, results, errors, Logger interface) — reason: avoids import cycles between root gitspork, drift, and integrate packages
   input/                # Prompt and JSON input resolution
   testharness/          # Shared test helpers (non-test package, importable by all test packages)
 test/
   functional/           # Scenario tests against compiled binary or Docker image
   examples/             # Tests that run against the docs/examples/ upstream directories
+  sdk/                  # Black-box tests importing github.com/rockholla/gitspork/v2 as a library
 docs/
   examples/             # Four fully worked upstream examples (platform-team, open-source-template, standards-library, integrate-local)
   superpowers/          # Design specs and implementation plans (specs/ and plans/)
@@ -59,21 +61,23 @@ make test-unit              # go vet ./... && go test ./... (unit tests, no buil
 make test-functional        # -tags functional (compiles binary, runs against synthetic repos)
 make test-functional-docker # -tags functional_docker (same scenarios via Docker image)
 make test-examples          # -tags examples (runs against docs/examples/ upstream dirs)
+make test-sdk               # -tags sdk (black-box tests importing github.com/rockholla/gitspork/v2)
 ```
 
 **Build tags are important:**
 - `functional` — activates `test/functional/` tests using the native binary runner
 - `functional_docker` — activates the same test scenarios using `DockerRunner`
 - `examples` — activates `test/examples/`
+- `sdk` — activates `test/sdk/` (black-box library tests)
 - `harness_native.go` uses `//go:build functional && !functional_docker` to avoid gopls duplicate declaration errors when both tags are active
 
-**Shared test helpers** live in `internal/testharness/testharness.go` (no build tag). Both `test/functional/` and `test/examples/` import from there. `test/functional/harness.go` wraps them with thin delegating functions.
+**Shared test helpers** live in `internal/testharness/testharness.go` (no build tag). Both `test/functional/`, `test/examples/`, and `test/sdk/` import from there. `test/functional/harness.go` wraps them with thin delegating functions.
 
 ## CI
 
 - `main.yml` — triggered on push/PR to `main`; calls the reusable `tests.yml` workflow
 - `release.yml` — triggered on `v*` tag push; runs `tests.yml` then goreleaser
-- `tests.yml` — reusable workflow with four parallel jobs: unit, functional, functional-docker, examples
+- `tests.yml` — reusable workflow with five parallel jobs: unit, functional, functional-docker, examples, sdk
 - goreleaser builds multi-arch Linux + Darwin binaries, multi-arch Docker images, pushes a Homebrew formula to `rockholla/homebrew-gitspork`
 
 ## Releasing
@@ -84,12 +88,12 @@ Pre-release tags (e.g. `v1.2.3-rc.1`) can be pushed from any branch.
 
 ## Key design decisions worth knowing
 
-**Upstream delta propagation:** When `integrate` runs against a new upstream commit, `computeUpstreamDelta` diffs `prevHash..newHash` in the upstream repo and applies file deletions/renames to the downstream before the normal integration logic runs. Critically, it builds managed globs from the **previous commit's `.gitspork.yml`** (with fallback to new config), not the new one — this ensures files removed by `gitspork rm` (which strips them from config in the same commit) are still recognized as managed and propagated as deletions.
+**Upstream delta propagation:** When `integrate` runs against a new upstream commit, `computeUpstreamDelta` (in `internal/integrate/upstream_delta.go`) diffs `prevHash..newHash` in the upstream repo and applies file deletions/renames to the downstream before the normal integration logic runs. Critically, it builds managed globs from the **previous commit's `.gitspork.yml`** (with fallback to new config), not the new one — this ensures files removed by `gitspork rm` (which strips them from config in the same commit) are still recognized as managed and propagated as deletions.
 
-**Drift detection isolation:** `CheckDrift` copies the downstream to a temp dir, `git init`s it as a baseline, then re-runs `Integrate` at the stored upstream commit hash (`ForDriftCheck: true` skips delta propagation and state saving). A `git diff HEAD` on the temp dir reveals drift.
+**Drift detection isolation:** `CheckDrift` (in `internal/drift/check_drift.go`) copies the downstream to a temp dir, `git init`s it as a baseline, then re-runs the integrate pipeline at the stored upstream commit hash via `integrate.IntegrateForDriftCheck` (skips delta propagation and state saving). A `git diff HEAD` on the temp dir reveals drift.
 
-**URL rewriting:** `resolveUpstreamURL(url, token string)` in `integrate.go` silently rewrites SSH↔HTTPS based on `SSH_AUTH_SOCK` and token presence. The caller (`CheckDrift`) selects which URL to pass (override or stored); the function only handles the protocol rewrite.
+**URL rewriting:** `resolveUpstreamURL(url, token string)` in `internal/integrate/integrate.go` silently rewrites SSH↔HTTPS based on token presence: a token forces the HTTPS form; no token forces the SSH form. `CheckDrift` selects which URL to pass (override or stored) to `IntegrateForDriftCheck`; the function only handles the protocol rewrite.
 
-**State storage:** `.gitspork/downstream-state.json` in the downstream repo stores `last_upstream_repo_url`, `last_upstream_repo_subpath`, `last_upstream_commit_hash`, and `migrations_complete`. State is only written by `Integrate` (not `CheckDrift` and not `IntegrateLocal`).
+**State storage:** `.gitspork/downstream-state.json` in the downstream repo stores a `migrations_complete` list and an `upstreams` slice, where each entry has `url`, `subpath`, and `commit_hash`. The state schema also carries three deprecated fields (`last_upstream_repo_url`, `last_upstream_repo_subpath`, `last_upstream_commit_hash`) for backward compatibility — `LoadDownstreamState` auto-migrates them into the `upstreams` slice on first read and clears them on next save. State is only written by `Integrate` (not `CheckDrift` and not `IntegrateLocal`).
 
-**`ColorizeYAML`** in `internal/logger.go` uses `goccy/go-yaml`'s `lexer.Tokenize` + `printer.Printer` for token-accurate YAML highlighting — do not replace with regex-based approaches. Color is suppressed automatically when stdout is not a TTY (`color.NoColor`).
+**`ColorizeYAML`** in `internal/logutil/colorize.go` uses `goccy/go-yaml`'s `lexer.Tokenize` + `printer.Printer` for token-accurate YAML highlighting — do not replace with regex-based approaches. Color is suppressed automatically when stdout is not a TTY (`color.NoColor`).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,3 +49,14 @@ jobs:
         go-version-file: 'go.mod'
     - name: Examples Tests
       run: make test-examples
+
+  sdk-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+    - name: SDK Tests
+      run: make test-sdk

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ go.work.sum
 # Added by goreleaser init:
 dist/
 
+# go build default
+/gitspork
+
 # Git worktrees
 .worktrees/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,7 @@ before:
 
 builds:
   - id: linux
+    main: ./cmd/gitspork
     env:
       - CGO_ENABLED=0
     goos:
@@ -30,6 +31,7 @@ builds:
     ldflags:
       - -s -w -X main.version={{ .Tag }}
   - id: darwin
+    main: ./cmd/gitspork
     env:
       - CGO_ENABLED=0
     goos:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "gopls": {
-    "build.buildFlags": ["-tags=functional,functional_docker,examples"]
+    "build.buildFlags": ["-tags=functional,functional_docker,examples,sdk"]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Module and key dependencies
 
-- Module: `github.com/rockholla/gitspork`
+- Module: `github.com/rockholla/gitspork/v2`
 - Go 1.26
 - `github.com/go-git/go-git/v6` — all git operations
 - `github.com/gobwas/glob` — glob pattern matching for file ownership rules
@@ -18,21 +18,23 @@
 ## Layout
 
 ```
-cmd/                    # Cobra subcommands (one file per command)
-internal/               # All business logic
-  gitspork.go           # Core types: GitSporkConfig, GitSporkDownstreamState, options structs
-  integrate.go          # Integrate and cloneUpstreamForIntegrate
-  integrate-local.go    # IntegrateLocal
-  check-drift.go        # CheckDrift
-  upstream-delta.go     # computeUpstreamDelta / applyUpstreamDelta
-  upstream-mv-rm.go     # UpstreamMv / UpstreamRm
-  integrator_*.go       # Per-ownership-type integration logic
-  logger.go             # Logger, Diff colorizer, ColorizeYAML
+gitspork.go             # Root SDK package: Integrate, IntegrateLocal, CheckDrift entry-points and re-exported type aliases
+doc.go                  # Package-level godoc for the root SDK
+cmd/
+  gitspork/             # main.go — CLI entry point
+internal/               # All business logic (unexported to SDK consumers)
+  cli/                  # Cobra subcommands (root, integrate, integrate-local, check-drift, mv, rm, init, schema)
+  config/               # GitSporkConfig types, YAML load/save, init scaffold, mv/rm config rewrite (UpstreamMv / UpstreamRm)
+  drift/                # CheckDrift orchestrator
+  integrate/            # Integrate, IntegrateLocal, IntegrateForDriftCheck, integrator_*.go per-ownership logic, upstream_delta.go (computeUpstreamDelta / applyUpstreamDelta)
+  logutil/              # Default Logger, diff colorizer, ColorizeYAML
+  sdktypes/             # Shared SDK types (options, results, errors, Logger interface) — reason: avoids import cycles between root gitspork, drift, and integrate packages
   input/                # Prompt and JSON input resolution
   testharness/          # Shared test helpers (non-test package, importable by all test packages)
 test/
   functional/           # Scenario tests against compiled binary or Docker image
   examples/             # Tests that run against the docs/examples/ upstream directories
+  sdk/                  # Black-box tests importing github.com/rockholla/gitspork/v2 as a library
 docs/
   examples/             # Four fully worked upstream examples (platform-team, open-source-template, standards-library, integrate-local)
   superpowers/          # Design specs and implementation plans (specs/ and plans/)
@@ -84,12 +86,12 @@ Pre-release tags (e.g. `v1.2.3-rc.1`) can be pushed from any branch.
 
 ## Key design decisions worth knowing
 
-**Upstream delta propagation:** When `integrate` runs against a new upstream commit, `computeUpstreamDelta` diffs `prevHash..newHash` in the upstream repo and applies file deletions/renames to the downstream before the normal integration logic runs. Critically, it builds managed globs from the **previous commit's `.gitspork.yml`** (with fallback to new config), not the new one — this ensures files removed by `gitspork rm` (which strips them from config in the same commit) are still recognized as managed and propagated as deletions.
+**Upstream delta propagation:** When `integrate` runs against a new upstream commit, `computeUpstreamDelta` (in `internal/integrate/upstream_delta.go`) diffs `prevHash..newHash` in the upstream repo and applies file deletions/renames to the downstream before the normal integration logic runs. Critically, it builds managed globs from the **previous commit's `.gitspork.yml`** (with fallback to new config), not the new one — this ensures files removed by `gitspork rm` (which strips them from config in the same commit) are still recognized as managed and propagated as deletions.
 
-**Drift detection isolation:** `CheckDrift` copies the downstream to a temp dir, `git init`s it as a baseline, then re-runs `Integrate` at the stored upstream commit hash (`ForDriftCheck: true` skips delta propagation and state saving). A `git diff HEAD` on the temp dir reveals drift.
+**Drift detection isolation:** `CheckDrift` (in `internal/drift/check_drift.go`) copies the downstream to a temp dir, `git init`s it as a baseline, then re-runs the integrate pipeline at the stored upstream commit hash via `integrate.IntegrateForDriftCheck` (skips delta propagation and state saving). A `git diff HEAD` on the temp dir reveals drift.
 
-**URL rewriting:** `resolveUpstreamURL(url, token string)` in `integrate.go` silently rewrites SSH↔HTTPS based on `SSH_AUTH_SOCK` and token presence. The caller (`CheckDrift`) selects which URL to pass (override or stored); the function only handles the protocol rewrite.
+**URL rewriting:** `resolveUpstreamURL(url, token string)` in `internal/integrate/integrate.go` silently rewrites SSH↔HTTPS based on token presence: a token forces the HTTPS form; no token forces the SSH form. `CheckDrift` selects which URL to pass (override or stored) to `IntegrateForDriftCheck`; the function only handles the protocol rewrite.
 
 **State storage:** `.gitspork/downstream-state.json` in the downstream repo stores `last_upstream_repo_url`, `last_upstream_repo_subpath`, `last_upstream_commit_hash`, and `migrations_complete`. State is only written by `Integrate` (not `CheckDrift` and not `IntegrateLocal`).
 
-**`ColorizeYAML`** in `internal/logger.go` uses `goccy/go-yaml`'s `lexer.Tokenize` + `printer.Printer` for token-accurate YAML highlighting — do not replace with regex-based approaches. Color is suppressed automatically when stdout is not a TTY (`color.NoColor`).
+**`ColorizeYAML`** in `internal/logutil/colorize.go` uses `goccy/go-yaml`'s `lexer.Tokenize` + `printer.Printer` for token-accurate YAML highlighting — do not replace with regex-based approaches. Color is suppressed automatically when stdout is not a TTY (`color.NoColor`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,21 +61,23 @@ make test-unit              # go vet ./... && go test ./... (unit tests, no buil
 make test-functional        # -tags functional (compiles binary, runs against synthetic repos)
 make test-functional-docker # -tags functional_docker (same scenarios via Docker image)
 make test-examples          # -tags examples (runs against docs/examples/ upstream dirs)
+make test-sdk               # -tags sdk (black-box tests importing github.com/rockholla/gitspork/v2)
 ```
 
 **Build tags are important:**
 - `functional` — activates `test/functional/` tests using the native binary runner
 - `functional_docker` — activates the same test scenarios using `DockerRunner`
 - `examples` — activates `test/examples/`
+- `sdk` — activates `test/sdk/` (black-box library tests)
 - `harness_native.go` uses `//go:build functional && !functional_docker` to avoid gopls duplicate declaration errors when both tags are active
 
-**Shared test helpers** live in `internal/testharness/testharness.go` (no build tag). Both `test/functional/` and `test/examples/` import from there. `test/functional/harness.go` wraps them with thin delegating functions.
+**Shared test helpers** live in `internal/testharness/testharness.go` (no build tag). Both `test/functional/`, `test/examples/`, and `test/sdk/` import from there. `test/functional/harness.go` wraps them with thin delegating functions.
 
 ## CI
 
 - `main.yml` — triggered on push/PR to `main`; calls the reusable `tests.yml` workflow
 - `release.yml` — triggered on `v*` tag push; runs `tests.yml` then goreleaser
-- `tests.yml` — reusable workflow with four parallel jobs: unit, functional, functional-docker, examples
+- `tests.yml` — reusable workflow with five parallel jobs: unit, functional, functional-docker, examples, sdk
 - goreleaser builds multi-arch Linux + Darwin binaries, multi-arch Docker images, pushes a Homebrew formula to `rockholla/homebrew-gitspork`
 
 ## Releasing
@@ -92,6 +94,6 @@ Pre-release tags (e.g. `v1.2.3-rc.1`) can be pushed from any branch.
 
 **URL rewriting:** `resolveUpstreamURL(url, token string)` in `internal/integrate/integrate.go` silently rewrites SSH↔HTTPS based on token presence: a token forces the HTTPS form; no token forces the SSH form. `CheckDrift` selects which URL to pass (override or stored) to `IntegrateForDriftCheck`; the function only handles the protocol rewrite.
 
-**State storage:** `.gitspork/downstream-state.json` in the downstream repo stores `last_upstream_repo_url`, `last_upstream_repo_subpath`, `last_upstream_commit_hash`, and `migrations_complete`. State is only written by `Integrate` (not `CheckDrift` and not `IntegrateLocal`).
+**State storage:** `.gitspork/downstream-state.json` in the downstream repo stores a `migrations_complete` list and an `upstreams` slice, where each entry has `url`, `subpath`, and `commit_hash`. The state schema also carries three deprecated fields (`last_upstream_repo_url`, `last_upstream_repo_subpath`, `last_upstream_commit_hash`) for backward compatibility — `LoadDownstreamState` auto-migrates them into the `upstreams` slice on first read and clears them on next save. State is only written by `Integrate` (not `CheckDrift` and not `IntegrateLocal`).
 
 **`ColorizeYAML`** in `internal/logutil/colorize.go` uses `goccy/go-yaml`'s `lexer.Tokenize` + `printer.Printer` for token-accurate YAML highlighting — do not replace with regex-based approaches. Color is suppressed automatically when stdout is not a TTY (`color.NoColor`).

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: schema
 schema: ## Outputs the current working schema for the version of source
-	@go run main.go schema
+	@go run ./cmd/gitspork schema
 
 .PHONY: build
 build: ## Builds gitspork to dist/gitspork and builds Docker image tagged gitspork:local
 	@mkdir -p dist dist/.docker-build
-	@go build -o dist/gitspork .
-	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/.docker-build/gitspork .
+	@go build -o dist/gitspork ./cmd/gitspork
+	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/.docker-build/gitspork ./cmd/gitspork
 	@cp Dockerfile dist/.docker-build/Dockerfile
 	@docker build -t gitspork:local dist/.docker-build/
 	@rm -rf dist/.docker-build

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,16 @@ test-functional-docker: ## Run tests specific to testing the containerized versi
 test-examples: ## Run example scenario tests
 	@go test -tags examples -timeout 120s -v ./test/examples/...
 
+.PHONY: test-sdk
+test-sdk: ## Run black-box SDK tests
+	@go test -tags sdk -timeout 120s -v ./test/sdk/...
+
 .PHONY: test-security-gate
 test-security-gate: ## Run unit tests for the CI security gate script
 	@./test/security-gate/run-tests.sh
 
 .PHONY: test-all
-test-all: test-unit test-security-gate test-functional test-functional-docker ## Run all test suite types
+test-all: test-unit test-security-gate test-functional test-functional-docker test-sdk ## Run all test suite types
 
 # NOTE: recommended way to run all of this to support multi-arch image builds along w/ release artifacts through goreleaser:
 #   1. Default macOS Docker desktop

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Docker/container images are published for every release, and available at: https
 
 Download the appropriate binary from the [Github releases](https://github.com/rockholla/gitspork/releases), and install on your system's `PATH`.
 
+## Programmatic use (Go SDK)
+
+gitspork is also importable as a Go library:
+
+    go get github.com/rockholla/gitspork/v2
+
+```go
+import gitspork "github.com/rockholla/gitspork/v2"
+```
+
+See `pkg.go.dev/github.com/rockholla/gitspork/v2` for the API reference. The three top-level operations mirror the CLI: `Integrate`, `IntegrateLocal`, and `CheckDrift`. Each returns a structural result so orchestrators and CI drift bots can consume outcomes without parsing log output.
+
 ## Initialize a Repo as a `gitspork` Upstream
 
 ```

--- a/cmd/gitspork/main.go
+++ b/cmd/gitspork/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/rockholla/gitspork/internal/cli"
+import "github.com/rockholla/gitspork/v2/internal/cli"
 
 var (
 	version = "dev"

--- a/doc.go
+++ b/doc.go
@@ -8,10 +8,17 @@
 //
 // Example — check-drift bot:
 //
+//	import (
+//	    "errors"
+//	    "log"
+//
+//	    gitspork "github.com/rockholla/gitspork/v2"
+//	)
+//
 //	report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
 //	    DownstreamRepoPath: "/path/to/downstream",
 //	})
-//	if err != nil && err != gitspork.ErrDriftDetected {
+//	if err != nil && !errors.Is(err, gitspork.ErrDriftDetected) {
 //	    log.Fatal(err)
 //	}
 //	for _, f := range report.Files {

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,37 @@
+// Package gitspork exposes the top-level operations of the gitspork tool as a
+// Go library. See https://github.com/rockholla/gitspork for the full CLI
+// documentation.
+//
+// The three entry points are Integrate, IntegrateLocal, and CheckDrift. Each
+// returns a structural result alongside an error, so consumers can inspect
+// what was integrated or which files drifted without parsing log output.
+//
+// Example — check-drift bot:
+//
+//	report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+//	    DownstreamRepoPath: "/path/to/downstream",
+//	})
+//	if err != nil && err != gitspork.ErrDriftDetected {
+//	    log.Fatal(err)
+//	}
+//	for _, f := range report.Files {
+//	    log.Printf("drifted: %s (attributed to %s)", f.Path, f.AttributedURL)
+//	}
+//
+// Example — fleet integrator:
+//
+//	for _, downstream := range downstreamDirs {
+//	    result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+//	        Upstreams: []gitspork.UpstreamSpec{{
+//	            URL:     "git@github.com:org/platform.git",
+//	            Version: "v1.2.0",
+//	        }},
+//	        DownstreamRepoPath: downstream,
+//	    })
+//	    if err != nil {
+//	        log.Printf("failed on %s: %v", downstream, err)
+//	        continue
+//	    }
+//	    log.Printf("%s: integrated %d upstream(s)", downstream, len(result.Upstreams))
+//	}
+package gitspork

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,3 +131,35 @@ gitspork integrate \
 ```
 
 Valid `--upstream` keys are `url` (required), `version`, `subpath`, and `token`. All upstreams are recorded in downstream state and re-checked on `check-drift`, which reports drift per file attributed to whichever upstream last wrote it. `integrate-local` uses `--upstream-path` (also repeatable) with the same precedence semantics.
+
+## Using gitspork as a Go SDK
+
+The three top-level operations are exposed as a Go library at `github.com/rockholla/gitspork/v2`. Add it to your Go module:
+
+    go get github.com/rockholla/gitspork/v2
+
+Import and call directly:
+
+```go
+package main
+
+import (
+    "log"
+
+    gitspork "github.com/rockholla/gitspork/v2"
+)
+
+func main() {
+    report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+        DownstreamRepoPath: "/path/to/downstream",
+    })
+    if err != nil && err != gitspork.ErrDriftDetected {
+        log.Fatal(err)
+    }
+    for _, f := range report.Files {
+        log.Printf("drifted: %s (attributed to %s)", f.Path, f.AttributedURL)
+    }
+}
+```
+
+The SDK returns structural data (`*DriftReport`, `*IntegrateResult`) so orchestrators and drift bots can consume outcomes programmatically. Pass `Logger: nil` on any Options struct to suppress internal progress output.

--- a/docs/README.md
+++ b/docs/README.md
@@ -144,6 +144,7 @@ Import and call directly:
 package main
 
 import (
+    "errors"
     "log"
 
     gitspork "github.com/rockholla/gitspork/v2"
@@ -153,7 +154,7 @@ func main() {
     report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
         DownstreamRepoPath: "/path/to/downstream",
     })
-    if err != nil && err != gitspork.ErrDriftDetected {
+    if err != nil && !errors.Is(err, gitspork.ErrDriftDetected) {
         log.Fatal(err)
     }
     for _, f := range report.Files {

--- a/docs/superpowers/plans/2026-07-05-sdk-phase-3-exposure.md
+++ b/docs/superpowers/plans/2026-07-05-sdk-phase-3-exposure.md
@@ -1,0 +1,1529 @@
+# SDK Phase 3: Expose the SDK as `github.com/rockholla/gitspork/v2` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the SDK-facing vocabulary from `internal/types/` up to a new `package gitspork` at the module root, bump the module path to `github.com/rockholla/gitspork/v2` (Go semantic import versioning for major v2+), relocate `main.go` under `cmd/gitspork/`, and add a black-box `test/sdk/` tier that imports the SDK as an external caller would.
+
+**Architecture:** Third and final phase of the SDK effort. Phases 1 and 2 reshaped return signatures and split `internal/` into subpackages, leaving `internal/types/` as the shared vocabulary parking spot. Phase 3 promotes that package to the module root as `package gitspork` and cleans up the exported surface (rename state types, hide internal-only options fields, add doc-comments/deprecation markers) so v2.0.0 ships a stable, documented SDK.
+
+**Tech Stack:** Go 1.26, existing dependencies unchanged. Module path changes from `github.com/rockholla/gitspork` to `github.com/rockholla/gitspork/v2` (SIV requirement).
+
+---
+
+## File Structure
+
+### Before (post-Phase-2 main)
+
+```
+├── main.go                          # package main; imports internal/cli
+├── go.mod                           # module github.com/rockholla/gitspork
+├── internal/
+│   ├── cli/
+│   ├── config/
+│   ├── drift/
+│   ├── input/
+│   ├── integrate/
+│   ├── logutil/
+│   ├── testharness/
+│   └── types/                       # will move to module root
+└── test/
+    ├── examples/
+    └── functional/
+```
+
+### After (Phase 3 target)
+
+```
+├── gitspork.go                      # package gitspork; Integrate, IntegrateLocal, CheckDrift thin coordinators
+├── options.go                       # package gitspork; Options structs, UpstreamSpec
+├── results.go                       # package gitspork; IntegrateResult, IntegratedUpstream, DriftReport, DriftedFile
+├── logger.go                        # package gitspork; Logger interface + NoopLogger
+├── errors.go                        # package gitspork; ErrDriftDetected sentinel
+├── state.go                         # package gitspork; DownstreamState, UpstreamState (moved from internal/types/state.go)
+├── doc.go                           # package gitspork; package-level docs + usage example
+├── go.mod                           # module github.com/rockholla/gitspork/v2
+├── cmd/
+│   └── gitspork/
+│       └── main.go                  # package main; the 6-line CLI entry
+├── internal/                        # unchanged directory layout minus types/
+│   ├── cli/
+│   ├── config/
+│   ├── drift/
+│   ├── input/
+│   ├── integrate/
+│   ├── logutil/
+│   └── testharness/
+└── test/
+    ├── examples/
+    ├── functional/                  # main_test.go build command updated
+    └── sdk/                         # new: black-box SDK tests
+```
+
+### API surface changes (public `package gitspork` after Phase 3)
+
+Compared to `internal/types/` today:
+
+| Change | Before | After | Rationale |
+|---|---|---|---|
+| Rename | `GitSporkDownstreamState` | `DownstreamState` | Avoid `gitspork.GitSporkDownstreamState` stutter |
+| Rename | `GitSporkUpstreamState` | `UpstreamState` | Same |
+| Remove | `IntegrateOptions.UpstreamRepoURL/Version/Subpath/Token` | (gone) | CLI reconstructs `Upstreams` from flags |
+| Remove | `IntegrateOptions.UpstreamRepoCommit`, `ForDriftCheck`, `PrevUpstreamCommitHash` | (gone) | Moved to `internal/integrate.IntegrateForDriftCheck` — internal wiring |
+| Remove | `IntegrateLocalOptions.UpstreamPath` | (gone) | CLI reconstructs `UpstreamPaths` from flags |
+| Keep | `IntegrateOptions.Upstreams`, `DownstreamRepoPath`, `ForceRePrompt`, `Logger` | (unchanged) | Public SDK surface |
+| Keep | `IntegrateLocalOptions.UpstreamPaths`, `DownstreamPath`, `ForceRePrompt`, `Logger` | (unchanged) | Public SDK surface |
+| Keep | `CheckDriftOptions.Upstreams`, `DownstreamRepoPath`, `Logger` | (unchanged) | Public SDK surface |
+| Keep | Everything in `Logger`, `NoopLogger`, `IntegrateResult`, `DriftReport`, `DriftedFile`, `UpstreamSpec`, `ErrDriftDetected` | (unchanged) | Already clean |
+
+---
+
+## Task 1: API prep — rename state types, add doc-comments and Deprecated markers
+
+**Goal:** Reduce diff noise in later tasks by doing pure-rename and doc-only edits while types still live in `internal/types/`. No behavior changes.
+
+**Files:**
+- Modify: `internal/types/state.go` (rename types, add doc comments)
+- Modify: `internal/types/options.go` (add Deprecated markers, add doc comments)
+- Modify: `internal/types/results.go` (add doc comments on non-nil invariant, last-writer-wins)
+- Modify: every file that references the two state types (there are ~15 across `internal/`, `test/functional/`, tests)
+
+- [ ] **Step 1: Rename `GitSporkDownstreamState` → `DownstreamState` in `internal/types/state.go`**
+
+Replace the entire file with:
+
+```go
+package types
+
+// DownstreamState is the on-disk state stored at
+// .gitspork/downstream-state.json in the downstream repo. It records each
+// integrated upstream so subsequent runs (integrate, check-drift) can locate
+// the previous commit hash and detect drift.
+type DownstreamState struct {
+	MigrationsComplete []string        `json:"migrations_complete"`
+	Upstreams          []UpstreamState `json:"upstreams,omitempty"`
+	// Deprecated: migrated to Upstreams on first load.
+	LastUpstreamRepoURL string `json:"last_upstream_repo_url,omitempty"`
+	// Deprecated: migrated to Upstreams on first load.
+	LastUpstreamRepoSubpath string `json:"last_upstream_repo_subpath,omitempty"`
+	// Deprecated: migrated to Upstreams on first load.
+	LastUpstreamCommitHash string `json:"last_upstream_commit_hash,omitempty"`
+}
+
+// UpstreamState records the last integration for a single upstream.
+type UpstreamState struct {
+	URL        string `json:"url"`
+	Subpath    string `json:"subpath,omitempty"`
+	CommitHash string `json:"commit_hash"`
+}
+```
+
+- [ ] **Step 2: Sweep-rename `GitSporkDownstreamState` → `DownstreamState` and `GitSporkUpstreamState` → `UpstreamState` across the repo**
+
+The two type names appear in these files (grep to double-check the current set before editing):
+
+```bash
+grep -rln "GitSporkDownstreamState\|GitSporkUpstreamState" --include="*.go" .
+```
+
+Expected locations (all in `internal/`):
+- `internal/config/config.go` and its test — the parsed state I/O uses these types
+- `internal/config/init.go` — writes a `DownstreamState{}` in some paths
+- `internal/integrate/integrate.go` — state I/O signatures + callers
+- `internal/integrate/integrate_test.go` — tests that construct state values
+- `internal/drift/check_drift.go` — reads state via `integrate.LoadDownstreamState`
+- `internal/drift/check_drift_test.go` — tests that construct state values (`saveDownstreamState`, etc.)
+
+For each file, replace `GitSporkDownstreamState` → `DownstreamState` and `GitSporkUpstreamState` → `UpstreamState`. The `types.` package prefix stays the same; only the type name changes.
+
+- [ ] **Step 3: Add doc-comment for non-nil invariant on `IntegrateResult` and `DriftReport`**
+
+In `internal/types/results.go`, replace the doc comments on `IntegrateResult` and `DriftReport` with:
+
+```go
+// IntegrateResult is the structural return value of Integrate and IntegrateLocal.
+// It records what was successfully integrated (in order); on partial failure
+// the successful upstreams so far are still present in this result alongside
+// the returned error.
+//
+// The returned *IntegrateResult is always non-nil — callers do not need to
+// nil-check before inspecting Upstreams.
+type IntegrateResult struct {
+	Upstreams []IntegratedUpstream
+}
+```
+
+```go
+// DriftReport is the structural return value of CheckDrift. HasDrift is false
+// when the downstream matches the recorded integration state; true when
+// differences were found. Files enumerates the drifted entries with per-file
+// attribution to whichever upstream last wrote each path.
+//
+// When two upstreams write the same file, AttributedURL on the corresponding
+// DriftedFile records the last-writing upstream — matching the last-writer-wins
+// semantics of multi-upstream integrate.
+//
+// The returned *DriftReport is always non-nil — callers do not need to
+// nil-check before inspecting HasDrift or Files.
+type DriftReport struct {
+	HasDrift bool
+	Files    []DriftedFile
+}
+```
+
+- [ ] **Step 4: Clarify local-path overload on `IntegratedUpstream.URL`**
+
+Also in `internal/types/results.go`, update the `IntegratedUpstream` doc comment:
+
+```go
+// IntegratedUpstream identifies a single successfully integrated upstream.
+// For Integrate, URL is the remote repo URL (SSH or HTTPS, whichever the
+// caller supplied). For IntegrateLocal, URL is the local filesystem path with
+// no scheme, and CommitHash is empty (local paths have no commit-hash concept).
+type IntegratedUpstream struct {
+	URL        string
+	Subpath    string
+	CommitHash string
+}
+```
+
+- [ ] **Step 5: Add Deprecated markers on legacy single-upstream options fields**
+
+In `internal/types/options.go`, add `// Deprecated:` markers so `godoc`/`staticcheck` flag callers of the legacy fields:
+
+```go
+// IntegrateOptions configures a call to Integrate. Populate Upstreams (one
+// or more entries) for multi-upstream integration.
+type IntegrateOptions struct {
+	Upstreams          []UpstreamSpec
+	DownstreamRepoPath string
+	ForceRePrompt      bool
+	Logger             Logger
+	// Task 2 removes ForDriftCheck / PrevUpstreamCommitHash / UpstreamRepo* from
+	// this struct. Until then, they carry legacy-flag data from the CLI and
+	// drift-check re-integration wiring.
+	ForDriftCheck          bool
+	PrevUpstreamCommitHash string
+	// Deprecated: set Upstreams instead. The CLI accepts --upstream-repo-url
+	// for backward compatibility and translates internally.
+	UpstreamRepoURL string
+	// Deprecated: set Upstreams instead.
+	UpstreamRepoVersion string
+	// Deprecated: set Upstreams instead.
+	UpstreamRepoSubpath string
+	// Deprecated: set Upstreams instead.
+	UpstreamRepoToken string
+	// Deprecated: internal drift-check wiring only.
+	UpstreamRepoCommit string
+}
+
+// IntegrateLocalOptions configures a call to IntegrateLocal. Populate
+// UpstreamPaths (one or more entries) for multi-path integration.
+type IntegrateLocalOptions struct {
+	UpstreamPaths  []string
+	DownstreamPath string
+	ForceRePrompt  bool
+	Logger         Logger
+	// Deprecated: set UpstreamPaths instead. The CLI accepts a single
+	// --upstream-path for backward compatibility and translates internally.
+	UpstreamPath string
+}
+```
+
+- [ ] **Step 6: Build and test**
+
+```bash
+go build ./...
+make test-unit
+make test-functional
+```
+
+Expected: all PASS. Deprecation warnings (`★` markers in gopls / staticcheck) on the migration code paths that read the deprecated fields are expected — legitimate reads.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/types/state.go internal/types/options.go internal/types/results.go internal/config/ internal/integrate/ internal/drift/
+git commit -m "refactor: rename state types + document non-nil invariant + Deprecated markers"
+```
+
+---
+
+## Task 2: Move internal-only fields off public IntegrateOptions
+
+**Goal:** Move `ForDriftCheck`, `PrevUpstreamCommitHash`, `UpstreamRepoCommit`, and the legacy `UpstreamRepo*` fields off `IntegrateOptions` and `IntegrateLocalOptions.UpstreamPath` off `IntegrateLocalOptions`. The public options structs end at 4 fields each. The CLI reconstructs `Upstreams`/`UpstreamPaths` from its old-style flags. Drift uses a new `internal/integrate.IntegrateForDriftCheck` function.
+
+**Files:**
+- Modify: `internal/types/options.go` (delete internal/deprecated fields)
+- Create: `internal/integrate/drift_check.go` (new `IntegrateForDriftCheck` function)
+- Modify: `internal/integrate/integrate.go` (remove legacy-field synthesis + ForDriftCheck branching; extract shared body used by both `Integrate` and `IntegrateForDriftCheck`)
+- Modify: `internal/integrate/integrate_local.go` (remove `UpstreamPath` legacy synthesis)
+- Modify: `internal/drift/check_drift.go` (call `integrate.IntegrateForDriftCheck` instead of `integrate.Integrate` with option flags)
+- Modify: `internal/cli/integrate.go` (reconstruct `Upstreams` from `--upstream-repo-url` etc. before calling `integrate.Integrate`)
+- Modify: `internal/cli/integrate_local.go` (accept multi `--upstream-path`; construct `UpstreamPaths` from flag)
+- Modify: `internal/integrate/integrate_test.go` (adapt any test that used legacy fields)
+
+- [ ] **Step 1: Add `IntegrateForDriftCheck` in `internal/integrate/drift_check.go`**
+
+```go
+package integrate
+
+import (
+	"fmt"
+
+	"github.com/rockholla/gitspork/internal/types"
+)
+
+// DriftCheckRequest is the internal request shape used by drift-check
+// re-integration. External SDK consumers should use Integrate; DriftCheckRequest
+// is a package-integrate contract intended only for internal/drift.
+type DriftCheckRequest struct {
+	Logger             types.Logger
+	DownstreamRepoPath string
+	UpstreamURL        string
+	UpstreamSubpath    string
+	UpstreamToken      string
+	UpstreamCommit     string
+}
+
+// IntegrateForDriftCheck runs a single-upstream integrate pinned to a specific
+// commit hash and skips the state write. It's used by internal/drift to
+// reconstruct the downstream at each recorded upstream's last-integrated
+// commit and then diff against HEAD.
+func IntegrateForDriftCheck(req *DriftCheckRequest) error {
+	if req.Logger == nil {
+		req.Logger = types.NoopLogger()
+	}
+	upstream := types.UpstreamSpec{
+		URL:     req.UpstreamURL,
+		Subpath: req.UpstreamSubpath,
+		Token:   req.UpstreamToken,
+	}
+	if _, err := integrateOneInternal(&internalRequest{
+		Logger:                 req.Logger,
+		DownstreamRepoPath:     req.DownstreamRepoPath,
+		forDriftCheck:          true,
+		upstreamCommit:         req.UpstreamCommit,
+	}, upstream); err != nil {
+		return fmt.Errorf("drift-check re-integration failed: %v", err)
+	}
+	return nil
+}
+```
+
+Where `internalRequest` (see Step 3) and `integrateOneInternal` (see Step 4) are unexported.
+
+- [ ] **Step 2: Introduce `internalRequest` struct in `internal/integrate/integrate.go`**
+
+At the top of `internal/integrate/integrate.go`, near the other type declarations, add:
+
+```go
+// internalRequest carries wiring needed by integrateOneInternal that is not
+// part of the public IntegrateOptions surface. It exists to keep the SDK's
+// IntegrateOptions minimal while still allowing drift-check to signal special
+// behavior.
+type internalRequest struct {
+	Logger                 types.Logger
+	DownstreamRepoPath     string
+	ForceRePrompt          bool
+	forDriftCheck          bool   // true = skip state write, skip delta
+	upstreamCommit         string // when forDriftCheck: the pinned commit
+	prevUpstreamCommitHash string // set by integrateOne between calls
+}
+```
+
+- [ ] **Step 3: Extract `integrateOneInternal` from current `integrateOne`**
+
+Refactor `integrateOne` in `internal/integrate/integrate.go`. The current function:
+
+```go
+func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (types.IntegratedUpstream, error) {
+	// ... uses opts.ForDriftCheck, opts.UpstreamRepoCommit, opts.PrevUpstreamCommitHash ...
+}
+```
+
+Becomes two functions. First, a thin wrapper that adapts the public `IntegrateOptions`:
+
+```go
+func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (types.IntegratedUpstream, error) {
+	return integrateOneInternal(&internalRequest{
+		Logger:                 opts.Logger,
+		DownstreamRepoPath:     opts.DownstreamRepoPath,
+		ForceRePrompt:          opts.ForceRePrompt,
+		forDriftCheck:          false, // public Integrate never sets this
+		upstreamCommit:         "",
+		prevUpstreamCommitHash: "",
+	}, upstream)
+}
+```
+
+Then `integrateOneInternal` — a paste of the current `integrateOne` body with every `opts.ForDriftCheck` → `req.forDriftCheck`, `opts.UpstreamRepoCommit` → `req.upstreamCommit`, `opts.PrevUpstreamCommitHash` → `req.prevUpstreamCommitHash`, `opts.Logger` → `req.Logger`, `opts.DownstreamRepoPath` → `req.DownstreamRepoPath`, `opts.ForceRePrompt` → `req.ForceRePrompt`:
+
+```go
+func integrateOneInternal(req *internalRequest, upstream types.UpstreamSpec) (types.IntegratedUpstream, error) {
+	// (body copied verbatim from current integrateOne, with the substitutions above)
+}
+```
+
+Note: the inner `singleOpts := &types.IntegrateOptions{...}` at ~line 175 also needs updating — it currently sets `ForDriftCheck: opts.ForDriftCheck`, `UpstreamRepoCommit: opts.UpstreamRepoCommit`, etc. Since we're removing those from `IntegrateOptions`, that pattern breaks. Instead, use a nested `internalRequest`:
+
+```go
+singleReq := &internalRequest{
+	Logger:                 req.Logger,
+	DownstreamRepoPath:     req.DownstreamRepoPath,
+	ForceRePrompt:          req.ForceRePrompt,
+	forDriftCheck:          req.forDriftCheck,
+	upstreamCommit:         req.upstreamCommit,
+	prevUpstreamCommitHash: prevHash,
+}
+```
+
+And update the recursive-ish `cloneUpstreamForIntegrate(cloneDir, singleReq)` call to accept `*internalRequest` instead of `*types.IntegrateOptions`.
+
+**This is the biggest edit in Task 2.** Read `integrateOne` end-to-end first, then apply the substitution mechanically. The function is ~85 lines currently; the internal version is the same length.
+
+- [ ] **Step 4: Update `cloneUpstreamForIntegrate` signature**
+
+`cloneUpstreamForIntegrate` currently takes `*types.IntegrateOptions`. Change to `*internalRequest`:
+
+```go
+func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest) (string, error) {
+	// (body updated: opts.* → req.*)
+}
+```
+
+Every field reference inside the function body: `opts.Logger` → `req.Logger`, `opts.UpstreamRepoURL` → (extract from upstream spec via req — see note below), etc.
+
+Note: `cloneUpstreamForIntegrate` also reads `opts.UpstreamRepoURL`, `opts.UpstreamRepoVersion`, `opts.UpstreamRepoSubpath`, `opts.UpstreamRepoToken` — those came from the legacy fields. Now these come from the `upstream types.UpstreamSpec` parameter, which is already passed to `integrateOneInternal`. Restructure so `cloneUpstreamForIntegrate` takes both `*internalRequest` AND the `types.UpstreamSpec` explicitly:
+
+```go
+func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest, upstream types.UpstreamSpec) (string, error) {
+	// use upstream.URL, upstream.Version, upstream.Subpath, upstream.Token here
+	// use req.Logger, req.upstreamCommit for the commit pin
+}
+```
+
+Update all callsites to pass both.
+
+- [ ] **Step 5: Remove legacy field synthesis + `Integrate` public shape**
+
+Now that `IntegrateOptions` no longer has `UpstreamRepoURL` etc., the "synthesize from legacy fields" block at the top of `Integrate` can go. `Integrate` becomes:
+
+```go
+// Integrate will ensure that the downstream at opts.DownstreamRepoPath is
+// integrated with each upstream in opts.Upstreams, in order.
+func Integrate(opts *types.IntegrateOptions) (*types.IntegrateResult, error) {
+	result := &types.IntegrateResult{}
+
+	if opts.Logger == nil {
+		opts.Logger = types.NoopLogger()
+	}
+
+	if opts.DownstreamRepoPath == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return result, fmt.Errorf("unable to get the present working directory: %v", err)
+		}
+		opts.DownstreamRepoPath = wd
+	} else {
+		abs, err := filepath.Abs(opts.DownstreamRepoPath)
+		if err != nil {
+			return result, fmt.Errorf("unable to determine local downstream repo path: %v", err)
+		}
+		opts.DownstreamRepoPath = abs
+	}
+
+	if len(opts.Upstreams) == 0 {
+		return result, fmt.Errorf("no upstream specified: set Upstreams on IntegrateOptions")
+	}
+
+	for _, upstream := range opts.Upstreams {
+		integrated, err := integrateOne(opts, upstream)
+		if err != nil {
+			return result, err
+		}
+		result.Upstreams = append(result.Upstreams, integrated)
+	}
+	return result, nil
+}
+```
+
+Delete `IntegrateOptions.ForDriftCheck`, `.PrevUpstreamCommitHash`, `.UpstreamRepoURL`, `.UpstreamRepoVersion`, `.UpstreamRepoSubpath`, `.UpstreamRepoToken`, `.UpstreamRepoCommit` from `internal/types/options.go`. The public `IntegrateOptions` is now 4 fields.
+
+- [ ] **Step 6: Same treatment for `IntegrateLocalOptions.UpstreamPath`**
+
+In `internal/types/options.go`, remove `UpstreamPath` from `IntegrateLocalOptions`. In `internal/integrate/integrate_local.go`, remove the `if len(opts.UpstreamPaths) == 0 && opts.UpstreamPath != ""` synthesis block.
+
+- [ ] **Step 7: Update `internal/drift/check_drift.go` to use `IntegrateForDriftCheck`**
+
+Currently:
+
+```go
+if _, err := integrate.Integrate(&types.IntegrateOptions{
+    Logger:              opts.Logger,
+    UpstreamRepoURL:     entry.spec.URL,
+    UpstreamRepoSubpath: entry.spec.Subpath,
+    UpstreamRepoToken:   entry.spec.Token,
+    UpstreamRepoCommit:  entry.commitHash,
+    DownstreamRepoPath:  opts.DownstreamRepoPath,
+    ForDriftCheck:       true,
+}); err != nil {
+    return report, fmt.Errorf("error running integration for drift check: %v", err)
+}
+```
+
+Replace with:
+
+```go
+if err := integrate.IntegrateForDriftCheck(&integrate.DriftCheckRequest{
+    Logger:             opts.Logger,
+    DownstreamRepoPath: opts.DownstreamRepoPath,
+    UpstreamURL:        entry.spec.URL,
+    UpstreamSubpath:    entry.spec.Subpath,
+    UpstreamToken:      entry.spec.Token,
+    UpstreamCommit:     entry.commitHash,
+}); err != nil {
+    return report, fmt.Errorf("error running integration for drift check: %v", err)
+}
+```
+
+- [ ] **Step 8: Update `internal/cli/integrate.go` — reconstruct Upstreams from CLI flags**
+
+Currently the CLI sets `opts.UpstreamRepoURL = upstreamRepoURL`, etc. Change to construct `Upstreams`:
+
+```go
+opts := &types.IntegrateOptions{
+    Logger:             logger,
+    DownstreamRepoPath: downstreamRepoPath,
+    ForceRePrompt:      forceRePrompt,
+}
+if upstreamRepoURL != "" && len(upstreamFlags) > 0 {
+    return fmt.Errorf("cannot mix --upstream with --upstream-repo-url/version/subpath/token flags")
+}
+if upstreamRepoURL != "" {
+    opts.Upstreams = []types.UpstreamSpec{{
+        URL:     upstreamRepoURL,
+        Version: upstreamRepoVersion,
+        Subpath: upstreamRepoSubpath,
+        Token:   upstreamRepoToken,
+    }}
+}
+for _, f := range upstreamFlags {
+    spec, err := ParseUpstreamFlag(f)
+    if err != nil {
+        return err
+    }
+    opts.Upstreams = append(opts.Upstreams, spec)
+}
+if _, err := integrate.Integrate(opts); err != nil {
+    return err
+}
+return nil
+```
+
+The current `cmd/integrate.go` has this exact logic partly — verify the actual state and adapt. The key change: `UpstreamRepoURL`/`Version`/`Subpath`/`Token` are used to build `Upstreams` at the CLI layer, not passed into `Integrate` as legacy fields.
+
+- [ ] **Step 9: Update `internal/cli/integrate_local.go` — reconstruct UpstreamPaths from CLI flag**
+
+Similar shape: the `--upstream-path` flag is already repeatable (`StringArrayVarP`), so the current CLI already provides a `[]string`. Just verify the CLI passes it directly to `opts.UpstreamPaths` without any legacy `opts.UpstreamPath = firstEntry` synthesis. Adjust if needed.
+
+- [ ] **Step 10: Update `internal/integrate/integrate_test.go` for removed fields**
+
+Any test that constructs `types.IntegrateOptions{UpstreamRepoURL: ...}` or `types.IntegrateOptions{ForDriftCheck: true}` needs updating:
+- Callsites that used legacy single-upstream form → construct `Upstreams []UpstreamSpec` instead
+- Callsites that used `ForDriftCheck: true` → replace with `integrate.IntegrateForDriftCheck(...)` if that's the intent, or drop entirely
+
+Specific case: `TestIntegrate_honors_UpstreamRepoCommit` at the top of the test file — this test relied on setting `UpstreamRepoCommit: commitV1.String()` and `ForDriftCheck: true` on IntegrateOptions. Rewrite as a call to `IntegrateForDriftCheck`:
+
+```go
+err = IntegrateForDriftCheck(&DriftCheckRequest{
+    Logger:             logutil.New(),
+    DownstreamRepoPath: downstreamDir,
+    UpstreamURL:        "file://" + upstreamDir,
+    UpstreamCommit:     commitV1.String(),
+})
+```
+
+- [ ] **Step 11: Build and test**
+
+```bash
+go build ./...
+make test-unit
+make test-functional
+make test-functional-docker
+make test-examples
+```
+
+Expected: all PASS. The public API surface for `IntegrateOptions`, `IntegrateLocalOptions` is now the 4-field / 4-field shape shown in the file structure section above.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add internal/types/options.go internal/integrate/ internal/drift/ internal/cli/
+git commit -m "refactor: hide integrate internal wiring behind IntegrateForDriftCheck; slim IntegrateOptions to 4 public fields"
+```
+
+---
+
+## Task 3: Honor `Logger == nil` as silent throughout
+
+**Goal:** Route the remaining stdout-bypass paths through the Logger interface so `Logger: nil` genuinely silences all output. Two categories:
+
+1. `fmt.Println("")` blank-line writes in `internal/integrate/integrate.go`
+2. go-git's clone `Progress: os.Stdout` in `cloneUpstreamForIntegrate`
+
+**Files:**
+- Modify: `internal/integrate/integrate.go` (replace bare `fmt.Println("")` with Logger.Log or delete)
+- Modify: `internal/integrate/integrate.go` (wrap clone `Progress` with a Logger-backed io.Writer)
+- Create: `internal/logutil/writer.go` — an `io.Writer` adapter over `types.Logger`
+
+- [ ] **Step 1: Create the writer adapter in `internal/logutil/writer.go`**
+
+```go
+package logutil
+
+import (
+	"strings"
+
+	"github.com/rockholla/gitspork/internal/types"
+)
+
+// LoggerWriter is an io.Writer that forwards each line written to it to a
+// types.Logger. Trailing newlines are trimmed since Logger implementations
+// handle line boundaries themselves.
+type LoggerWriter struct {
+	L types.Logger
+}
+
+// Write splits input on newlines and calls L.Log for each non-empty line.
+// If L is nil, Write is a no-op (bytes still accepted but discarded).
+func (w *LoggerWriter) Write(p []byte) (int, error) {
+	if w == nil || w.L == nil {
+		return len(p), nil
+	}
+	text := strings.TrimRight(string(p), "\n")
+	if text == "" {
+		return len(p), nil
+	}
+	for _, line := range strings.Split(text, "\n") {
+		w.L.Log("%s", line)
+	}
+	return len(p), nil
+}
+```
+
+- [ ] **Step 2: Replace bare `fmt.Println("")` calls in `internal/integrate/integrate.go`**
+
+Grep for the call sites:
+
+```bash
+grep -n 'fmt\.Println("")' internal/integrate/integrate.go
+```
+
+Each occurrence is a blank line between sections of progress output. Options per site:
+- **Preferred**: delete the blank line. Logger consumers can add their own spacing if desired; SDK-consumer stdout should not have gratuitous blank lines from library code.
+- **Alternative**: replace with `req.Logger.Log("")` — passes through Logger, silent when nil.
+
+Take the "delete" path unless a functional test depends on the blank line (grep the functional tests to confirm; expected: no dependency).
+
+- [ ] **Step 3: Wrap go-git clone `Progress` in a Logger-backed writer**
+
+Grep for the current `Progress:` reference:
+
+```bash
+grep -n "Progress:" internal/integrate/integrate.go
+```
+
+Currently likely:
+
+```go
+clone, err := git.PlainClone(cloneDir, false, &git.CloneOptions{
+    URL:      resolveUpstreamURL(req.upstreamRepoURL, req.upstreamRepoToken),
+    Progress: os.Stdout,
+    // ...
+})
+```
+
+Change `Progress: os.Stdout` to a Logger-backed writer:
+
+```go
+clone, err := git.PlainClone(cloneDir, false, &git.CloneOptions{
+    URL:      resolveUpstreamURL(upstream.URL, upstream.Token),
+    Progress: &logutil.LoggerWriter{L: req.Logger},
+    // ...
+})
+```
+
+Add `import "github.com/rockholla/gitspork/internal/logutil"` if not present. Note: creating a dependency edge `integrate → logutil`. This is fine — logutil already has no upward deps.
+
+- [ ] **Step 4: Remove `"os"` import if no longer used** in `internal/integrate/integrate.go`.
+
+- [ ] **Step 5: Build and test**
+
+```bash
+go build ./...
+make test-unit
+make test-functional
+make test-functional-docker
+make test-examples
+```
+
+Expected: all PASS. If any functional test asserts on blank-line output structure, adjust the assertion (blank lines are cosmetic).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/logutil/writer.go internal/integrate/integrate.go
+git commit -m "refactor: route go-git Progress and blank-line output through Logger interface"
+```
+
+---
+
+## Task 4: Promote `internal/types/` → `package gitspork` at module root; bump to `/v2`
+
+**Goal:** The pivot task. Move every file from `internal/types/` to the module root as `package gitspork`. Add thin coordinator entry-point functions (`Integrate`, `IntegrateLocal`, `CheckDrift`). Bump `go.mod` to `github.com/rockholla/gitspork/v2`. Rewrite every internal import to use the `/v2` path. Move `main.go` under `cmd/gitspork/`. Update build system.
+
+**Files:**
+- Move: 7 files from `internal/types/` to module root, package rename `types` → `gitspork`
+- Create: `gitspork.go` (public entry-point coordinators)
+- Create: `doc.go` (package-level documentation)
+- Move: `main.go` → `cmd/gitspork/main.go` (path only; still `package main`)
+- Modify: `go.mod` (module path bump)
+- Modify: every `.go` file that imports `github.com/rockholla/gitspork/...` (rewrite to `/v2` path)
+- Modify: `.goreleaser.yaml`, `Dockerfile`, `Makefile`, `test/functional/main_test.go` (build path bump)
+
+**Sequencing note:** This task is one atomic edit — intermediate steps will not compile. Do NOT run `go build` after individual steps; only Step 13 verifies the full end-state builds. In particular: as soon as any `package gitspork` file lives at the module root while `main.go` (`package main`) is still there, the root directory has two packages and Go rejects it. All steps land in a single commit.
+
+- [ ] **Step 1: Move `internal/types/` files to module root and rename package**
+
+```bash
+git mv internal/types/logger.go       logger.go
+git mv internal/types/options.go      options.go
+git mv internal/types/results.go      results.go
+git mv internal/types/state.go        state.go
+git mv internal/types/errors.go       errors.go
+git mv internal/types/noop_logger.go  noop_logger.go
+```
+
+- [ ] **Step 2: Change `package types` → `package gitspork` in each moved file**
+
+Edit each of the 6 moved files: replace `package types` at line 1 with `package gitspork`.
+
+- [ ] **Step 3: Delete the now-empty `internal/types/` directory**
+
+```bash
+rmdir internal/types 2>/dev/null || true
+```
+
+- [ ] **Step 4: Create `gitspork.go` — the public entry-point file**
+
+At the module root, new file `gitspork.go`:
+
+```go
+package gitspork
+
+import (
+	"github.com/rockholla/gitspork/v2/internal/drift"
+	"github.com/rockholla/gitspork/v2/internal/integrate"
+)
+
+// Integrate integrates one or more upstream repos into the downstream at
+// opts.DownstreamRepoPath. See IntegrateOptions for configuration. On partial
+// failure the returned *IntegrateResult still contains the upstreams that
+// were successfully integrated before the error.
+func Integrate(opts *IntegrateOptions) (*IntegrateResult, error) {
+	return integrate.Integrate(opts)
+}
+
+// IntegrateLocal integrates one or more local upstream paths into the
+// downstream at opts.DownstreamPath. Local integrations do not write to
+// downstream state.
+func IntegrateLocal(opts *IntegrateLocalOptions) (*IntegrateResult, error) {
+	return integrate.IntegrateLocal(opts)
+}
+
+// CheckDrift re-runs each recorded upstream's integration at its pinned
+// commit hash in an isolated copy of the downstream and reports any files
+// that differ from the current downstream HEAD. Returns a populated
+// *DriftReport alongside ErrDriftDetected when drift is found.
+func CheckDrift(opts *CheckDriftOptions) (*DriftReport, error) {
+	return drift.CheckDrift(opts)
+}
+```
+
+- [ ] **Step 5: Create `doc.go` — package-level documentation and example**
+
+```go
+// Package gitspork exposes the top-level operations of the gitspork tool as a
+// Go library. See https://github.com/rockholla/gitspork for the full CLI
+// documentation.
+//
+// The three entry points are Integrate, IntegrateLocal, and CheckDrift. Each
+// returns a structural result alongside an error, so consumers can inspect
+// what was integrated or which files drifted without parsing log output.
+//
+// Example — check-drift bot:
+//
+//	report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+//	    DownstreamRepoPath: "/path/to/downstream",
+//	})
+//	if err != nil && err != gitspork.ErrDriftDetected {
+//	    log.Fatal(err)
+//	}
+//	for _, f := range report.Files {
+//	    log.Printf("drifted: %s (attributed to %s)", f.Path, f.AttributedURL)
+//	}
+//
+// Example — fleet integrator:
+//
+//	for _, downstream := range downstreamDirs {
+//	    result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+//	        Upstreams: []gitspork.UpstreamSpec{{
+//	            URL:     "git@github.com:org/platform.git",
+//	            Version: "v1.2.0",
+//	        }},
+//	        DownstreamRepoPath: downstream,
+//	    })
+//	    if err != nil {
+//	        log.Printf("failed on %s: %v", downstream, err)
+//	        continue
+//	    }
+//	    log.Printf("%s: integrated %d upstream(s)", downstream, len(result.Upstreams))
+//	}
+package gitspork
+```
+
+- [ ] **Step 6: Update `go.mod` to `github.com/rockholla/gitspork/v2`**
+
+Edit `go.mod` line 1:
+
+```
+module github.com/rockholla/gitspork/v2
+```
+
+- [ ] **Step 7: Rewrite every internal import to use the `/v2` path**
+
+Every Go file that imports `github.com/rockholla/gitspork/...` needs `/v2` inserted. Grep the current set:
+
+```bash
+grep -rln "github.com/rockholla/gitspork" --include="*.go" .
+```
+
+Expected files (~30):
+- Everything in `internal/cli/`, `internal/config/`, `internal/drift/`, `internal/integrate/`, `internal/logutil/`
+- Everything in `test/functional/`, `test/examples/`
+- `main.go`
+
+For each file, replace:
+- `"github.com/rockholla/gitspork/internal/types"` → `"github.com/rockholla/gitspork/v2"` (types package promoted to module root)
+- `"github.com/rockholla/gitspork/internal/config"` → `"github.com/rockholla/gitspork/v2/internal/config"`
+- `"github.com/rockholla/gitspork/internal/integrate"` → `"github.com/rockholla/gitspork/v2/internal/integrate"`
+- `"github.com/rockholla/gitspork/internal/drift"` → `"github.com/rockholla/gitspork/v2/internal/drift"`
+- `"github.com/rockholla/gitspork/internal/logutil"` → `"github.com/rockholla/gitspork/v2/internal/logutil"`
+- `"github.com/rockholla/gitspork/internal/cli"` → `"github.com/rockholla/gitspork/v2/internal/cli"`
+- `"github.com/rockholla/gitspork/internal/input"` → `"github.com/rockholla/gitspork/v2/internal/input"`
+- `"github.com/rockholla/gitspork/internal/testharness"` → `"github.com/rockholla/gitspork/v2/internal/testharness"`
+
+**Important**: also update every `types.<Type>` reference to `gitspork.<Type>` — since types moved from `package types` to `package gitspork`. The import alias changes:
+- Was: `"github.com/rockholla/gitspork/internal/types"` → package `types` → `types.IntegrateOptions`
+- Now: `"github.com/rockholla/gitspork/v2"` → package `gitspork` → `gitspork.IntegrateOptions`
+
+Wide sweep. Use `sed` or a series of targeted `Edit` calls. Search:
+
+```bash
+grep -rn "types\." internal/ test/ | wc -l
+```
+
+to gauge scope. Do them file-by-file to avoid mistakes.
+
+- [ ] **Step 8: Move `main.go` → `cmd/gitspork/main.go`**
+
+```bash
+mkdir -p cmd/gitspork
+git mv main.go cmd/gitspork/main.go
+```
+
+Update the moved file's import path if needed (it currently imports `internal/cli` — this must become `github.com/rockholla/gitspork/v2/internal/cli` per Step 7). Verify:
+
+```go
+package main
+
+import "github.com/rockholla/gitspork/v2/internal/cli"
+
+var (
+	version = "dev"
+)
+
+func main() {
+	cli.Execute(version)
+}
+```
+
+- [ ] **Step 9: Update `.goreleaser.yaml` build entries**
+
+The two `builds:` entries (`- id: linux`, `- id: darwin`) currently rely on goreleaser's default (`go build .`). Add `main:` to each:
+
+```yaml
+builds:
+  - id: linux
+    main: ./cmd/gitspork
+    env:
+      - CGO_ENABLED=0
+    # ...
+  - id: darwin
+    main: ./cmd/gitspork
+    env:
+      - CGO_ENABLED=0
+    # ...
+```
+
+- [ ] **Step 10: Update `Makefile`**
+
+The current Makefile has:
+
+```makefile
+schema:
+	@go run main.go schema
+
+build:
+	@go build -o dist/gitspork .
+	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/.docker-build/gitspork .
+```
+
+Change to:
+
+```makefile
+schema:
+	@go run ./cmd/gitspork schema
+
+build:
+	@go build -o dist/gitspork ./cmd/gitspork
+	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/.docker-build/gitspork ./cmd/gitspork
+```
+
+- [ ] **Step 11: Update `test/functional/main_test.go`**
+
+The `buildBinary` and `buildDockerImageForTests` functions build with `go build ... .`. Update the build target from `.` to `./cmd/gitspork`:
+
+```go
+// In buildBinary:
+cmd := exec.Command("go", "build", "-o", out, "./cmd/gitspork")
+
+// In buildDockerImageForTests:
+buildCmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/gitspork")
+```
+
+- [ ] **Step 12: Dockerfile check**
+
+The current `Dockerfile` (5 lines) doesn't build anything — it copies a pre-built `gitspork` binary. No changes needed.
+
+- [ ] **Step 13: Build and test all suites**
+
+```bash
+go build ./...
+go build ./cmd/gitspork
+make test-unit
+make test-functional
+make test-functional-docker
+make test-examples
+```
+
+Expected: all PASS. If a subpackage's import path is still stale, the build points directly at the file.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add go.mod gitspork.go doc.go options.go results.go state.go logger.go errors.go noop_logger.go cmd/gitspork/main.go internal/ test/ Makefile .goreleaser.yaml
+git commit -m "feat: promote SDK to package gitspork at module root; bump module path to /v2; relocate main.go under cmd/gitspork/"
+```
+
+---
+
+## Task 5: Add `test/sdk/` black-box test tier
+
+**Goal:** New test suite that imports `github.com/rockholla/gitspork/v2` as an external caller would. Validates the public API from outside the module's internals.
+
+**Files:**
+- Create: `test/sdk/sdk_test.go` — test entry file
+- Create: `test/sdk/helpers_test.go` — helpers wrapping testharness
+- Modify: `Makefile` (add `test-sdk` target)
+
+- [ ] **Step 1: Add `make test-sdk` target to Makefile**
+
+After `test-examples`:
+
+```makefile
+.PHONY: test-sdk
+test-sdk: ## Run black-box SDK tests
+	@go test -tags sdk -timeout 120s -v ./test/sdk/...
+```
+
+Also add `test-sdk` to `test-all`:
+
+```makefile
+.PHONY: test-all
+test-all: test-unit test-security-gate test-functional test-functional-docker test-sdk
+```
+
+- [ ] **Step 2: Create `test/sdk/helpers_test.go`** — fixture helpers using testharness
+
+```go
+//go:build sdk
+
+package sdk_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rockholla/gitspork/v2/internal/testharness"
+)
+
+// minimalUpstream builds a local upstream git repo with a minimal .gitspork.yml
+// (upstream_owned only) and one file. Returns the repo dir and its HEAD hash.
+func minimalUpstream(t *testing.T) (string, plumbing.Hash) {
+	t.Helper()
+	return testharness.MinimalUpstream(t)
+}
+
+// emptyDownstream returns a fresh non-bare local downstream git repo dir.
+func emptyDownstream(t *testing.T) string {
+	t.Helper()
+	return testharness.EmptyDownstream(t)
+}
+
+// writeAndCommit writes a file in downstreamDir and commits it, returning the
+// resulting commit hash.
+func writeAndCommit(t *testing.T, downstreamDir, relPath, content string) plumbing.Hash {
+	t.Helper()
+	full := filepath.Join(downstreamDir, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	repo, err := gogit.PlainOpen(downstreamDir)
+	require.NoError(t, err)
+	return testharness.CommitAllWithMessage(t, repo, "edit: "+relPath)
+}
+```
+
+Note: `package sdk_test` — external test package (import path ends in `_test`). This forces the file to import `github.com/rockholla/gitspork/v2` externally, mirroring what a real SDK consumer would do.
+
+- [ ] **Step 3: Create `test/sdk/sdk_test.go`** — the black-box tests
+
+```go
+//go:build sdk
+
+package sdk_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rockholla/gitspork/v2"
+)
+
+// integrate: single upstream returns a populated *IntegrateResult
+func TestIntegrate_singleUpstream(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, "file://"+upstreamDir, result.Upstreams[0].URL)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+// integrate: multi-upstream order is preserved in the result
+func TestIntegrate_multiUpstreamOrder(t *testing.T) {
+	upstreamA, hashA := minimalUpstream(t)
+	upstreamB, hashB := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams: []gitspork.UpstreamSpec{
+			{URL: "file://" + upstreamA, Version: "main"},
+			{URL: "file://" + upstreamB, Version: "main"},
+		},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Upstreams, 2)
+	assert.Equal(t, "file://"+upstreamA, result.Upstreams[0].URL)
+	assert.Equal(t, "file://"+upstreamB, result.Upstreams[1].URL)
+	assert.Equal(t, hashA.String(), result.Upstreams[0].CommitHash)
+	assert.Equal(t, hashB.String(), result.Upstreams[1].CommitHash)
+}
+
+// integrate-local: multi-path precedence; state file not written
+func TestIntegrateLocal_multiPath_noStateFile(t *testing.T) {
+	upstreamA, _ := minimalUpstream(t)
+	upstreamB, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.IntegrateLocal(&gitspork.IntegrateLocalOptions{
+		UpstreamPaths:  []string{upstreamA, upstreamB},
+		DownstreamPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Upstreams, 2)
+
+	// State file must NOT be written for IntegrateLocal.
+	_, err = os_Stat_helper(downstreamDir, ".gitspork", "downstream-state.json")
+	assert.True(t, err != nil, "expected no state file after IntegrateLocal, got err=%v", err)
+}
+
+// check-drift: no drift returns HasDrift=false and nil error
+func TestCheckDrift_noDrift(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+
+	// commit the integrated files so check-drift sees a clean tree
+	writeAndCommit(t, downstreamDir, ".gitspork/marker", "baseline")
+
+	report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.False(t, report.HasDrift)
+	assert.Empty(t, report.Files)
+}
+
+// check-drift: drift returns HasDrift=true, populated Files, ErrDriftDetected sentinel
+func TestCheckDrift_driftDetected_returnsErrSentinel(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	writeAndCommit(t, downstreamDir, ".gitspork/marker", "baseline")
+	writeAndCommit(t, downstreamDir, "upstream-owned/file.txt", "drifted content\n")
+
+	report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.True(t, errors.Is(err, gitspork.ErrDriftDetected), "expected ErrDriftDetected, got %v", err)
+	require.NotNil(t, report)
+	assert.True(t, report.HasDrift)
+	require.Len(t, report.Files, 1)
+	assert.Equal(t, "upstream-owned/file.txt", report.Files[0].Path)
+	assert.Equal(t, "file://"+upstreamDir, report.Files[0].AttributedURL)
+	assert.Contains(t, report.Files[0].Diff, "upstream-owned/file.txt", "per-file diff should reference the path")
+}
+
+// Logger contract: nil Logger means silent (no panic, no output)
+func TestLogger_nilIsSilent(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	// Pass Logger: nil explicitly.
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Logger:             nil,
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	// Passing nil should not panic and should complete without error.
+}
+
+// Logger contract: custom implementation receives the internal progress calls
+func TestLogger_customImplementation(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	captured := &captureLogger{}
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Logger:             captured,
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, captured.entries, "custom Logger should receive progress calls")
+}
+
+// Error path: no upstreams and no override → error
+func TestCheckDrift_noStateNoOverride_errors(t *testing.T) {
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gitspork integrate")
+}
+
+// Error path: override URL not in state → error names the URL
+func TestCheckDrift_overrideMissingState_errors(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	writeAndCommit(t, downstreamDir, ".gitspork/marker", "baseline")
+
+	bogus := "file:///tmp/gitspork-never-integrated-sdk-test"
+	_, err = gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+		Upstreams:          []gitspork.UpstreamSpec{{URL: bogus}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), bogus)
+}
+
+// captureLogger records the strings sent to it.
+type captureLogger struct {
+	entries []string
+}
+
+func (c *captureLogger) Log(msg string, args ...any)   { c.entries = append(c.entries, "log: "+msg) }
+func (c *captureLogger) Error(msg string, args ...any) { c.entries = append(c.entries, "err: "+msg) }
+```
+
+Note: `os_Stat_helper` is a placeholder for a small helper — see Step 4.
+
+- [ ] **Step 4: Add the `os_Stat_helper` helper to `test/sdk/helpers_test.go`**
+
+```go
+// os_Stat_helper checks whether a file exists relative to a base dir. Returns
+// nil if it exists, error otherwise.
+func os_Stat_helper(base string, parts ...string) (os.FileInfo, error) {
+	return os.Stat(filepath.Join(append([]string{base}, parts...)...))
+}
+```
+
+- [ ] **Step 5: Compile-time assertion that `logutil.Logger` satisfies the public Logger**
+
+Add a small compile-time test in `test/sdk/sdk_test.go` — but since `logutil` is in `internal/`, external test consumers can't import it. Skip this check here; it's already asserted inside `logutil/logger.go`.
+
+- [ ] **Step 6: Run the SDK tests**
+
+```bash
+make test-sdk
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Confirm no regression in other suites**
+
+```bash
+make test-unit
+make test-functional
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add test/sdk/ Makefile
+git commit -m "test: add black-box test/sdk/ tier importing github.com/rockholla/gitspork/v2"
+```
+
+---
+
+## Task 6: CLI polish — restore colored `--verbose` diff output
+
+**Goal:** In Phase 1, `Logger.Diff(io.Reader)` was removed and `--verbose` output became plain-text unified diff. This task restores ANSI colorization at the CLI layer (headers bold, hunks cyan, additions green, removals red) while keeping the SDK's `DriftedFile.Diff` field plain.
+
+**Files:**
+- Modify: `internal/cli/check_drift.go` — colorize per-file `Diff` when `verbose` is set and stdout is a TTY
+
+- [ ] **Step 1: Add a small colorizer helper in `internal/cli/check_drift.go`**
+
+Near the top of `internal/cli/check_drift.go`, add:
+
+```go
+import (
+	// existing imports…
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// colorizeUnifiedDiff applies ANSI colors to a unified diff string based on
+// per-line prefix: `diff --git` and `+++`/`---` headers bold, `@@` hunks cyan,
+// `+`/`-` change lines green/red. Falls through unchanged when color output
+// is disabled (non-TTY / NO_COLOR).
+func colorizeUnifiedDiff(diff string) string {
+	if color.NoColor {
+		return diff
+	}
+	var out strings.Builder
+	for _, line := range strings.Split(diff, "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git"), strings.HasPrefix(line, "--- "), strings.HasPrefix(line, "+++ "):
+			out.WriteString(color.New(color.Bold).Sprint(line))
+		case strings.HasPrefix(line, "@@"):
+			out.WriteString(color.CyanString(line))
+		case strings.HasPrefix(line, "+"):
+			out.WriteString(color.GreenString(line))
+		case strings.HasPrefix(line, "-"):
+			out.WriteString(color.RedString(line))
+		default:
+			out.WriteString(line)
+		}
+		out.WriteString("\n")
+	}
+	return out.String()
+}
+```
+
+- [ ] **Step 2: Call the colorizer in the verbose print loop**
+
+Find the verbose-print block in `internal/cli/check_drift.go` (currently prints `f.Diff` via `fmt.Print`):
+
+```go
+if verbose {
+	for _, f := range report.Files {
+		if f.Diff == "" {
+			continue
+		}
+		fmt.Print(f.Diff)
+	}
+}
+```
+
+Change to:
+
+```go
+if verbose {
+	for _, f := range report.Files {
+		if f.Diff == "" {
+			continue
+		}
+		fmt.Print(colorizeUnifiedDiff(f.Diff))
+	}
+}
+```
+
+- [ ] **Step 3: Build and test**
+
+```bash
+go build ./...
+make test-functional
+```
+
+Expected: PASS. The functional test `TestCheckDrift_drift_detected` at `test/functional/check_drift_test.go` asserts on the file-path substring, which colorized output still contains. No test assertion changes needed.
+
+- [ ] **Step 4: Manual sanity check**
+
+```bash
+go build -o /tmp/gitspork-phase3 ./cmd/gitspork
+# Set up an integrate + drift scenario, then:
+/tmp/gitspork-phase3 check-drift --downstream-repo-path <dir> --verbose | cat
+```
+
+Expected: with `| cat` (non-TTY), plain output. Without `| cat` (TTY), colored output with green additions, red removals, cyan hunks, bold headers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/check_drift.go
+git commit -m "feat: restore colored --verbose diff output in CLI (SDK output stays plain)"
+```
+
+---
+
+## Task 7: Documentation updates
+
+**Goal:** Update `CLAUDE.md`'s stale `resolveUpstreamURL` note, add the SDK availability announcement to README, and refresh `docs/README.md` with an SDK section.
+
+**Files:**
+- Modify: `CLAUDE.md` (fix stale resolveUpstreamURL description)
+- Modify: `README.md` (add SDK announcement)
+- Modify: `docs/README.md` (add SDK usage section)
+
+- [ ] **Step 1: Fix `CLAUDE.md` stale note about `resolveUpstreamURL`**
+
+Find the section that says `resolveUpstreamURL(url, token string)` "silently rewrites SSH↔HTTPS based on `SSH_AUTH_SOCK` and token presence". The `SSH_AUTH_SOCK` check does not exist in the current implementation — it's based on token presence only. Replace with:
+
+```markdown
+**URL rewriting:** `resolveUpstreamURL(url, token string)` in `internal/integrate/integrate.go` silently rewrites SSH↔HTTPS based on token presence: a token forces HTTPS rewrite; no token keeps SSH form (or, if given an HTTPS URL with no token, rewrites to SSH so key-auth flows). The caller (`CheckDrift`) selects which URL to pass (override or stored); the function only handles the protocol rewrite.
+```
+
+Also update any file-path references in `CLAUDE.md` that still say `internal/integrate.go` (should now be `internal/integrate/integrate.go`).
+
+- [ ] **Step 2: Add SDK announcement to root `README.md`**
+
+Under the "Getting Started" section (or a new "Programmatic Use" subsection at the top of the doc), add:
+
+```markdown
+## Programmatic use (Go SDK)
+
+gitspork is also importable as a Go library:
+
+```go
+import gitspork "github.com/rockholla/gitspork/v2"
+```
+
+See `pkg.go.dev/github.com/rockholla/gitspork/v2` for the API reference. The three top-level operations mirror the CLI: `Integrate`, `IntegrateLocal`, and `CheckDrift`. Each returns a structural result so orchestrators and CI drift bots can consume outcomes without parsing log output.
+```
+
+- [ ] **Step 3: Add SDK usage section to `docs/README.md`**
+
+After the "For Downstream Integrators" section, add:
+
+```markdown
+## Using gitspork as a Go SDK
+
+The three top-level operations are exposed as a Go library at `github.com/rockholla/gitspork/v2`. Add it to your Go module:
+
+```bash
+go get github.com/rockholla/gitspork/v2
+```
+
+Import and call as in the CLI:
+
+```go
+package main
+
+import (
+    "log"
+
+    gitspork "github.com/rockholla/gitspork/v2"
+)
+
+func main() {
+    report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+        DownstreamRepoPath: "/path/to/downstream",
+    })
+    if err != nil && err != gitspork.ErrDriftDetected {
+        log.Fatal(err)
+    }
+    for _, f := range report.Files {
+        log.Printf("drifted: %s (attributed to %s)", f.Path, f.AttributedURL)
+    }
+}
+```
+
+The SDK returns structural data (`*DriftReport`, `*IntegrateResult`) so orchestrators and drift bots can consume outcomes programmatically. Pass `Logger: nil` on any Options struct to suppress internal progress output.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md docs/README.md
+git commit -m "docs: announce Go SDK availability, fix stale resolveUpstreamURL note"
+```
+
+---
+
+## Task 8: Final verification and cleanup
+
+- [ ] **Step 1: Run every test suite**
+
+```bash
+make test-unit
+make test-functional
+make test-functional-docker
+make test-examples
+make test-sdk
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Grep for stale imports**
+
+```bash
+grep -rn "github.com/rockholla/gitspork\"" --include="*.go" .
+```
+
+Expected: no matches. Every import path in Go source ends with `/v2` or `/v2/internal/...`.
+
+```bash
+grep -rn "internal/types" --include="*.go" .
+```
+
+Expected: no matches. The `types` package no longer exists.
+
+- [ ] **Step 3: Confirm directory layout matches target**
+
+```bash
+ls
+```
+
+Expected top level: `cmd/`, `docs/`, `dist/`, `internal/`, `scripts/`, `test/`, `Dockerfile`, `Makefile`, `README.md`, `go.mod`, `go.sum`, plus the new `.go` files at root: `gitspork.go`, `options.go`, `results.go`, `state.go`, `logger.go`, `errors.go`, `noop_logger.go`, `doc.go`.
+
+Expected `internal/`: `cli/`, `config/`, `drift/`, `input/`, `integrate/`, `logutil/`, `testharness/`. Notably NO `types/`.
+
+Expected `cmd/`: only `gitspork/main.go`.
+
+- [ ] **Step 4: `go vet ./...` clean**
+
+```bash
+go vet ./...
+```
+
+- [ ] **Step 5: Manual sanity — SDK import from an external module**
+
+In a scratch dir outside this repo:
+
+```bash
+mkdir /tmp/gitspork-sdk-smoke && cd /tmp/gitspork-sdk-smoke
+cat > go.mod <<EOF
+module smoketest
+go 1.26
+require github.com/rockholla/gitspork/v2 v2.0.0
+EOF
+cat > main.go <<'EOF'
+package main
+import gitspork "github.com/rockholla/gitspork/v2"
+func main() {
+    _ = &gitspork.IntegrateOptions{}
+    _ = &gitspork.CheckDriftOptions{}
+}
+EOF
+go build .
+```
+
+Expected: build succeeds. Note: this requires the v2.0.0 tag to actually be published, so this smoke test happens post-merge/post-tag. Before tag, `go get` will pin to the branch's commit; use `replace github.com/rockholla/gitspork/v2 => /path/to/this/repo` in the scratch go.mod for local verification.
+
+- [ ] **Step 6: Manual CLI sanity**
+
+```bash
+go build -o /tmp/gitspork-phase3 ./cmd/gitspork
+/tmp/gitspork-phase3 --help
+/tmp/gitspork-phase3 schema
+```
+
+Expected: CLI works identically to pre-refactor.
+
+- [ ] **Step 7: Commit any final tweaks**
+
+If Steps 1–6 exposed missed spots, fix and commit as `fix: post-refactor cleanup for phase 3`.
+
+---
+
+## Backward Compatibility
+
+| Scenario | Behavior after v2.0.0 |
+|---|---|
+| Existing CLI invocations (all flags including backward-compat `--upstream-repo-url` etc.) | Identical output, exit codes, and filesystem effects. CLI internally reconstructs `Upstreams` from legacy flags. |
+| Existing downstream state files | Read and used unchanged; auto-migration of legacy single-upstream state fields continues to work. |
+| Third-party Go code that imported `github.com/rockholla/gitspork/internal/...` | Never supported — Go's `internal/` restriction prevented this. No breakage risk. |
+| Third-party Go code that will use the v2 SDK | Imports `github.com/rockholla/gitspork/v2` and calls the three exported entry points. Semver-stable from v2.0.0 forward. |
+| Third-party Go code that wants config parsing, mv/rm, init, or schema helpers | Not exposed in v2.0.0. Additive minor version if requested later. |
+| Old (v1.x) module path | Not automatically updated — v1 users must change their import path to `/v2` to pick up v2.0.0. Standard Go SIV behavior. |

--- a/gitspork.go
+++ b/gitspork.go
@@ -6,25 +6,75 @@ import (
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
-// Type aliases re-export the SDK types defined in internal/sdktypes so that
-// consumers see them as first-class members of package gitspork. The alias
-// pattern (rather than moving the definitions to the root package) is
-// required to avoid an import cycle: internal/integrate and internal/drift
-// need these types in their signatures, and this root package needs to call
-// into those subpackages to implement the coordinator entry-points below.
-type (
-	IntegrateOptions      = sdktypes.IntegrateOptions
-	IntegrateLocalOptions = sdktypes.IntegrateLocalOptions
-	CheckDriftOptions     = sdktypes.CheckDriftOptions
-	UpstreamSpec          = sdktypes.UpstreamSpec
-	IntegrateResult       = sdktypes.IntegrateResult
-	IntegratedUpstream    = sdktypes.IntegratedUpstream
-	DriftReport           = sdktypes.DriftReport
-	DriftedFile           = sdktypes.DriftedFile
-	DownstreamState       = sdktypes.DownstreamState
-	UpstreamState         = sdktypes.UpstreamState
-	Logger                = sdktypes.Logger
-)
+// The type aliases below re-export the SDK types defined in internal/sdktypes
+// so that consumers see them as first-class members of package gitspork. The
+// alias pattern (rather than moving the definitions to the root package)
+// avoids an import cycle: internal/integrate and internal/drift need these
+// types in their signatures, and this root package needs to call into those
+// subpackages to implement the coordinator entry-points below.
+
+// IntegrateOptions configures a call to Integrate. Populate Upstreams (one
+// or more entries) for multi-upstream integration.
+type IntegrateOptions = sdktypes.IntegrateOptions
+
+// IntegrateLocalOptions configures a call to IntegrateLocal. Populate
+// UpstreamPaths (one or more entries) for multi-path integration.
+type IntegrateLocalOptions = sdktypes.IntegrateLocalOptions
+
+// CheckDriftOptions configures a call to CheckDrift. Leave Upstreams empty
+// to use the recorded state; supply entries to override with different
+// URLs/tokens for the same recorded commit hashes.
+type CheckDriftOptions = sdktypes.CheckDriftOptions
+
+// UpstreamSpec identifies a single upstream to integrate from.
+type UpstreamSpec = sdktypes.UpstreamSpec
+
+// IntegrateResult is the structural return value of Integrate and IntegrateLocal.
+// It records what was successfully integrated (in order); on partial failure
+// the successful upstreams so far are still present in this result alongside
+// the returned error.
+//
+// The returned *IntegrateResult is always non-nil — callers do not need to
+// nil-check before inspecting Upstreams.
+type IntegrateResult = sdktypes.IntegrateResult
+
+// IntegratedUpstream identifies a single successfully integrated upstream.
+// For Integrate, URL is the remote repo URL (SSH or HTTPS, whichever the
+// caller supplied). For IntegrateLocal, URL is the local filesystem path with
+// no scheme, and CommitHash is empty (local paths have no commit-hash concept).
+type IntegratedUpstream = sdktypes.IntegratedUpstream
+
+// DriftReport is the structural return value of CheckDrift. HasDrift is false
+// when the downstream matches the recorded integration state; true when
+// differences were found. Files enumerates the drifted entries with per-file
+// attribution to whichever upstream last wrote each path.
+//
+// When two upstreams write the same file, AttributedURL on the corresponding
+// DriftedFile records the last-writing upstream — matching the last-writer-wins
+// semantics of multi-upstream integrate.
+//
+// The returned *DriftReport is always non-nil — callers do not need to
+// nil-check before inspecting HasDrift or Files.
+type DriftReport = sdktypes.DriftReport
+
+// DriftedFile is a single entry in a DriftReport.
+type DriftedFile = sdktypes.DriftedFile
+
+// DownstreamState is the on-disk state stored at
+// .gitspork/downstream-state.json in the downstream repo. It records each
+// integrated upstream so subsequent runs (integrate, check-drift) can locate
+// the previous commit hash and detect drift.
+type DownstreamState = sdktypes.DownstreamState
+
+// UpstreamState records the last integration for a single upstream.
+type UpstreamState = sdktypes.UpstreamState
+
+// Logger is the small interface gitspork uses for narration/progress and
+// error messages. It is deliberately narrow so SDK consumers can wire their
+// own logging (slog, zap, log/logr) with minimal glue. A nil Logger means
+// silent — implementations that accept Logger as a field MUST check for nil
+// before calling either method.
+type Logger = sdktypes.Logger
 
 // ErrDriftDetected is returned by CheckDrift when drift is present in the
 // downstream relative to its recorded upstream state.

--- a/gitspork.go
+++ b/gitspork.go
@@ -1,0 +1,59 @@
+package gitspork
+
+import (
+	"github.com/rockholla/gitspork/v2/internal/drift"
+	"github.com/rockholla/gitspork/v2/internal/integrate"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
+)
+
+// Type aliases re-export the SDK types defined in internal/sdktypes so that
+// consumers see them as first-class members of package gitspork. The alias
+// pattern (rather than moving the definitions to the root package) is
+// required to avoid an import cycle: internal/integrate and internal/drift
+// need these types in their signatures, and this root package needs to call
+// into those subpackages to implement the coordinator entry-points below.
+type (
+	IntegrateOptions      = sdktypes.IntegrateOptions
+	IntegrateLocalOptions = sdktypes.IntegrateLocalOptions
+	CheckDriftOptions     = sdktypes.CheckDriftOptions
+	UpstreamSpec          = sdktypes.UpstreamSpec
+	IntegrateResult       = sdktypes.IntegrateResult
+	IntegratedUpstream    = sdktypes.IntegratedUpstream
+	DriftReport           = sdktypes.DriftReport
+	DriftedFile           = sdktypes.DriftedFile
+	DownstreamState       = sdktypes.DownstreamState
+	UpstreamState         = sdktypes.UpstreamState
+	Logger                = sdktypes.Logger
+)
+
+// ErrDriftDetected is returned by CheckDrift when drift is present in the
+// downstream relative to its recorded upstream state.
+var ErrDriftDetected = sdktypes.ErrDriftDetected
+
+// NoopLogger returns a Logger implementation that discards all messages.
+// SDK consumers can pass this (or nil, which is treated equivalently by the
+// coordinator entry-points) to silence gitspork output.
+func NoopLogger() Logger { return sdktypes.NoopLogger() }
+
+// Integrate integrates one or more upstream repos into the downstream at
+// opts.DownstreamRepoPath. See IntegrateOptions for configuration. On partial
+// failure the returned *IntegrateResult still contains the upstreams that
+// were successfully integrated before the error.
+func Integrate(opts *IntegrateOptions) (*IntegrateResult, error) {
+	return integrate.Integrate(opts)
+}
+
+// IntegrateLocal integrates one or more local upstream paths into the
+// downstream at opts.DownstreamPath. Local integrations do not write to
+// downstream state.
+func IntegrateLocal(opts *IntegrateLocalOptions) (*IntegrateResult, error) {
+	return integrate.IntegrateLocal(opts)
+}
+
+// CheckDrift re-runs each recorded upstream's integration at its pinned
+// commit hash in an isolated copy of the downstream and reports any files
+// that differ from the current downstream HEAD. Returns a populated
+// *DriftReport alongside ErrDriftDetected when drift is found.
+func CheckDrift(opts *CheckDriftOptions) (*DriftReport, error) {
+	return drift.CheckDrift(opts)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rockholla/gitspork
+module github.com/rockholla/gitspork/v2
 
 go 1.26.0
 

--- a/internal/cli/check_drift.go
+++ b/internal/cli/check_drift.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -12,35 +11,6 @@ import (
 	"github.com/rockholla/gitspork/v2/internal/drift"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
-
-// colorizeUnifiedDiff applies ANSI colors to a unified-diff string based on
-// per-line prefix: `diff --git` and `+++`/`---` headers bold, `@@` hunks
-// cyan, `+`/`-` change lines green/red. Falls through unchanged when color
-// output is disabled (non-TTY / NO_COLOR).
-func colorizeUnifiedDiff(diff string) string {
-	if color.NoColor {
-		return diff
-	}
-	var out strings.Builder
-	for _, line := range strings.Split(diff, "\n") {
-		switch {
-		case strings.HasPrefix(line, "diff --git"),
-			strings.HasPrefix(line, "--- "),
-			strings.HasPrefix(line, "+++ "):
-			out.WriteString(color.New(color.Bold).Sprint(line))
-		case strings.HasPrefix(line, "@@"):
-			out.WriteString(color.CyanString(line))
-		case strings.HasPrefix(line, "+"):
-			out.WriteString(color.GreenString(line))
-		case strings.HasPrefix(line, "-"):
-			out.WriteString(color.RedString(line))
-		default:
-			out.WriteString(line)
-		}
-		out.WriteString("\n")
-	}
-	return out.String()
-}
 
 const (
 	checkDriftHelpShort string = "check if a downstream repo has drifted from its last integrated upstream state"
@@ -106,7 +76,11 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 					if f.Diff == "" {
 						continue
 					}
-					fmt.Print(colorizeUnifiedDiff(f.Diff))
+					if color.NoColor {
+						fmt.Print(f.Diff)
+					} else {
+						fmt.Print(f.ColorizedDiff)
+					}
 				}
 			}
 			os.Exit(2)

--- a/internal/cli/check_drift.go
+++ b/internal/cli/check_drift.go
@@ -4,12 +4,43 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/rockholla/gitspork/v2/internal/drift"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
+
+// colorizeUnifiedDiff applies ANSI colors to a unified-diff string based on
+// per-line prefix: `diff --git` and `+++`/`---` headers bold, `@@` hunks
+// cyan, `+`/`-` change lines green/red. Falls through unchanged when color
+// output is disabled (non-TTY / NO_COLOR).
+func colorizeUnifiedDiff(diff string) string {
+	if color.NoColor {
+		return diff
+	}
+	var out strings.Builder
+	for _, line := range strings.Split(diff, "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git"),
+			strings.HasPrefix(line, "--- "),
+			strings.HasPrefix(line, "+++ "):
+			out.WriteString(color.New(color.Bold).Sprint(line))
+		case strings.HasPrefix(line, "@@"):
+			out.WriteString(color.CyanString(line))
+		case strings.HasPrefix(line, "+"):
+			out.WriteString(color.GreenString(line))
+		case strings.HasPrefix(line, "-"):
+			out.WriteString(color.RedString(line))
+		default:
+			out.WriteString(line)
+		}
+		out.WriteString("\n")
+	}
+	return out.String()
+}
 
 const (
 	checkDriftHelpShort string = "check if a downstream repo has drifted from its last integrated upstream state"
@@ -75,7 +106,7 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 					if f.Diff == "" {
 						continue
 					}
-					fmt.Print(f.Diff)
+					fmt.Print(colorizeUnifiedDiff(f.Diff))
 				}
 			}
 			os.Exit(2)

--- a/internal/cli/check_drift.go
+++ b/internal/cli/check_drift.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rockholla/gitspork/internal/drift"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/drift"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 const (
@@ -43,7 +43,7 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := &types.CheckDriftOptions{
+			opts := &sdktypes.CheckDriftOptions{
 				Logger:             logger,
 				DownstreamRepoPath: downstreamRepoPath,
 			}
@@ -55,7 +55,7 @@ func (cds *CheckDriftSubcommand) GetCmd() *cobra.Command {
 				opts.Upstreams = append(opts.Upstreams, spec)
 			}
 			report, err := drift.CheckDrift(opts)
-			if err != nil && !errors.Is(err, types.ErrDriftDetected) {
+			if err != nil && !errors.Is(err, sdktypes.ErrDriftDetected) {
 				return err
 			}
 			if !report.HasDrift {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"fmt"
 
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/integrate.go
+++ b/internal/cli/integrate.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rockholla/gitspork/internal/integrate"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/integrate"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 const (
@@ -40,13 +40,13 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 				return fmt.Errorf("cannot mix --upstream with --upstream-repo-url/version/subpath/token flags")
 			}
 
-			opts := &types.IntegrateOptions{
+			opts := &sdktypes.IntegrateOptions{
 				Logger:             logger,
 				DownstreamRepoPath: downstreamRepoPath,
 				ForceRePrompt:      forceRePrompt,
 			}
 			if oldFlagsSet {
-				opts.Upstreams = []types.UpstreamSpec{{
+				opts.Upstreams = []sdktypes.UpstreamSpec{{
 					URL:     upstreamRepoURL,
 					Version: upstreamRepoVersion,
 					Subpath: upstreamRepoSubpath,

--- a/internal/cli/integrate.go
+++ b/internal/cli/integrate.go
@@ -41,13 +41,17 @@ func (isc *IntegrateSubcommand) GetCmd() *cobra.Command {
 			}
 
 			opts := &types.IntegrateOptions{
-				Logger:              logger,
-				UpstreamRepoURL:     upstreamRepoURL,
-				UpstreamRepoVersion: upstreamRepoVersion,
-				UpstreamRepoSubpath: upstreamRepoSubpath,
-				UpstreamRepoToken:   upstreamRepoToken,
-				DownstreamRepoPath:  downstreamRepoPath,
-				ForceRePrompt:       forceRePrompt,
+				Logger:             logger,
+				DownstreamRepoPath: downstreamRepoPath,
+				ForceRePrompt:      forceRePrompt,
+			}
+			if oldFlagsSet {
+				opts.Upstreams = []types.UpstreamSpec{{
+					URL:     upstreamRepoURL,
+					Version: upstreamRepoVersion,
+					Subpath: upstreamRepoSubpath,
+					Token:   upstreamRepoToken,
+				}}
 			}
 			for _, f := range upstreamFlags {
 				spec, err := ParseUpstreamFlag(f)

--- a/internal/cli/integrate_local.go
+++ b/internal/cli/integrate_local.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rockholla/gitspork/internal/integrate"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/integrate"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 const (
@@ -32,7 +32,7 @@ func (ilsc *IntegrateLocalSubcommand) GetCmd() *cobra.Command {
 		Short: integrateLocalHelpShort,
 		Long:  fmt.Sprintf("%s\n\n%s", integrateLocalHelpShort, integrateLocalHelpLong),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := integrate.IntegrateLocal(&types.IntegrateLocalOptions{
+			if _, err := integrate.IntegrateLocal(&sdktypes.IntegrateLocalOptions{
 				Logger:         logger,
 				UpstreamPaths:  upstreamPaths,
 				DownstreamPath: downstreamPath,

--- a/internal/cli/mv.go
+++ b/internal/cli/mv.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rockholla/gitspork/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/rockholla/gitspork/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/rockholla/gitspork/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"fmt"
 
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/upstream_flag.go
+++ b/internal/cli/upstream_flag.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // ParseUpstreamFlag parses a comma-separated key=value --upstream flag value.
 // Valid keys: url (required), version, subpath, token.
-func ParseUpstreamFlag(val string) (types.UpstreamSpec, error) {
-	spec := types.UpstreamSpec{}
+func ParseUpstreamFlag(val string) (sdktypes.UpstreamSpec, error) {
+	spec := sdktypes.UpstreamSpec{}
 	for _, part := range strings.Split(val, ",") {
 		kv := strings.SplitN(part, "=", 2)
 		if len(kv) != 2 {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 const (
@@ -13,11 +13,11 @@ const (
 )
 
 // Init will initialize a path for use as a gitspork upstream
-func Init(initPath string, logger types.Logger) error {
+func Init(initPath string, logger sdktypes.Logger) error {
 	var err error
 
 	if logger == nil {
-		logger = types.NoopLogger()
+		logger = sdktypes.NoopLogger()
 	}
 	logger.Log("initializing gitspork upstream at %s", initPath)
 	if initPath == "" {

--- a/internal/config/init_test.go
+++ b/internal/config/init_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/rockholla/gitspork/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/drift/check_drift.go
+++ b/internal/drift/check_drift.go
@@ -15,20 +15,20 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	fdiff "github.com/go-git/go-git/v6/plumbing/format/diff"
 	"github.com/go-git/go-git/v6/plumbing/object"
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/integrate"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/integrate"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 const driftCheckBranch = "_gitspork-check-drift"
 
 // CheckDrift detects whether the downstream has drifted from its last integrated upstream state
-func CheckDrift(opts *types.CheckDriftOptions) (*types.DriftReport, error) {
-	report := &types.DriftReport{}
+func CheckDrift(opts *sdktypes.CheckDriftOptions) (*sdktypes.DriftReport, error) {
+	report := &sdktypes.DriftReport{}
 	var err error
 
 	if opts.Logger == nil {
-		opts.Logger = types.NoopLogger()
+		opts.Logger = sdktypes.NoopLogger()
 	}
 
 	if opts.DownstreamRepoPath == "" {
@@ -50,7 +50,7 @@ func CheckDrift(opts *types.CheckDriftOptions) (*types.DriftReport, error) {
 
 	// Resolve which upstreams to check and their recorded commit hashes.
 	type upstreamCheckEntry struct {
-		spec       types.UpstreamSpec
+		spec       sdktypes.UpstreamSpec
 		commitHash string
 	}
 	var entries []upstreamCheckEntry
@@ -77,7 +77,7 @@ func CheckDrift(opts *types.CheckDriftOptions) (*types.DriftReport, error) {
 		}
 		for _, su := range state.Upstreams {
 			entries = append(entries, upstreamCheckEntry{
-				spec:       types.UpstreamSpec{URL: su.URL, Subpath: su.Subpath},
+				spec:       sdktypes.UpstreamSpec{URL: su.URL, Subpath: su.Subpath},
 				commitHash: su.CommitHash,
 			})
 		}
@@ -187,14 +187,14 @@ func CheckDrift(opts *types.CheckDriftOptions) (*types.DriftReport, error) {
 		if err != nil {
 			return report, fmt.Errorf("error encoding per-file diff for %s: %v", name, err)
 		}
-		report.Files = append(report.Files, types.DriftedFile{
+		report.Files = append(report.Files, sdktypes.DriftedFile{
 			Path:          name,
 			AttributedURL: fileOwner[name], // empty string means unattributed
 			Diff:          diffText,
 		})
 	}
 
-	return report, types.ErrDriftDetected
+	return report, sdktypes.ErrDriftDetected
 }
 
 // diffWorktreeAgainstHEAD stages all changes and compares against HEAD.

--- a/internal/drift/check_drift.go
+++ b/internal/drift/check_drift.go
@@ -134,14 +134,13 @@ func CheckDrift(opts *types.CheckDriftOptions) (*types.DriftReport, error) {
 			return report, fmt.Errorf("error listing worktree files before integrate: %v", err)
 		}
 
-		if _, err := integrate.Integrate(&types.IntegrateOptions{
-			Logger:              opts.Logger,
-			UpstreamRepoURL:     entry.spec.URL,
-			UpstreamRepoSubpath: entry.spec.Subpath,
-			UpstreamRepoToken:   entry.spec.Token,
-			UpstreamRepoCommit:  entry.commitHash,
-			DownstreamRepoPath:  opts.DownstreamRepoPath,
-			ForDriftCheck:       true,
+		if err := integrate.IntegrateForDriftCheck(&integrate.DriftCheckRequest{
+			Logger:             opts.Logger,
+			DownstreamRepoPath: opts.DownstreamRepoPath,
+			UpstreamURL:        entry.spec.URL,
+			UpstreamSubpath:    entry.spec.Subpath,
+			UpstreamToken:      entry.spec.Token,
+			UpstreamCommit:     entry.commitHash,
 		}); err != nil {
 			return report, fmt.Errorf("error running integration for drift check: %v", err)
 		}

--- a/internal/drift/check_drift.go
+++ b/internal/drift/check_drift.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/rockholla/gitspork/v2/internal/config"
 	"github.com/rockholla/gitspork/v2/internal/integrate"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
@@ -191,6 +192,7 @@ func CheckDrift(opts *sdktypes.CheckDriftOptions) (*sdktypes.DriftReport, error)
 			Path:          name,
 			AttributedURL: fileOwner[name], // empty string means unattributed
 			Diff:          diffText,
+			ColorizedDiff: logutil.ColorizeUnifiedDiff(diffText),
 		})
 	}
 

--- a/internal/drift/check_drift_test.go
+++ b/internal/drift/check_drift_test.go
@@ -40,7 +40,7 @@ func TestCheckDrift(t *testing.T) {
 		err = os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644)
 		require.NoError(t, err)
 
-		state := &types.GitSporkDownstreamState{
+		state := &types.DownstreamState{
 			LastUpstreamRepoURL:     "https://github.com/rockholla/gitspork.git",
 			LastUpstreamRepoSubpath: "docs/examples/simple/upstream",
 			LastUpstreamCommitHash:  "abc123",

--- a/internal/drift/check_drift_test.go
+++ b/internal/drift/check_drift_test.go
@@ -9,11 +9,11 @@ import (
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/integrate"
-	"github.com/rockholla/gitspork/internal/logutil"
-	"github.com/rockholla/gitspork/internal/testharness"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/integrate"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +24,7 @@ func TestCheckDrift(t *testing.T) {
 		require.NoError(t, err)
 		defer os.RemoveAll(dir)
 
-		_, err = CheckDrift(&types.CheckDriftOptions{
+		_, err = CheckDrift(&sdktypes.CheckDriftOptions{
 			Logger:             logutil.New(),
 			DownstreamRepoPath: dir,
 		})
@@ -40,14 +40,14 @@ func TestCheckDrift(t *testing.T) {
 		err = os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644)
 		require.NoError(t, err)
 
-		state := &types.DownstreamState{
+		state := &sdktypes.DownstreamState{
 			LastUpstreamRepoURL:     "https://github.com/rockholla/gitspork.git",
 			LastUpstreamRepoSubpath: "docs/examples/simple/upstream",
 			LastUpstreamCommitHash:  "abc123",
 		}
 		require.NoError(t, integrate.SaveDownstreamState(dir, state))
 
-		_, err = CheckDrift(&types.CheckDriftOptions{
+		_, err = CheckDrift(&sdktypes.CheckDriftOptions{
 			Logger:             logutil.New(),
 			DownstreamRepoPath: dir,
 		})
@@ -173,7 +173,7 @@ func TestCheckDrift_returns_report_no_drift(t *testing.T) {
 	downstreamDir := testharness.EmptyDownstream(t)
 	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
 
-	report, err := CheckDrift(&types.CheckDriftOptions{
+	report, err := CheckDrift(&sdktypes.CheckDriftOptions{
 		Logger:             logutil.New(),
 		DownstreamRepoPath: downstreamDir,
 	})
@@ -189,11 +189,11 @@ func TestCheckDrift_returns_report_with_drifted_file_and_attribution(t *testing.
 	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
 	testWriteAndCommitInDownstream(t, downstreamDir, "upstream-owned/file.txt", "drifted\n")
 
-	report, err := CheckDrift(&types.CheckDriftOptions{
+	report, err := CheckDrift(&sdktypes.CheckDriftOptions{
 		Logger:             logutil.New(),
 		DownstreamRepoPath: downstreamDir,
 	})
-	require.ErrorIs(t, err, types.ErrDriftDetected)
+	require.ErrorIs(t, err, sdktypes.ErrDriftDetected)
 	require.NotNil(t, report)
 	assert.True(t, report.HasDrift)
 	require.Len(t, report.Files, 1)
@@ -206,9 +206,9 @@ func TestCheckDrift_returns_report_with_drifted_file_and_attribution(t *testing.
 // CheckDrift can operate. Returns the post-integrate commit hash.
 func testIntegrateAndCommitBaseline(t *testing.T, upstreamDir, downstreamDir string) plumbing.Hash {
 	t.Helper()
-	_, err := integrate.Integrate(&types.IntegrateOptions{
+	_, err := integrate.Integrate(&sdktypes.IntegrateOptions{
 		Logger:             logutil.New(),
-		Upstreams:          []types.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		Upstreams:          []sdktypes.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
 		DownstreamRepoPath: downstreamDir,
 	})
 	require.NoError(t, err)
@@ -235,11 +235,11 @@ func TestCheckDrift_report_files_include_unified_diff(t *testing.T) {
 	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
 	testWriteAndCommitInDownstream(t, downstreamDir, "upstream-owned/file.txt", "drifted\n")
 
-	report, err := CheckDrift(&types.CheckDriftOptions{
+	report, err := CheckDrift(&sdktypes.CheckDriftOptions{
 		Logger:             logutil.New(),
 		DownstreamRepoPath: downstreamDir,
 	})
-	require.ErrorIs(t, err, types.ErrDriftDetected)
+	require.ErrorIs(t, err, sdktypes.ErrDriftDetected)
 	require.Len(t, report.Files, 1)
 	diff := report.Files[0].Diff
 	assert.Contains(t, diff, "upstream-owned/file.txt",

--- a/internal/integrate/drift_check.go
+++ b/internal/integrate/drift_check.go
@@ -3,14 +3,14 @@ package integrate
 import (
 	"fmt"
 
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // DriftCheckRequest is the internal request shape used by drift-check
 // re-integration. External SDK consumers should use Integrate; DriftCheckRequest
 // is a package-integrate contract intended only for internal/drift.
 type DriftCheckRequest struct {
-	Logger             types.Logger
+	Logger             sdktypes.Logger
 	DownstreamRepoPath string
 	UpstreamURL        string
 	UpstreamSubpath    string
@@ -24,9 +24,9 @@ type DriftCheckRequest struct {
 // commit and then diff against HEAD.
 func IntegrateForDriftCheck(req *DriftCheckRequest) error {
 	if req.Logger == nil {
-		req.Logger = types.NoopLogger()
+		req.Logger = sdktypes.NoopLogger()
 	}
-	upstream := types.UpstreamSpec{
+	upstream := sdktypes.UpstreamSpec{
 		URL:     req.UpstreamURL,
 		Subpath: req.UpstreamSubpath,
 		Token:   req.UpstreamToken,

--- a/internal/integrate/drift_check.go
+++ b/internal/integrate/drift_check.go
@@ -1,0 +1,44 @@
+package integrate
+
+import (
+	"fmt"
+
+	"github.com/rockholla/gitspork/internal/types"
+)
+
+// DriftCheckRequest is the internal request shape used by drift-check
+// re-integration. External SDK consumers should use Integrate; DriftCheckRequest
+// is a package-integrate contract intended only for internal/drift.
+type DriftCheckRequest struct {
+	Logger             types.Logger
+	DownstreamRepoPath string
+	UpstreamURL        string
+	UpstreamSubpath    string
+	UpstreamToken      string
+	UpstreamCommit     string
+}
+
+// IntegrateForDriftCheck runs a single-upstream integrate pinned to a specific
+// commit hash and skips the state write. It's used by internal/drift to
+// reconstruct the downstream at each recorded upstream's last-integrated
+// commit and then diff against HEAD.
+func IntegrateForDriftCheck(req *DriftCheckRequest) error {
+	if req.Logger == nil {
+		req.Logger = types.NoopLogger()
+	}
+	upstream := types.UpstreamSpec{
+		URL:     req.UpstreamURL,
+		Subpath: req.UpstreamSubpath,
+		Token:   req.UpstreamToken,
+	}
+	internalReq := &internalRequest{
+		Logger:             req.Logger,
+		DownstreamRepoPath: req.DownstreamRepoPath,
+		forDriftCheck:      true,
+		upstreamCommit:     req.UpstreamCommit,
+	}
+	if _, err := integrateOneInternal(internalReq, upstream); err != nil {
+		return fmt.Errorf("drift-check re-integration failed: %v", err)
+	}
+	return nil
+}

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gobwas/glob"
 	"github.com/goccy/go-yaml"
 	"github.com/rockholla/gitspork/internal/config"
+	"github.com/rockholla/gitspork/internal/logutil"
 	"github.com/rockholla/gitspork/internal/types"
 )
 
@@ -275,7 +276,6 @@ func integrate(gitSporkConfig *config.GitSporkConfig, upstreamPath string, downs
 	}
 
 	for _, preIntegrateMigration := range preIntegrateMigrations {
-		fmt.Println("")
 		logger.Log("%s", greenBold.Sprintf("running pre-integrate migration defined in upstream against the downstream: %s", preIntegrateMigration.ID))
 		if err := runMigration(preIntegrateMigration, upstreamPath, downstreamPath); err != nil {
 			return fmt.Errorf("error running pre-integrate migration against the downstream: %v", err)
@@ -287,44 +287,37 @@ func integrate(gitSporkConfig *config.GitSporkConfig, upstreamPath string, downs
 		}
 	}
 
-	fmt.Println("")
 	logger.Log("%s", greenBold.Sprint("integrating configured upstream-owned resources from upstream to downstream"))
 	if err := (&IntegratorUpstreamOwned{}).Integrate(gitSporkConfig.UpstreamOwned, upstreamPath, downstreamPath, logger); err != nil {
 		return fmt.Errorf("error integrating upstream-owned: %v", err)
 	}
 
-	fmt.Println("")
 	logger.Log("%s", greenBold.Sprint("integrating configured downstream-owned resources from upstream to downstream"))
 	if err := (&IntegratorDownstreamOwned{}).Integrate(gitSporkConfig.DownstreamOwned, upstreamPath, downstreamPath, logger); err != nil {
 		return fmt.Errorf("error integrating downstream-owned: %v", err)
 	}
 
-	fmt.Println("")
 	logger.Log("%s", greenBold.Sprint("integrating configured shared-ownership generic resources to merge b/w upstream and downstream"))
 	if err := (&IntegratorSharedOwnershipMerged{}).Integrate(gitSporkConfig.SharedOwnership.Merged, upstreamPath, downstreamPath, logger); err != nil {
 		return fmt.Errorf("error integrating shared-ownership.merged: %v", err)
 	}
 
-	fmt.Println("")
 	logger.Log("%s", greenBold.Sprint("integrating configured shared-ownership structured resources to merge, prefering upstream data"))
 	if err := (&IntegratorSharedOwnershipStructuredPreferUpstream{}).Integrate(gitSporkConfig.SharedOwnership.Structured.PreferUpstream, upstreamPath, downstreamPath, logger); err != nil {
 		return fmt.Errorf("error integrating shared-ownership.structured.prefer_upstream: %v", err)
 	}
 
-	fmt.Println("")
 	logger.Log("%s", greenBold.Sprint("integrating configured shared-ownership structured resources to merge, prefering downstream data"))
 	if err := (&IntegratorSharedOwnershipStructuredPreferDownstream{}).Integrate(gitSporkConfig.SharedOwnership.Structured.PreferDownstream, upstreamPath, downstreamPath, logger); err != nil {
 		return fmt.Errorf("error integrating shared-ownership.structured.prefer_downstream: %v", err)
 	}
 
-	fmt.Println("")
 	logger.Log("%s", greenBold.Sprint("integrating configured templated resources from upstream to downstream"))
 	if err := (&IntegratorTemplated{}).Integrate(gitSporkConfig.Templated, upstreamPath, downstreamPath, forceRePrompt, logger); err != nil {
 		return fmt.Errorf("error integrating templated: %v", err)
 	}
 
 	for _, postIntegrateMigration := range postIntegrateMigrations {
-		fmt.Println("")
 		logger.Log("%s", greenBold.Sprintf("running post-integrate migration defined in upstream against the downstream: %s", postIntegrateMigration.ID))
 		if err := runMigration(postIntegrateMigration, upstreamPath, downstreamPath); err != nil {
 			return fmt.Errorf("error running post-integrate migration against the downstream: %v", err)
@@ -336,7 +329,6 @@ func integrate(gitSporkConfig *config.GitSporkConfig, upstreamPath string, downs
 		}
 	}
 
-	fmt.Println("")
 	return nil
 }
 
@@ -404,7 +396,7 @@ func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest, upstream t
 	cloneOptions := &git.CloneOptions{
 		URL:          upstreamURL,
 		SingleBranch: true,
-		Progress:     os.Stdout,
+		Progress:     &logutil.LoggerWriter{L: req.Logger},
 	}
 	if authMethod != nil {
 		cloneOptions.Auth = authMethod

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -38,6 +38,19 @@ var (
 	reHTTPProto                            = regexp.MustCompile(`^https?://`)
 )
 
+// internalRequest carries wiring needed by integrateOneInternal that is not
+// part of the public IntegrateOptions surface. It exists to keep the SDK's
+// IntegrateOptions minimal while still allowing drift-check to signal special
+// behavior.
+type internalRequest struct {
+	Logger                 types.Logger
+	DownstreamRepoPath     string
+	ForceRePrompt          bool
+	forDriftCheck          bool   // true = skip state write, skip delta
+	upstreamCommit         string // when forDriftCheck: the pinned commit
+	prevUpstreamCommitHash string // set by integrateOne between calls
+}
+
 // Integrator is implemented by the ownership integrators that process a
 // homogeneous list of items into the downstream: T is OwnedEntry for the
 // upstream_owned/downstream_owned lists and string (glob pattern) for the
@@ -90,7 +103,6 @@ func UpsertUpstreamState(state *types.DownstreamState, entry types.UpstreamState
 // Integrate will ensure that the downstream at opts.DownstreamRepoPath is
 // integrated with each upstream in opts.Upstreams, in order.
 func Integrate(opts *types.IntegrateOptions) (*types.IntegrateResult, error) {
-	var err error
 	result := &types.IntegrateResult{}
 
 	if opts.Logger == nil {
@@ -98,28 +110,21 @@ func Integrate(opts *types.IntegrateOptions) (*types.IntegrateResult, error) {
 	}
 
 	if opts.DownstreamRepoPath == "" {
-		opts.DownstreamRepoPath, err = os.Getwd()
+		wd, err := os.Getwd()
 		if err != nil {
 			return result, fmt.Errorf("unable to get the present working directory: %v", err)
 		}
+		opts.DownstreamRepoPath = wd
 	} else {
-		opts.DownstreamRepoPath, err = filepath.Abs(opts.DownstreamRepoPath)
+		abs, err := filepath.Abs(opts.DownstreamRepoPath)
 		if err != nil {
 			return result, fmt.Errorf("unable to determine local downstream repo path: %v", err)
 		}
+		opts.DownstreamRepoPath = abs
 	}
 
-	// Normalize: synthesize Upstreams from single-upstream fields for backward compat.
-	if len(opts.Upstreams) == 0 && opts.UpstreamRepoURL != "" {
-		opts.Upstreams = []types.UpstreamSpec{{
-			URL:     opts.UpstreamRepoURL,
-			Version: opts.UpstreamRepoVersion,
-			Subpath: opts.UpstreamRepoSubpath,
-			Token:   opts.UpstreamRepoToken,
-		}}
-	}
 	if len(opts.Upstreams) == 0 {
-		return result, fmt.Errorf("no upstream specified: provide --upstream or --upstream-repo-url")
+		return result, fmt.Errorf("no upstream specified: set Upstreams on IntegrateOptions")
 	}
 
 	for _, upstream := range opts.Upstreams {
@@ -132,10 +137,26 @@ func Integrate(opts *types.IntegrateOptions) (*types.IntegrateResult, error) {
 	return result, nil
 }
 
+// integrateOne is the public-facing helper called from Integrate. It adapts
+// the public *types.IntegrateOptions into an internalRequest.
 func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (types.IntegratedUpstream, error) {
+	req := &internalRequest{
+		Logger:             opts.Logger,
+		DownstreamRepoPath: opts.DownstreamRepoPath,
+		ForceRePrompt:      opts.ForceRePrompt,
+		// forDriftCheck / upstreamCommit / prevUpstreamCommitHash stay zero-value:
+		// public Integrate never runs drift-check semantics.
+	}
+	return integrateOneInternal(req, upstream)
+}
+
+// integrateOneInternal is the shared body. It receives the internalRequest
+// carrying the drift-check flag and pinned commit hash, and is called from
+// both integrateOne (public path) and IntegrateForDriftCheck.
+func integrateOneInternal(req *internalRequest, upstream types.UpstreamSpec) (types.IntegratedUpstream, error) {
 	prevHash := ""
-	if !opts.ForDriftCheck {
-		existingState, err := LoadDownstreamState(opts.DownstreamRepoPath)
+	if !req.forDriftCheck {
+		existingState, err := LoadDownstreamState(req.DownstreamRepoPath)
 		if err != nil {
 			return types.IntegratedUpstream{}, fmt.Errorf("error loading downstream state for delta check: %v", err)
 		}
@@ -154,34 +175,30 @@ func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (ty
 	}
 	defer os.RemoveAll(cloneDir)
 
-	singleOpts := &types.IntegrateOptions{
-		Logger:                 opts.Logger,
-		UpstreamRepoURL:        upstream.URL,
-		UpstreamRepoVersion:    upstream.Version,
-		UpstreamRepoSubpath:    upstream.Subpath,
-		UpstreamRepoToken:      upstream.Token,
-		UpstreamRepoCommit:     opts.UpstreamRepoCommit,
-		DownstreamRepoPath:     opts.DownstreamRepoPath,
-		ForceRePrompt:          opts.ForceRePrompt,
-		ForDriftCheck:          opts.ForDriftCheck,
-		PrevUpstreamCommitHash: prevHash,
+	nestedReq := &internalRequest{
+		Logger:                 req.Logger,
+		DownstreamRepoPath:     req.DownstreamRepoPath,
+		ForceRePrompt:          req.ForceRePrompt,
+		forDriftCheck:          req.forDriftCheck,
+		upstreamCommit:         req.upstreamCommit,
+		prevUpstreamCommitHash: prevHash,
 	}
 
 	originalUpstreamURL := upstream.URL
-	opts.Logger.Log("cloning gitspork upstream repo %s", upstream.URL)
-	commitHash, err := cloneUpstreamForIntegrate(cloneDir, singleOpts)
+	req.Logger.Log("cloning gitspork upstream repo %s", upstream.URL)
+	commitHash, err := cloneUpstreamForIntegrate(cloneDir, nestedReq, upstream)
 	if err != nil {
 		return types.IntegratedUpstream{}, err
 	}
 
 	upstreamRootPath := filepath.Join(cloneDir, upstream.Subpath)
-	opts.Logger.Log("parsing the gitspork config file in the upstream repo clone at %s or %s", config.GitSporkConfigFileName, config.GitSporkConfigFileNameAlt)
+	req.Logger.Log("parsing the gitspork config file in the upstream repo clone at %s or %s", config.GitSporkConfigFileName, config.GitSporkConfigFileNameAlt)
 	gitSporkConfig, err := getGitSporkConfig(upstreamRootPath)
 	if err != nil {
 		return types.IntegratedUpstream{}, err
 	}
 
-	if !opts.ForDriftCheck && prevHash != "" {
+	if !req.forDriftCheck && prevHash != "" {
 		upstreamRepo, err := git.PlainOpen(cloneDir)
 		if err != nil {
 			return types.IntegratedUpstream{}, fmt.Errorf("error opening upstream clone for delta computation: %v", err)
@@ -190,17 +207,17 @@ func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (ty
 		if err != nil {
 			return types.IntegratedUpstream{}, fmt.Errorf("error computing upstream delta: %v", err)
 		}
-		if err := applyUpstreamDelta(delta, opts.DownstreamRepoPath, opts.Logger); err != nil {
+		if err := applyUpstreamDelta(delta, req.DownstreamRepoPath, req.Logger); err != nil {
 			return types.IntegratedUpstream{}, fmt.Errorf("error applying upstream delta to downstream: %v", err)
 		}
 	}
 
-	if err := integrate(gitSporkConfig, upstreamRootPath, opts.DownstreamRepoPath, opts.ForceRePrompt, opts.ForDriftCheck, opts.Logger); err != nil {
+	if err := integrate(gitSporkConfig, upstreamRootPath, req.DownstreamRepoPath, req.ForceRePrompt, req.forDriftCheck, req.Logger); err != nil {
 		return types.IntegratedUpstream{}, err
 	}
 
-	if !opts.ForDriftCheck {
-		state, err := LoadDownstreamState(opts.DownstreamRepoPath)
+	if !req.forDriftCheck {
+		state, err := LoadDownstreamState(req.DownstreamRepoPath)
 		if err != nil {
 			return types.IntegratedUpstream{}, fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
 		}
@@ -209,7 +226,7 @@ func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (ty
 			Subpath:    upstream.Subpath,
 			CommitHash: commitHash,
 		})
-		if err := SaveDownstreamState(opts.DownstreamRepoPath, state); err != nil {
+		if err := SaveDownstreamState(req.DownstreamRepoPath, state); err != nil {
 			return types.IntegratedUpstream{}, fmt.Errorf("error saving upstream metadata to downstream state: %v", err)
 		}
 	}
@@ -363,16 +380,16 @@ func resolveUpstreamURL(url string, token string) string {
 	return url
 }
 
-func cloneUpstreamForIntegrate(cloneDir string, opts *types.IntegrateOptions) (string, error) {
-	opts.UpstreamRepoURL = resolveUpstreamURL(opts.UpstreamRepoURL, opts.UpstreamRepoToken)
+func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest, upstream types.UpstreamSpec) (string, error) {
+	upstreamURL := resolveUpstreamURL(upstream.URL, upstream.Token)
 	var err error
 	var authMethod transport.AuthMethod
-	isHTTPsUpstreamURL, _ := regexp.MatchString("^https://.*$", opts.UpstreamRepoURL)
-	isSSHUpstreamURL, _ := regexp.MatchString("^git@", opts.UpstreamRepoURL)
-	if isHTTPsUpstreamURL && opts.UpstreamRepoToken != "" {
+	isHTTPsUpstreamURL, _ := regexp.MatchString("^https://.*$", upstreamURL)
+	isSSHUpstreamURL, _ := regexp.MatchString("^git@", upstreamURL)
+	if isHTTPsUpstreamURL && upstream.Token != "" {
 		authMethod = &http.BasicAuth{
 			Username: config.GitSpork,
-			Password: opts.UpstreamRepoToken,
+			Password: upstream.Token,
 		}
 	} else if isSSHUpstreamURL {
 		agentAuth, err := ssh.NewSSHAgentAuth(config.GitSSHUsername)
@@ -385,25 +402,25 @@ func cloneUpstreamForIntegrate(cloneDir string, opts *types.IntegrateOptions) (s
 		authMethod = agentAuth
 	}
 	cloneOptions := &git.CloneOptions{
-		URL:          opts.UpstreamRepoURL,
+		URL:          upstreamURL,
 		SingleBranch: true,
 		Progress:     os.Stdout,
 	}
 	if authMethod != nil {
 		cloneOptions.Auth = authMethod
 	}
-	if opts.UpstreamRepoVersion != "" {
-		refName := fmt.Sprintf("refs/heads/%s", opts.UpstreamRepoVersion)
-		isTag, err := regexp.MatchString("^tags\\/", opts.UpstreamRepoVersion)
+	if upstream.Version != "" {
+		refName := fmt.Sprintf("refs/heads/%s", upstream.Version)
+		isTag, err := regexp.MatchString("^tags\\/", upstream.Version)
 		if err != nil {
 			return "", fmt.Errorf("error processing upstream gitspork repo version to use: %v", err)
 		}
 		if isTag {
-			refName = fmt.Sprintf("refs/%s", opts.UpstreamRepoVersion)
+			refName = fmt.Sprintf("refs/%s", upstream.Version)
 		}
 		cloneOptions.ReferenceName = plumbing.ReferenceName(refName)
 	}
-	if opts.UpstreamRepoCommit != "" || opts.PrevUpstreamCommitHash != "" {
+	if req.upstreamCommit != "" || req.prevUpstreamCommitHash != "" {
 		// need full history to checkout a specific commit
 		cloneOptions.SingleBranch = false
 	}
@@ -411,17 +428,17 @@ func cloneUpstreamForIntegrate(cloneDir string, opts *types.IntegrateOptions) (s
 	if err != nil {
 		return "", fmt.Errorf("error cloning upstream gitspork repo: %v", err)
 	}
-	if opts.UpstreamRepoCommit != "" {
+	if req.upstreamCommit != "" {
 		worktree, err := repo.Worktree()
 		if err != nil {
 			return "", fmt.Errorf("error getting worktree for commit checkout: %v", err)
 		}
 		if err := worktree.Checkout(&git.CheckoutOptions{
-			Hash: plumbing.NewHash(opts.UpstreamRepoCommit),
+			Hash: plumbing.NewHash(req.upstreamCommit),
 		}); err != nil {
-			return "", fmt.Errorf("error checking out commit %s: %v", opts.UpstreamRepoCommit, err)
+			return "", fmt.Errorf("error checking out commit %s: %v", req.upstreamCommit, err)
 		}
-		return opts.UpstreamRepoCommit, nil
+		return req.upstreamCommit, nil
 	}
 	ref, err := repo.Head()
 	if err != nil {

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -18,9 +18,9 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	"github.com/gobwas/glob"
 	"github.com/goccy/go-yaml"
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/logutil"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 const (
@@ -44,7 +44,7 @@ var (
 // IntegrateOptions minimal while still allowing drift-check to signal special
 // behavior.
 type internalRequest struct {
-	Logger                 types.Logger
+	Logger                 sdktypes.Logger
 	DownstreamRepoPath     string
 	ForceRePrompt          bool
 	forDriftCheck          bool   // true = skip state write, skip delta
@@ -59,14 +59,14 @@ type internalRequest struct {
 // `var _ Integrator[T] = (*Type)(nil)` assertion, so a newly added integrator
 // that diverges from this contract fails to build.
 type Integrator[T any] interface {
-	Integrate(items []T, upstreamPath string, downstreamPath string, logger types.Logger) error
+	Integrate(items []T, upstreamPath string, downstreamPath string, logger sdktypes.Logger) error
 }
 
 // TemplatedIntegrator is kept separate from Integrator[T] because rendering
 // templates additionally needs the forceRePrompt flag to drive input
 // collection, so its Integrate signature cannot match the generic contract.
 type TemplatedIntegrator interface {
-	Integrate(instructions []config.GitSporkConfigTemplated, upstreamPath string, downstreamPath string, forceRePrompt bool, logger types.Logger) error
+	Integrate(instructions []config.GitSporkConfigTemplated, upstreamPath string, downstreamPath string, forceRePrompt bool, logger sdktypes.Logger) error
 }
 
 // NormalizeUpstreamURL returns a canonical key for an upstream URL+subpath pair
@@ -90,7 +90,7 @@ func NormalizeUpstreamURL(rawURL string, subpath string) string {
 
 // UpsertUpstreamState inserts entry into state.Upstreams, replacing any existing
 // entry whose URL+subpath normalises to the same key while preserving slice order.
-func UpsertUpstreamState(state *types.DownstreamState, entry types.UpstreamState) {
+func UpsertUpstreamState(state *sdktypes.DownstreamState, entry sdktypes.UpstreamState) {
 	key := NormalizeUpstreamURL(entry.URL, entry.Subpath)
 	for i, existing := range state.Upstreams {
 		if NormalizeUpstreamURL(existing.URL, existing.Subpath) == key {
@@ -103,11 +103,11 @@ func UpsertUpstreamState(state *types.DownstreamState, entry types.UpstreamState
 
 // Integrate will ensure that the downstream at opts.DownstreamRepoPath is
 // integrated with each upstream in opts.Upstreams, in order.
-func Integrate(opts *types.IntegrateOptions) (*types.IntegrateResult, error) {
-	result := &types.IntegrateResult{}
+func Integrate(opts *sdktypes.IntegrateOptions) (*sdktypes.IntegrateResult, error) {
+	result := &sdktypes.IntegrateResult{}
 
 	if opts.Logger == nil {
-		opts.Logger = types.NoopLogger()
+		opts.Logger = sdktypes.NoopLogger()
 	}
 
 	if opts.DownstreamRepoPath == "" {
@@ -139,8 +139,8 @@ func Integrate(opts *types.IntegrateOptions) (*types.IntegrateResult, error) {
 }
 
 // integrateOne is the public-facing helper called from Integrate. It adapts
-// the public *types.IntegrateOptions into an internalRequest.
-func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (types.IntegratedUpstream, error) {
+// the public *sdktypes.IntegrateOptions into an internalRequest.
+func integrateOne(opts *sdktypes.IntegrateOptions, upstream sdktypes.UpstreamSpec) (sdktypes.IntegratedUpstream, error) {
 	req := &internalRequest{
 		Logger:             opts.Logger,
 		DownstreamRepoPath: opts.DownstreamRepoPath,
@@ -154,12 +154,12 @@ func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (ty
 // integrateOneInternal is the shared body. It receives the internalRequest
 // carrying the drift-check flag and pinned commit hash, and is called from
 // both integrateOne (public path) and IntegrateForDriftCheck.
-func integrateOneInternal(req *internalRequest, upstream types.UpstreamSpec) (types.IntegratedUpstream, error) {
+func integrateOneInternal(req *internalRequest, upstream sdktypes.UpstreamSpec) (sdktypes.IntegratedUpstream, error) {
 	prevHash := ""
 	if !req.forDriftCheck {
 		existingState, err := LoadDownstreamState(req.DownstreamRepoPath)
 		if err != nil {
-			return types.IntegratedUpstream{}, fmt.Errorf("error loading downstream state for delta check: %v", err)
+			return sdktypes.IntegratedUpstream{}, fmt.Errorf("error loading downstream state for delta check: %v", err)
 		}
 		key := NormalizeUpstreamURL(upstream.URL, upstream.Subpath)
 		for _, u := range existingState.Upstreams {
@@ -172,7 +172,7 @@ func integrateOneInternal(req *internalRequest, upstream types.UpstreamSpec) (ty
 
 	cloneDir, err := os.MkdirTemp("", config.GitSpork)
 	if err != nil {
-		return types.IntegratedUpstream{}, fmt.Errorf("error creating temporary directory: %v", err)
+		return sdktypes.IntegratedUpstream{}, fmt.Errorf("error creating temporary directory: %v", err)
 	}
 	defer os.RemoveAll(cloneDir)
 
@@ -189,57 +189,57 @@ func integrateOneInternal(req *internalRequest, upstream types.UpstreamSpec) (ty
 	req.Logger.Log("cloning gitspork upstream repo %s", upstream.URL)
 	commitHash, err := cloneUpstreamForIntegrate(cloneDir, nestedReq, upstream)
 	if err != nil {
-		return types.IntegratedUpstream{}, err
+		return sdktypes.IntegratedUpstream{}, err
 	}
 
 	upstreamRootPath := filepath.Join(cloneDir, upstream.Subpath)
 	req.Logger.Log("parsing the gitspork config file in the upstream repo clone at %s or %s", config.GitSporkConfigFileName, config.GitSporkConfigFileNameAlt)
 	gitSporkConfig, err := getGitSporkConfig(upstreamRootPath)
 	if err != nil {
-		return types.IntegratedUpstream{}, err
+		return sdktypes.IntegratedUpstream{}, err
 	}
 
 	if !req.forDriftCheck && prevHash != "" {
 		upstreamRepo, err := git.PlainOpen(cloneDir)
 		if err != nil {
-			return types.IntegratedUpstream{}, fmt.Errorf("error opening upstream clone for delta computation: %v", err)
+			return sdktypes.IntegratedUpstream{}, fmt.Errorf("error opening upstream clone for delta computation: %v", err)
 		}
 		delta, err := computeUpstreamDelta(upstreamRepo, prevHash, commitHash, gitSporkConfig, upstream.Subpath)
 		if err != nil {
-			return types.IntegratedUpstream{}, fmt.Errorf("error computing upstream delta: %v", err)
+			return sdktypes.IntegratedUpstream{}, fmt.Errorf("error computing upstream delta: %v", err)
 		}
 		if err := applyUpstreamDelta(delta, req.DownstreamRepoPath, req.Logger); err != nil {
-			return types.IntegratedUpstream{}, fmt.Errorf("error applying upstream delta to downstream: %v", err)
+			return sdktypes.IntegratedUpstream{}, fmt.Errorf("error applying upstream delta to downstream: %v", err)
 		}
 	}
 
 	if err := integrate(gitSporkConfig, upstreamRootPath, req.DownstreamRepoPath, req.ForceRePrompt, req.forDriftCheck, req.Logger); err != nil {
-		return types.IntegratedUpstream{}, err
+		return sdktypes.IntegratedUpstream{}, err
 	}
 
 	if !req.forDriftCheck {
 		state, err := LoadDownstreamState(req.DownstreamRepoPath)
 		if err != nil {
-			return types.IntegratedUpstream{}, fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
+			return sdktypes.IntegratedUpstream{}, fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
 		}
-		UpsertUpstreamState(state, types.UpstreamState{
+		UpsertUpstreamState(state, sdktypes.UpstreamState{
 			URL:        originalUpstreamURL,
 			Subpath:    upstream.Subpath,
 			CommitHash: commitHash,
 		})
 		if err := SaveDownstreamState(req.DownstreamRepoPath, state); err != nil {
-			return types.IntegratedUpstream{}, fmt.Errorf("error saving upstream metadata to downstream state: %v", err)
+			return sdktypes.IntegratedUpstream{}, fmt.Errorf("error saving upstream metadata to downstream state: %v", err)
 		}
 	}
 
-	return types.IntegratedUpstream{
+	return sdktypes.IntegratedUpstream{
 		URL:        originalUpstreamURL,
 		Subpath:    upstream.Subpath,
 		CommitHash: commitHash,
 	}, nil
 }
 
-func integrate(gitSporkConfig *config.GitSporkConfig, upstreamPath string, downstreamPath string, forceRePrompt bool, forDriftCheck bool, logger types.Logger) error {
+func integrate(gitSporkConfig *config.GitSporkConfig, upstreamPath string, downstreamPath string, forceRePrompt bool, forDriftCheck bool, logger sdktypes.Logger) error {
 	greenBold := color.New(color.FgHiGreen, color.Bold)
 
 	preIntegrateMigrations := []*config.GitSporkConfigMigrationInstructions{}
@@ -372,7 +372,7 @@ func resolveUpstreamURL(url string, token string) string {
 	return url
 }
 
-func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest, upstream types.UpstreamSpec) (string, error) {
+func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest, upstream sdktypes.UpstreamSpec) (string, error) {
 	upstreamURL := resolveUpstreamURL(upstream.URL, upstream.Token)
 	var err error
 	var authMethod transport.AuthMethod
@@ -616,12 +616,12 @@ func ensureDownstreamMetaDir(downstreamRepoPath string) (string, error) {
 // .gitspork/downstream-state.json under downstreamRepoPath, creating the
 // metadata directory if it does not already exist. Deprecated single-upstream
 // fields on disk are migrated in-memory into the Upstreams slice.
-func LoadDownstreamState(downstreamRepoPath string) (*types.DownstreamState, error) {
+func LoadDownstreamState(downstreamRepoPath string) (*sdktypes.DownstreamState, error) {
 	gitSporkMetaDir, err := ensureDownstreamMetaDir(downstreamRepoPath)
 	if err != nil {
 		return nil, err
 	}
-	state := &types.DownstreamState{}
+	state := &sdktypes.DownstreamState{}
 	stateFilePath := filepath.Join(gitSporkMetaDir, downstreamStateFileName)
 	if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
 		return state, nil
@@ -636,7 +636,7 @@ func LoadDownstreamState(downstreamRepoPath string) (*types.DownstreamState, err
 	}
 	// Migrate deprecated single-upstream fields to Upstreams slice.
 	if len(state.Upstreams) == 0 && state.LastUpstreamCommitHash != "" {
-		state.Upstreams = []types.UpstreamState{{
+		state.Upstreams = []sdktypes.UpstreamState{{
 			URL:        state.LastUpstreamRepoURL,
 			Subpath:    state.LastUpstreamRepoSubpath,
 			CommitHash: state.LastUpstreamCommitHash,
@@ -650,7 +650,7 @@ func LoadDownstreamState(downstreamRepoPath string) (*types.DownstreamState, err
 
 // SaveDownstreamState persists state to .gitspork/downstream-state.json under
 // downstreamRepoPath, ensuring the metadata directory exists first.
-func SaveDownstreamState(downstreamRepoPath string, state *types.DownstreamState) error {
+func SaveDownstreamState(downstreamRepoPath string, state *sdktypes.DownstreamState) error {
 	b, err := json.Marshal(state)
 	if err != nil {
 		return err

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -277,7 +277,7 @@ func integrate(gitSporkConfig *config.GitSporkConfig, upstreamPath string, downs
 
 	for _, preIntegrateMigration := range preIntegrateMigrations {
 		logger.Log("%s", greenBold.Sprintf("running pre-integrate migration defined in upstream against the downstream: %s", preIntegrateMigration.ID))
-		if err := runMigration(preIntegrateMigration, upstreamPath, downstreamPath); err != nil {
+		if err := runMigration(preIntegrateMigration, upstreamPath, downstreamPath, logger); err != nil {
 			return fmt.Errorf("error running pre-integrate migration against the downstream: %v", err)
 		}
 		if !forDriftCheck {
@@ -319,7 +319,7 @@ func integrate(gitSporkConfig *config.GitSporkConfig, upstreamPath string, downs
 
 	for _, postIntegrateMigration := range postIntegrateMigrations {
 		logger.Log("%s", greenBold.Sprintf("running post-integrate migration defined in upstream against the downstream: %s", postIntegrateMigration.ID))
-		if err := runMigration(postIntegrateMigration, upstreamPath, downstreamPath); err != nil {
+		if err := runMigration(postIntegrateMigration, upstreamPath, downstreamPath, logger); err != nil {
 			return fmt.Errorf("error running post-integrate migration against the downstream: %v", err)
 		}
 		if !forDriftCheck {
@@ -679,7 +679,7 @@ func migrationCompletedInDownstream(migrationID string, downstreamRepoPath strin
 	return false, nil
 }
 
-func runMigration(migrationInstructions *config.GitSporkConfigMigrationInstructions, upstreamRepoRootPath string, downstreamRepoPath string) error {
+func runMigration(migrationInstructions *config.GitSporkConfigMigrationInstructions, upstreamRepoRootPath string, downstreamRepoPath string, logger sdktypes.Logger) error {
 	if migrationInstructions.Exec != "" {
 		execParts := strings.Split(migrationInstructions.Exec, " ")
 		if _, err := os.Stat(filepath.Join(upstreamRepoRootPath, execParts[0])); err == nil {
@@ -687,8 +687,8 @@ func runMigration(migrationInstructions *config.GitSporkConfigMigrationInstructi
 			execParts[0] = filepath.Join(upstreamRepoRootPath, execParts[0])
 		}
 		cmd := exec.Command(execParts[0], execParts[1:]...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		cmd.Stdout = &logutil.LoggerWriter{L: logger}
+		cmd.Stderr = &logutil.LoggerWriter{L: logger}
 		cmd.Dir = downstreamRepoPath
 		return cmd.Run()
 	}

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -76,7 +76,7 @@ func NormalizeUpstreamURL(rawURL string, subpath string) string {
 
 // UpsertUpstreamState inserts entry into state.Upstreams, replacing any existing
 // entry whose URL+subpath normalises to the same key while preserving slice order.
-func UpsertUpstreamState(state *types.GitSporkDownstreamState, entry types.GitSporkUpstreamState) {
+func UpsertUpstreamState(state *types.DownstreamState, entry types.UpstreamState) {
 	key := NormalizeUpstreamURL(entry.URL, entry.Subpath)
 	for i, existing := range state.Upstreams {
 		if NormalizeUpstreamURL(existing.URL, existing.Subpath) == key {
@@ -204,7 +204,7 @@ func integrateOne(opts *types.IntegrateOptions, upstream types.UpstreamSpec) (ty
 		if err != nil {
 			return types.IntegratedUpstream{}, fmt.Errorf("error loading downstream state to save upstream metadata: %v", err)
 		}
-		UpsertUpstreamState(state, types.GitSporkUpstreamState{
+		UpsertUpstreamState(state, types.UpstreamState{
 			URL:        originalUpstreamURL,
 			Subpath:    upstream.Subpath,
 			CommitHash: commitHash,
@@ -607,12 +607,12 @@ func ensureDownstreamMetaDir(downstreamRepoPath string) (string, error) {
 // .gitspork/downstream-state.json under downstreamRepoPath, creating the
 // metadata directory if it does not already exist. Deprecated single-upstream
 // fields on disk are migrated in-memory into the Upstreams slice.
-func LoadDownstreamState(downstreamRepoPath string) (*types.GitSporkDownstreamState, error) {
+func LoadDownstreamState(downstreamRepoPath string) (*types.DownstreamState, error) {
 	gitSporkMetaDir, err := ensureDownstreamMetaDir(downstreamRepoPath)
 	if err != nil {
 		return nil, err
 	}
-	state := &types.GitSporkDownstreamState{}
+	state := &types.DownstreamState{}
 	stateFilePath := filepath.Join(gitSporkMetaDir, downstreamStateFileName)
 	if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
 		return state, nil
@@ -627,7 +627,7 @@ func LoadDownstreamState(downstreamRepoPath string) (*types.GitSporkDownstreamSt
 	}
 	// Migrate deprecated single-upstream fields to Upstreams slice.
 	if len(state.Upstreams) == 0 && state.LastUpstreamCommitHash != "" {
-		state.Upstreams = []types.GitSporkUpstreamState{{
+		state.Upstreams = []types.UpstreamState{{
 			URL:        state.LastUpstreamRepoURL,
 			Subpath:    state.LastUpstreamRepoSubpath,
 			CommitHash: state.LastUpstreamCommitHash,
@@ -641,7 +641,7 @@ func LoadDownstreamState(downstreamRepoPath string) (*types.GitSporkDownstreamSt
 
 // SaveDownstreamState persists state to .gitspork/downstream-state.json under
 // downstreamRepoPath, ensuring the metadata directory exists first.
-func SaveDownstreamState(downstreamRepoPath string, state *types.GitSporkDownstreamState) error {
+func SaveDownstreamState(downstreamRepoPath string, state *types.DownstreamState) error {
 	b, err := json.Marshal(state)
 	if err != nil {
 		return err

--- a/internal/integrate/integrate_local.go
+++ b/internal/integrate/integrate_local.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // IntegrateLocal integrates one or more local upstream paths into the downstream.
-func IntegrateLocal(opts *types.IntegrateLocalOptions) (*types.IntegrateResult, error) {
-	result := &types.IntegrateResult{}
+func IntegrateLocal(opts *sdktypes.IntegrateLocalOptions) (*sdktypes.IntegrateResult, error) {
+	result := &sdktypes.IntegrateResult{}
 
 	if opts.Logger == nil {
-		opts.Logger = types.NoopLogger()
+		opts.Logger = sdktypes.NoopLogger()
 	}
 
 	if len(opts.UpstreamPaths) == 0 {
@@ -31,7 +31,7 @@ func IntegrateLocal(opts *types.IntegrateLocalOptions) (*types.IntegrateResult, 
 		if err := integrate(gitSporkConfig, upstreamPath, opts.DownstreamPath, opts.ForceRePrompt, false, opts.Logger); err != nil {
 			return result, err
 		}
-		result.Upstreams = append(result.Upstreams, types.IntegratedUpstream{
+		result.Upstreams = append(result.Upstreams, sdktypes.IntegratedUpstream{
 			URL: upstreamPath, // local path recorded in URL slot; no CommitHash concept for local
 		})
 	}

--- a/internal/integrate/integrate_local.go
+++ b/internal/integrate/integrate_local.go
@@ -16,12 +16,8 @@ func IntegrateLocal(opts *types.IntegrateLocalOptions) (*types.IntegrateResult, 
 		opts.Logger = types.NoopLogger()
 	}
 
-	// Normalize: single UpstreamPath -> UpstreamPaths slice.
-	if len(opts.UpstreamPaths) == 0 && opts.UpstreamPath != "" {
-		opts.UpstreamPaths = []string{opts.UpstreamPath}
-	}
 	if len(opts.UpstreamPaths) == 0 {
-		return result, fmt.Errorf("no upstream path specified: provide --upstream-path")
+		return result, fmt.Errorf("no upstream path specified: set UpstreamPaths on IntegrateLocalOptions")
 	}
 
 	for _, upstreamPath := range opts.UpstreamPaths {

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	gogitssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/logutil"
-	"github.com/rockholla/gitspork/internal/testharness"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,29 +84,29 @@ func Test_NormalizeUpstreamURL(t *testing.T) {
 }
 
 func Test_UpsertUpstreamState_newEntry(t *testing.T) {
-	state := &types.DownstreamState{}
-	UpsertUpstreamState(state, types.UpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "abc"})
+	state := &sdktypes.DownstreamState{}
+	UpsertUpstreamState(state, sdktypes.UpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "abc"})
 	require.Len(t, state.Upstreams, 1)
 	assert.Equal(t, "https://github.com/org/repo.git", state.Upstreams[0].URL)
 	assert.Equal(t, "abc", state.Upstreams[0].CommitHash)
 }
 
 func Test_UpsertUpstreamState_updateExisting(t *testing.T) {
-	state := &types.DownstreamState{Upstreams: []types.UpstreamState{
+	state := &sdktypes.DownstreamState{Upstreams: []sdktypes.UpstreamState{
 		{URL: "git@github.com:org/repo.git", CommitHash: "old"},
 	}}
 	// SSH and HTTPS forms of same repo — should match and update in place
-	UpsertUpstreamState(state, types.UpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "new"})
+	UpsertUpstreamState(state, sdktypes.UpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "new"})
 	require.Len(t, state.Upstreams, 1)
 	assert.Equal(t, "new", state.Upstreams[0].CommitHash)
 }
 
 func Test_UpsertUpstreamState_orderPreserved(t *testing.T) {
-	state := &types.DownstreamState{Upstreams: []types.UpstreamState{
+	state := &sdktypes.DownstreamState{Upstreams: []sdktypes.UpstreamState{
 		{URL: "https://github.com/org/base.git", CommitHash: "b1"},
 		{URL: "https://github.com/org/platform.git", CommitHash: "p1"},
 	}}
-	UpsertUpstreamState(state, types.UpstreamState{URL: "https://github.com/org/base.git", CommitHash: "b2"})
+	UpsertUpstreamState(state, sdktypes.UpstreamState{URL: "https://github.com/org/base.git", CommitHash: "b2"})
 	require.Len(t, state.Upstreams, 2)
 	assert.Equal(t, "b2", state.Upstreams[0].CommitHash)
 	assert.Equal(t, "p1", state.Upstreams[1].CommitHash)
@@ -181,9 +181,9 @@ func TestIntegrate_returns_result_with_upstream_url_and_hash(t *testing.T) {
 	upstreamDir, upstreamHash := testharness.MinimalUpstream(t)
 	downstreamDir := testharness.EmptyDownstream(t)
 
-	result, err := Integrate(&types.IntegrateOptions{
+	result, err := Integrate(&sdktypes.IntegrateOptions{
 		Logger:             logutil.New(),
-		Upstreams:          []types.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		Upstreams:          []sdktypes.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
 		DownstreamRepoPath: downstreamDir,
 	})
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestIntegrateLocal_returns_result_with_upstream_paths(t *testing.T) {
 	upstreamDir, _ := testharness.MinimalUpstream(t)
 	downstreamDir := testharness.EmptyDownstream(t)
 
-	result, err := IntegrateLocal(&types.IntegrateLocalOptions{
+	result, err := IntegrateLocal(&sdktypes.IntegrateLocalOptions{
 		Logger:         logutil.New(),
 		UpstreamPaths:  []string{upstreamDir},
 		DownstreamPath: downstreamDir,
@@ -223,9 +223,9 @@ func TestIntegrate(t *testing.T) {
 
 		makeUpstreamRepo(t, upstreamDir)
 
-		_, err = Integrate(&types.IntegrateOptions{
+		_, err = Integrate(&sdktypes.IntegrateOptions{
 			Logger:             logutil.New(),
-			Upstreams:          []types.UpstreamSpec{{URL: upstreamDir, Version: "master"}},
+			Upstreams:          []sdktypes.UpstreamSpec{{URL: upstreamDir, Version: "master"}},
 			DownstreamRepoPath: downstreamDir,
 		})
 		require.NoError(t, err)

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -131,9 +131,10 @@ func Test_LoadDownstreamState_migration(t *testing.T) {
 	assert.Equal(t, "", state.LastUpstreamRepoSubpath)
 }
 
-func TestIntegrate_honors_UpstreamRepoCommit(t *testing.T) {
-	// Create a local upstream repo with two commits; verify that Integrate
-	// checks out the older commit (v1) when UpstreamRepoCommit is set.
+func TestIntegrateForDriftCheck_honors_UpstreamCommit(t *testing.T) {
+	// Create a local upstream repo with two commits; verify that
+	// IntegrateForDriftCheck checks out the older commit (v1) when
+	// UpstreamCommit is set.
 	upstreamDir := t.TempDir()
 	upstreamRepo, err := gogit.PlainInit(upstreamDir, false,
 		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
@@ -162,19 +163,18 @@ func TestIntegrate_honors_UpstreamRepoCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := logutil.New()
-	_, err = Integrate(&types.IntegrateOptions{
+	err = IntegrateForDriftCheck(&DriftCheckRequest{
 		Logger:             logger,
-		UpstreamRepoURL:    "file://" + upstreamDir,
-		UpstreamRepoCommit: commitV1.String(),
 		DownstreamRepoPath: downstreamDir,
-		ForDriftCheck:      true, // skip state write; we only care about file content
+		UpstreamURL:        "file://" + upstreamDir,
+		UpstreamCommit:     commitV1.String(),
 	})
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(downstreamDir, "upstream-owned", "file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "version one\n", string(content),
-		"Integrate with UpstreamRepoCommit set to v1 should produce v1 content, not HEAD (v2)")
+		"IntegrateForDriftCheck with UpstreamCommit set to v1 should produce v1 content, not HEAD (v2)")
 }
 
 func TestIntegrate_returns_result_with_upstream_url_and_hash(t *testing.T) {
@@ -224,10 +224,9 @@ func TestIntegrate(t *testing.T) {
 		makeUpstreamRepo(t, upstreamDir)
 
 		_, err = Integrate(&types.IntegrateOptions{
-			Logger:              logutil.New(),
-			UpstreamRepoURL:     upstreamDir,
-			UpstreamRepoVersion: "master",
-			DownstreamRepoPath:  downstreamDir,
+			Logger:             logutil.New(),
+			Upstreams:          []types.UpstreamSpec{{URL: upstreamDir, Version: "master"}},
+			DownstreamRepoPath: downstreamDir,
 		})
 		require.NoError(t, err)
 

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -84,29 +84,29 @@ func Test_NormalizeUpstreamURL(t *testing.T) {
 }
 
 func Test_UpsertUpstreamState_newEntry(t *testing.T) {
-	state := &types.GitSporkDownstreamState{}
-	UpsertUpstreamState(state, types.GitSporkUpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "abc"})
+	state := &types.DownstreamState{}
+	UpsertUpstreamState(state, types.UpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "abc"})
 	require.Len(t, state.Upstreams, 1)
 	assert.Equal(t, "https://github.com/org/repo.git", state.Upstreams[0].URL)
 	assert.Equal(t, "abc", state.Upstreams[0].CommitHash)
 }
 
 func Test_UpsertUpstreamState_updateExisting(t *testing.T) {
-	state := &types.GitSporkDownstreamState{Upstreams: []types.GitSporkUpstreamState{
+	state := &types.DownstreamState{Upstreams: []types.UpstreamState{
 		{URL: "git@github.com:org/repo.git", CommitHash: "old"},
 	}}
 	// SSH and HTTPS forms of same repo — should match and update in place
-	UpsertUpstreamState(state, types.GitSporkUpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "new"})
+	UpsertUpstreamState(state, types.UpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "new"})
 	require.Len(t, state.Upstreams, 1)
 	assert.Equal(t, "new", state.Upstreams[0].CommitHash)
 }
 
 func Test_UpsertUpstreamState_orderPreserved(t *testing.T) {
-	state := &types.GitSporkDownstreamState{Upstreams: []types.GitSporkUpstreamState{
+	state := &types.DownstreamState{Upstreams: []types.UpstreamState{
 		{URL: "https://github.com/org/base.git", CommitHash: "b1"},
 		{URL: "https://github.com/org/platform.git", CommitHash: "p1"},
 	}}
-	UpsertUpstreamState(state, types.GitSporkUpstreamState{URL: "https://github.com/org/base.git", CommitHash: "b2"})
+	UpsertUpstreamState(state, types.UpstreamState{URL: "https://github.com/org/base.git", CommitHash: "b2"})
 	require.Len(t, state.Upstreams, 2)
 	assert.Equal(t, "b2", state.Upstreams[0].CommitHash)
 	assert.Equal(t, "p1", state.Upstreams[1].CommitHash)

--- a/internal/integrate/integrator_downstream_owned.go
+++ b/internal/integrate/integrator_downstream_owned.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // IntegratorDownstreamOwned will process a list of files to be managed as owned by the downstream gitspork repo, just initially bootstrapped by the upstream
@@ -18,7 +18,7 @@ var _ Integrator[config.OwnedEntry] = (*IntegratorDownstreamOwned)(nil)
 // applying rename entries' destination resolution. A file is only copied when
 // its downstream destination does not already exist — the downstream owns it
 // thereafter.
-func (i *IntegratorDownstreamOwned) Integrate(entries []config.OwnedEntry, upstreamPath string, downstreamPath string, logger types.Logger) error {
+func (i *IntegratorDownstreamOwned) Integrate(entries []config.OwnedEntry, upstreamPath string, downstreamPath string, logger sdktypes.Logger) error {
 	for _, entry := range entries {
 		integrateFiles, err := getIntegrateFiles(upstreamPath, []string{entry.SourcePattern()})
 		if err != nil {

--- a/internal/integrate/integrator_shared_ownership_merged.go
+++ b/internal/integrate/integrator_shared_ownership_merged.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 const (
@@ -28,7 +28,7 @@ type upstreamOwnedBlock struct {
 }
 
 // Integrate will process the gitspork files list to ensure integration b/w upstream -> downstream
-func (i *IntegratorSharedOwnershipMerged) Integrate(configuredGlobPatterns []string, upstreamPath string, downstreamPath string, logger types.Logger) error {
+func (i *IntegratorSharedOwnershipMerged) Integrate(configuredGlobPatterns []string, upstreamPath string, downstreamPath string, logger sdktypes.Logger) error {
 	integrateFiles, err := getIntegrateFiles(upstreamPath, configuredGlobPatterns)
 	if err != nil {
 		return fmt.Errorf("error determining the list of files to integrate in %s from %v: %v", upstreamPath, configuredGlobPatterns, err)

--- a/internal/integrate/integrator_shared_ownership_structured_prefer_downstream.go
+++ b/internal/integrate/integrator_shared_ownership_structured_prefer_downstream.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"dario.cat/mergo"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // IntegratorSharedOwnershipStructuredPreferDownstream will process a list of structured data files to be co-owned by upstream and downstream, merged with preference/precdence in favor of downstream
@@ -14,7 +14,7 @@ type IntegratorSharedOwnershipStructuredPreferDownstream struct{}
 var _ Integrator[string] = (*IntegratorSharedOwnershipStructuredPreferDownstream)(nil)
 
 // Integrate will process the gitspork files list to ensure integration b/w upstream -> downstream
-func (i *IntegratorSharedOwnershipStructuredPreferDownstream) Integrate(configuredGlobPatterns []string, upstreamPath string, downstreamPath string, logger types.Logger) error {
+func (i *IntegratorSharedOwnershipStructuredPreferDownstream) Integrate(configuredGlobPatterns []string, upstreamPath string, downstreamPath string, logger sdktypes.Logger) error {
 	integrateFiles, err := getIntegrateFiles(upstreamPath, configuredGlobPatterns)
 	if err != nil {
 		return fmt.Errorf("error determining the list of files to integrate in %s from %v: %v", upstreamPath, configuredGlobPatterns, err)

--- a/internal/integrate/integrator_shared_ownership_structured_prefer_upstream.go
+++ b/internal/integrate/integrator_shared_ownership_structured_prefer_upstream.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"dario.cat/mergo"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // IntegratorSharedOwnershipStructuredPreferUpstream will process a list of structured data files to be co-owned by upstream and downstream, merged with preference/precdence in favor of upstream
@@ -14,7 +14,7 @@ type IntegratorSharedOwnershipStructuredPreferUpstream struct{}
 var _ Integrator[string] = (*IntegratorSharedOwnershipStructuredPreferUpstream)(nil)
 
 // Integrate will process the gitspork files list to ensure integration b/w upstream -> downstream
-func (i *IntegratorSharedOwnershipStructuredPreferUpstream) Integrate(configuredGlobPatterns []string, upstreamPath string, downstreamPath string, logger types.Logger) error {
+func (i *IntegratorSharedOwnershipStructuredPreferUpstream) Integrate(configuredGlobPatterns []string, upstreamPath string, downstreamPath string, logger sdktypes.Logger) error {
 	integrateFiles, err := getIntegrateFiles(upstreamPath, configuredGlobPatterns)
 	if err != nil {
 		return fmt.Errorf("error determining the list of files to integrate in %s from %v: %v", upstreamPath, configuredGlobPatterns, err)

--- a/internal/integrate/integrator_templated.go
+++ b/internal/integrate/integrator_templated.go
@@ -11,9 +11,9 @@ import (
 	"text/template"
 
 	"dario.cat/mergo"
-	"github.com/rockholla/gitspork/internal/config"
-	inputpkg "github.com/rockholla/gitspork/internal/input"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	inputpkg "github.com/rockholla/gitspork/v2/internal/input"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // IntegratorTemplated will process a list of instructions on how to render Go templates in the upstream to downstream rendered files
@@ -27,7 +27,7 @@ type IntegratorTemplatedData struct {
 }
 
 // Integrate will process the gitspork files list to ensure integration b/w upstream -> downstream
-func (i *IntegratorTemplated) Integrate(templatedInstructions []config.GitSporkConfigTemplated, upstreamPath string, downstreamPath string, forceRePrompt bool, logger types.Logger) error {
+func (i *IntegratorTemplated) Integrate(templatedInstructions []config.GitSporkConfigTemplated, upstreamPath string, downstreamPath string, forceRePrompt bool, logger sdktypes.Logger) error {
 
 	// captured input values will support the input 'previous_input' type via this structure:
 	/*

--- a/internal/integrate/integrator_upstream_owned.go
+++ b/internal/integrate/integrator_upstream_owned.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // IntegratorUpstreamOwned will process a list of files to be managed as owned by the upstream gitspork repo
@@ -15,7 +15,7 @@ var _ Integrator[config.OwnedEntry] = (*IntegratorUpstreamOwned)(nil)
 
 // Integrate copies each upstream-owned file to the downstream, applying rename
 // entries' destination resolution.
-func (i *IntegratorUpstreamOwned) Integrate(entries []config.OwnedEntry, upstreamPath string, downstreamPath string, logger types.Logger) error {
+func (i *IntegratorUpstreamOwned) Integrate(entries []config.OwnedEntry, upstreamPath string, downstreamPath string, logger sdktypes.Logger) error {
 	for _, entry := range entries {
 		integrateFiles, err := getIntegrateFiles(upstreamPath, []string{entry.SourcePattern()})
 		if err != nil {

--- a/internal/integrate/upstream_delta.go
+++ b/internal/integrate/upstream_delta.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	"github.com/gobwas/glob"
 	"github.com/goccy/go-yaml"
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 type upstreamRename struct {
@@ -235,7 +235,7 @@ func readConfigFromCommit(commit *object.Commit, subpath string) (*config.GitSpo
 	return cfg, nil
 }
 
-func applyUpstreamDelta(delta *upstreamDelta, downstreamPath string, logger types.Logger) error {
+func applyUpstreamDelta(delta *upstreamDelta, downstreamPath string, logger sdktypes.Logger) error {
 	for _, del := range delta.Deletions {
 		target := filepath.Join(downstreamPath, del)
 		if _, err := os.Stat(target); os.IsNotExist(err) {

--- a/internal/integrate/upstream_delta_test.go
+++ b/internal/integrate/upstream_delta_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/goccy/go-yaml"
-	"github.com/rockholla/gitspork/internal/config"
-	"github.com/rockholla/gitspork/internal/logutil"
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/logutil/diff.go
+++ b/internal/logutil/diff.go
@@ -1,0 +1,50 @@
+package logutil
+
+import "strings"
+
+// ANSI escape codes for unified-diff colorization. Emitted directly (not via
+// fatih/color) so ColorizeUnifiedDiff produces the same output regardless of
+// the process's TTY state — SDK consumers may render the result in contexts
+// where TTY detection at generation time doesn't reflect the eventual sink.
+const (
+	ansiBold  = "\x1b[1m"
+	ansiCyan  = "\x1b[36m"
+	ansiGreen = "\x1b[32m"
+	ansiRed   = "\x1b[31m"
+	ansiReset = "\x1b[0m"
+)
+
+// ColorizeUnifiedDiff applies ANSI color codes to a unified-diff string
+// based on per-line prefix: `diff --git` and `+++`/`---` headers bold, `@@`
+// hunks cyan, `+` additions green, `-` removals red. Always emits color
+// codes; callers that want to suppress color (non-TTY output, NO_COLOR env)
+// should render the raw diff instead.
+func ColorizeUnifiedDiff(diff string) string {
+	var out strings.Builder
+	for _, line := range strings.Split(diff, "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git"),
+			strings.HasPrefix(line, "--- "),
+			strings.HasPrefix(line, "+++ "):
+			out.WriteString(ansiBold)
+			out.WriteString(line)
+			out.WriteString(ansiReset)
+		case strings.HasPrefix(line, "@@"):
+			out.WriteString(ansiCyan)
+			out.WriteString(line)
+			out.WriteString(ansiReset)
+		case strings.HasPrefix(line, "+"):
+			out.WriteString(ansiGreen)
+			out.WriteString(line)
+			out.WriteString(ansiReset)
+		case strings.HasPrefix(line, "-"):
+			out.WriteString(ansiRed)
+			out.WriteString(line)
+			out.WriteString(ansiReset)
+		default:
+			out.WriteString(line)
+		}
+		out.WriteString("\n")
+	}
+	return out.String()
+}

--- a/internal/logutil/logger.go
+++ b/internal/logutil/logger.go
@@ -1,6 +1,6 @@
 // Package logutil provides gitspork's concrete Logger implementation used by
-// the CLI binary. It satisfies internal/types.Logger. SDK consumers can pass
-// this or any other types.Logger implementation (or nil for silent).
+// the CLI binary. It satisfies internal/sdktypes.Logger. SDK consumers can pass
+// this or any other sdktypes.Logger implementation (or nil for silent).
 package logutil
 
 import (
@@ -9,11 +9,11 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // Logger writes log/error messages to stdout/stderr with ANSI color when
-// stdout is a TTY. Its Log and Error methods satisfy types.Logger; Fatal
+// stdout is a TTY. Its Log and Error methods satisfy sdktypes.Logger; Fatal
 // stays concrete because it terminates the process and isn't needed by SDK
 // consumers.
 type Logger struct {
@@ -21,8 +21,8 @@ type Logger struct {
 	errorLogger   *log.Logger
 }
 
-// Compile-time assertion that Logger satisfies types.Logger.
-var _ types.Logger = (*Logger)(nil)
+// Compile-time assertion that Logger satisfies sdktypes.Logger.
+var _ sdktypes.Logger = (*Logger)(nil)
 
 // New returns a Logger configured for the CLI.
 func New() *Logger {

--- a/internal/logutil/writer.go
+++ b/internal/logutil/writer.go
@@ -1,0 +1,32 @@
+package logutil
+
+import (
+	"strings"
+
+	"github.com/rockholla/gitspork/internal/types"
+)
+
+// LoggerWriter is an io.Writer that forwards each line written to it to a
+// types.Logger. Trailing newlines are trimmed since Logger implementations
+// handle line boundaries themselves. If L is nil, Write accepts bytes and
+// discards them silently — matching the types.Logger "nil is silent"
+// contract for callers that pass this writer through third-party APIs
+// (like go-git's clone Progress).
+type LoggerWriter struct {
+	L types.Logger
+}
+
+// Write splits input on newlines and calls L.Log for each non-empty line.
+func (w *LoggerWriter) Write(p []byte) (int, error) {
+	if w == nil || w.L == nil {
+		return len(p), nil
+	}
+	text := strings.TrimRight(string(p), "\n")
+	if text == "" {
+		return len(p), nil
+	}
+	for _, line := range strings.Split(text, "\n") {
+		w.L.Log("%s", line)
+	}
+	return len(p), nil
+}

--- a/internal/logutil/writer.go
+++ b/internal/logutil/writer.go
@@ -3,17 +3,17 @@ package logutil
 import (
 	"strings"
 
-	"github.com/rockholla/gitspork/internal/types"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
 // LoggerWriter is an io.Writer that forwards each line written to it to a
-// types.Logger. Trailing newlines are trimmed since Logger implementations
+// sdktypes.Logger. Trailing newlines are trimmed since Logger implementations
 // handle line boundaries themselves. If L is nil, Write accepts bytes and
-// discards them silently — matching the types.Logger "nil is silent"
+// discards them silently — matching the sdktypes.Logger "nil is silent"
 // contract for callers that pass this writer through third-party APIs
 // (like go-git's clone Progress).
 type LoggerWriter struct {
-	L types.Logger
+	L sdktypes.Logger
 }
 
 // Write splits input on newlines and calls L.Log for each non-empty line.

--- a/internal/sdktypes/errors.go
+++ b/internal/sdktypes/errors.go
@@ -1,4 +1,4 @@
-package types
+package sdktypes
 
 import "errors"
 

--- a/internal/sdktypes/logger.go
+++ b/internal/sdktypes/logger.go
@@ -1,4 +1,4 @@
-package types
+package sdktypes
 
 // Logger is the small interface gitspork uses for narration/progress and
 // error messages. It is deliberately narrow so SDK consumers can wire their

--- a/internal/sdktypes/noop_logger.go
+++ b/internal/sdktypes/noop_logger.go
@@ -1,4 +1,4 @@
-package types
+package sdktypes
 
 // noopLogger is a Logger implementation whose methods do nothing. It exists so
 // entry-point functions can normalize a nil Logger into a non-nil no-op

--- a/internal/sdktypes/options.go
+++ b/internal/sdktypes/options.go
@@ -1,4 +1,4 @@
-package types
+package sdktypes
 
 // IntegrateOptions configures a call to Integrate. Populate Upstreams (one
 // or more entries) for multi-upstream integration.

--- a/internal/sdktypes/results.go
+++ b/internal/sdktypes/results.go
@@ -42,4 +42,5 @@ type DriftedFile struct {
 	Path          string
 	AttributedURL string // upstream URL responsible for this file; empty means unattributed
 	Diff          string // unified-diff text for this file; a `Binary files ... differ` marker line when the file is binary
+	ColorizedDiff string // same content as Diff with ANSI color codes applied by line prefix (headers bold, hunks cyan, additions green, removals red); always populated regardless of the process's TTY state so SDK consumers can render into any sink
 }

--- a/internal/sdktypes/results.go
+++ b/internal/sdktypes/results.go
@@ -1,4 +1,4 @@
-package types
+package sdktypes
 
 // IntegrateResult is the structural return value of Integrate and IntegrateLocal.
 // It records what was successfully integrated (in order); on partial failure

--- a/internal/sdktypes/state.go
+++ b/internal/sdktypes/state.go
@@ -1,4 +1,4 @@
-package types
+package sdktypes
 
 // DownstreamState is the on-disk state stored at
 // .gitspork/downstream-state.json in the downstream repo. It records each

--- a/internal/types/options.go
+++ b/internal/types/options.go
@@ -1,31 +1,40 @@
 package types
 
 // IntegrateOptions configures a call to Integrate. Populate Upstreams (one
-// or more entries) for multi-upstream integration, or the deprecated
-// UpstreamRepo* single-value fields for backward compatibility.
+// or more entries) for multi-upstream integration.
 type IntegrateOptions struct {
-	Upstreams              []UpstreamSpec
-	DownstreamRepoPath     string
-	ForceRePrompt          bool
-	Logger                 Logger
+	Upstreams          []UpstreamSpec
+	DownstreamRepoPath string
+	ForceRePrompt      bool
+	Logger             Logger
+	// Task 2 removes ForDriftCheck / PrevUpstreamCommitHash / UpstreamRepo* from
+	// this struct. Until then, they carry legacy-flag data from the CLI and
+	// drift-check re-integration wiring.
 	ForDriftCheck          bool
 	PrevUpstreamCommitHash string
-	UpstreamRepoURL        string
-	UpstreamRepoVersion    string
-	UpstreamRepoSubpath    string
-	UpstreamRepoToken      string
-	UpstreamRepoCommit     string
+	// Deprecated: set Upstreams instead. The CLI accepts --upstream-repo-url
+	// for backward compatibility and translates internally.
+	UpstreamRepoURL string
+	// Deprecated: set Upstreams instead.
+	UpstreamRepoVersion string
+	// Deprecated: set Upstreams instead.
+	UpstreamRepoSubpath string
+	// Deprecated: set Upstreams instead.
+	UpstreamRepoToken string
+	// Deprecated: internal drift-check wiring only.
+	UpstreamRepoCommit string
 }
 
 // IntegrateLocalOptions configures a call to IntegrateLocal. Populate
-// UpstreamPaths for multi-path integration; UpstreamPath (deprecated) is
-// preserved for backward compatibility.
+// UpstreamPaths (one or more entries) for multi-path integration.
 type IntegrateLocalOptions struct {
 	UpstreamPaths  []string
-	UpstreamPath   string
 	DownstreamPath string
 	ForceRePrompt  bool
 	Logger         Logger
+	// Deprecated: set UpstreamPaths instead. The CLI accepts a single
+	// --upstream-path for backward compatibility and translates internally.
+	UpstreamPath string
 }
 
 // CheckDriftOptions configures a call to CheckDrift. Leave Upstreams empty

--- a/internal/types/options.go
+++ b/internal/types/options.go
@@ -7,22 +7,6 @@ type IntegrateOptions struct {
 	DownstreamRepoPath string
 	ForceRePrompt      bool
 	Logger             Logger
-	// Task 2 removes ForDriftCheck / PrevUpstreamCommitHash / UpstreamRepo* from
-	// this struct. Until then, they carry legacy-flag data from the CLI and
-	// drift-check re-integration wiring.
-	ForDriftCheck          bool
-	PrevUpstreamCommitHash string
-	// Deprecated: set Upstreams instead. The CLI accepts --upstream-repo-url
-	// for backward compatibility and translates internally.
-	UpstreamRepoURL string
-	// Deprecated: set Upstreams instead.
-	UpstreamRepoVersion string
-	// Deprecated: set Upstreams instead.
-	UpstreamRepoSubpath string
-	// Deprecated: set Upstreams instead.
-	UpstreamRepoToken string
-	// Deprecated: internal drift-check wiring only.
-	UpstreamRepoCommit string
 }
 
 // IntegrateLocalOptions configures a call to IntegrateLocal. Populate
@@ -32,9 +16,6 @@ type IntegrateLocalOptions struct {
 	DownstreamPath string
 	ForceRePrompt  bool
 	Logger         Logger
-	// Deprecated: set UpstreamPaths instead. The CLI accepts a single
-	// --upstream-path for backward compatibility and translates internally.
-	UpstreamPath string
 }
 
 // CheckDriftOptions configures a call to CheckDrift. Leave Upstreams empty

--- a/internal/types/results.go
+++ b/internal/types/results.go
@@ -4,11 +4,17 @@ package types
 // It records what was successfully integrated (in order); on partial failure
 // the successful upstreams so far are still present in this result alongside
 // the returned error.
+//
+// The returned *IntegrateResult is always non-nil — callers do not need to
+// nil-check before inspecting Upstreams.
 type IntegrateResult struct {
 	Upstreams []IntegratedUpstream
 }
 
 // IntegratedUpstream identifies a single successfully integrated upstream.
+// For Integrate, URL is the remote repo URL (SSH or HTTPS, whichever the
+// caller supplied). For IntegrateLocal, URL is the local filesystem path with
+// no scheme, and CommitHash is empty (local paths have no commit-hash concept).
 type IntegratedUpstream struct {
 	URL        string
 	Subpath    string
@@ -19,6 +25,13 @@ type IntegratedUpstream struct {
 // when the downstream matches the recorded integration state; true when
 // differences were found. Files enumerates the drifted entries with per-file
 // attribution to whichever upstream last wrote each path.
+//
+// When two upstreams write the same file, AttributedURL on the corresponding
+// DriftedFile records the last-writing upstream — matching the last-writer-wins
+// semantics of multi-upstream integrate.
+//
+// The returned *DriftReport is always non-nil — callers do not need to
+// nil-check before inspecting HasDrift or Files.
 type DriftReport struct {
 	HasDrift bool
 	Files    []DriftedFile

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -1,10 +1,12 @@
 package types
 
-// GitSporkDownstreamState is the on-disk state stored at
-// .gitspork/downstream-state.json in the downstream repo.
-type GitSporkDownstreamState struct {
-	MigrationsComplete []string                `json:"migrations_complete"`
-	Upstreams          []GitSporkUpstreamState `json:"upstreams,omitempty"`
+// DownstreamState is the on-disk state stored at
+// .gitspork/downstream-state.json in the downstream repo. It records each
+// integrated upstream so subsequent runs (integrate, check-drift) can locate
+// the previous commit hash and detect drift.
+type DownstreamState struct {
+	MigrationsComplete []string        `json:"migrations_complete"`
+	Upstreams          []UpstreamState `json:"upstreams,omitempty"`
 	// Deprecated: migrated to Upstreams on first load.
 	LastUpstreamRepoURL string `json:"last_upstream_repo_url,omitempty"`
 	// Deprecated: migrated to Upstreams on first load.
@@ -13,8 +15,8 @@ type GitSporkDownstreamState struct {
 	LastUpstreamCommitHash string `json:"last_upstream_commit_hash,omitempty"`
 }
 
-// GitSporkUpstreamState records the last integration for a single upstream.
-type GitSporkUpstreamState struct {
+// UpstreamState records the last integration for a single upstream.
+type UpstreamState struct {
 	URL        string `json:"url"`
 	Subpath    string `json:"subpath,omitempty"`
 	CommitHash string `json:"commit_hash"`

--- a/test/examples/integrate_local_test.go
+++ b/test/examples/integrate_local_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/rockholla/gitspork/internal/testharness"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/examples/main_test.go
+++ b/test/examples/main_test.go
@@ -32,7 +32,7 @@ func buildBinary(repoRoot string) string {
 		panic("cannot create temp dir for binary: " + err.Error())
 	}
 	out := filepath.Join(dir, "gitspork")
-	cmd := exec.Command("go", "build", "-o", out, ".")
+	cmd := exec.Command("go", "build", "-o", out, "./cmd/gitspork")
 	cmd.Dir = repoRoot
 	if b, err := cmd.CombinedOutput(); err != nil {
 		panic("go build failed:\n" + string(b))

--- a/test/examples/open_source_template_test.go
+++ b/test/examples/open_source_template_test.go
@@ -5,7 +5,7 @@ package examples
 import (
 	"testing"
 
-	"github.com/rockholla/gitspork/internal/testharness"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/test/examples/platform_team_test.go
+++ b/test/examples/platform_team_test.go
@@ -5,7 +5,7 @@ package examples
 import (
 	"testing"
 
-	"github.com/rockholla/gitspork/internal/testharness"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/test/examples/standards_library_test.go
+++ b/test/examples/standards_library_test.go
@@ -5,7 +5,7 @@ package examples
 import (
 	"testing"
 
-	"github.com/rockholla/gitspork/internal/testharness"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/test/functional/harness.go
+++ b/test/functional/harness.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	gogit "github.com/go-git/go-git/v6"
-	"github.com/rockholla/gitspork/internal/testharness"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
 )
 
 type Runner interface {

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -42,7 +42,7 @@ func buildBinary(repoRoot string) string {
 		panic("cannot create temp dir for binary: " + err.Error())
 	}
 	out := filepath.Join(dir, "gitspork")
-	cmd := exec.Command("go", "build", "-o", out, ".")
+	cmd := exec.Command("go", "build", "-o", out, "./cmd/gitspork")
 	cmd.Dir = repoRoot
 	if b, err := cmd.CombinedOutput(); err != nil {
 		panic("go build failed:\n" + string(b))
@@ -59,7 +59,7 @@ func buildDockerImageForTests(repoRoot string) {
 		panic("cannot create temp dir for docker build context: " + err.Error())
 	}
 	binaryPath := filepath.Join(dir, "gitspork")
-	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/gitspork")
 	buildCmd.Dir = repoRoot
 	buildCmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
 	if b, err := buildCmd.CombinedOutput(); err != nil {

--- a/test/sdk/helpers_test.go
+++ b/test/sdk/helpers_test.go
@@ -1,0 +1,46 @@
+//go:build sdk
+
+package sdk_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rockholla/gitspork/v2/internal/testharness"
+)
+
+// minimalUpstream builds a local upstream git repo with a minimal .gitspork.yml
+// (upstream_owned only) and one file. Returns the repo dir and its HEAD hash.
+func minimalUpstream(t *testing.T) (string, plumbing.Hash) {
+	t.Helper()
+	return testharness.MinimalUpstream(t)
+}
+
+// emptyDownstream returns a fresh non-bare local downstream git repo dir.
+func emptyDownstream(t *testing.T) string {
+	t.Helper()
+	return testharness.EmptyDownstream(t)
+}
+
+// writeAndCommit writes a file in downstreamDir and commits it, returning the
+// resulting commit hash.
+func writeAndCommit(t *testing.T, downstreamDir, relPath, content string) plumbing.Hash {
+	t.Helper()
+	full := filepath.Join(downstreamDir, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	repo, err := gogit.PlainOpen(downstreamDir)
+	require.NoError(t, err)
+	return testharness.CommitAllWithMessage(t, repo, "edit: "+relPath)
+}
+
+// fileExists returns nil if the file exists at base/parts..., non-nil error otherwise.
+func fileExists(base string, parts ...string) error {
+	_, err := os.Stat(filepath.Join(append([]string{base}, parts...)...))
+	return err
+}

--- a/test/sdk/sdk_test.go
+++ b/test/sdk/sdk_test.go
@@ -112,6 +112,15 @@ func TestCheckDrift_driftDetected_returnsErrSentinel(t *testing.T) {
 	assert.Equal(t, "upstream-owned/file.txt", report.Files[0].Path)
 	assert.Equal(t, "file://"+upstreamDir, report.Files[0].AttributedURL)
 	assert.Contains(t, report.Files[0].Diff, "upstream-owned/file.txt", "per-file diff should reference the path")
+
+	// ColorizedDiff contains ANSI escape codes so SDK consumers can render
+	// human-readable output. Populated regardless of process TTY state.
+	assert.NotEqual(t, report.Files[0].Diff, report.Files[0].ColorizedDiff,
+		"ColorizedDiff should differ from Diff (colors were applied)")
+	assert.Contains(t, report.Files[0].ColorizedDiff, "\x1b[",
+		"ColorizedDiff should contain ANSI escape codes")
+	assert.Contains(t, report.Files[0].ColorizedDiff, "upstream-owned/file.txt",
+		"ColorizedDiff should still reference the path")
 }
 
 // Logger contract: nil Logger means silent (no panic)

--- a/test/sdk/sdk_test.go
+++ b/test/sdk/sdk_test.go
@@ -1,0 +1,183 @@
+//go:build sdk
+
+package sdk_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rockholla/gitspork/v2"
+)
+
+// integrate: single upstream returns a populated *IntegrateResult
+func TestIntegrate_singleUpstream(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, "file://"+upstreamDir, result.Upstreams[0].URL)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+// integrate: multi-upstream order is preserved in the result
+func TestIntegrate_multiUpstreamOrder(t *testing.T) {
+	upstreamA, hashA := minimalUpstream(t)
+	upstreamB, hashB := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams: []gitspork.UpstreamSpec{
+			{URL: "file://" + upstreamA, Version: "main"},
+			{URL: "file://" + upstreamB, Version: "main"},
+		},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Upstreams, 2)
+	assert.Equal(t, "file://"+upstreamA, result.Upstreams[0].URL)
+	assert.Equal(t, "file://"+upstreamB, result.Upstreams[1].URL)
+	assert.Equal(t, hashA.String(), result.Upstreams[0].CommitHash)
+	assert.Equal(t, hashB.String(), result.Upstreams[1].CommitHash)
+}
+
+// integrate-local: multi-path; state file not written
+func TestIntegrateLocal_multiPath_noStateFile(t *testing.T) {
+	upstreamA, _ := minimalUpstream(t)
+	upstreamB, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.IntegrateLocal(&gitspork.IntegrateLocalOptions{
+		UpstreamPaths:  []string{upstreamA, upstreamB},
+		DownstreamPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Upstreams, 2)
+
+	// State file must NOT be written for IntegrateLocal.
+	err = fileExists(downstreamDir, ".gitspork", "downstream-state.json")
+	assert.Error(t, err, "expected no state file after IntegrateLocal")
+}
+
+// check-drift: no drift returns HasDrift=false and nil error
+func TestCheckDrift_noDrift(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+
+	writeAndCommit(t, downstreamDir, ".gitspork/marker", "baseline")
+
+	report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.False(t, report.HasDrift)
+	assert.Empty(t, report.Files)
+}
+
+// check-drift: drift returns HasDrift=true, populated Files, ErrDriftDetected sentinel
+func TestCheckDrift_driftDetected_returnsErrSentinel(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	writeAndCommit(t, downstreamDir, ".gitspork/marker", "baseline")
+	writeAndCommit(t, downstreamDir, "upstream-owned/file.txt", "drifted content\n")
+
+	report, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.True(t, errors.Is(err, gitspork.ErrDriftDetected), "expected ErrDriftDetected, got %v", err)
+	require.NotNil(t, report)
+	assert.True(t, report.HasDrift)
+	require.Len(t, report.Files, 1)
+	assert.Equal(t, "upstream-owned/file.txt", report.Files[0].Path)
+	assert.Equal(t, "file://"+upstreamDir, report.Files[0].AttributedURL)
+	assert.Contains(t, report.Files[0].Diff, "upstream-owned/file.txt", "per-file diff should reference the path")
+}
+
+// Logger contract: nil Logger means silent (no panic)
+func TestLogger_nilIsSilent(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Logger:             nil,
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+}
+
+// Logger contract: custom implementation receives progress calls
+func TestLogger_customImplementation(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	captured := &captureLogger{}
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Logger:             captured,
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, captured.entries, "custom Logger should receive progress calls")
+}
+
+// Error path: no upstreams in state and no override → error mentions integrate
+func TestCheckDrift_noStateNoOverride_errors(t *testing.T) {
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gitspork integrate")
+}
+
+// Error path: override URL not in state → error names the URL
+func TestCheckDrift_overrideMissingState_errors(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	writeAndCommit(t, downstreamDir, ".gitspork/marker", "baseline")
+
+	bogus := "file:///tmp/gitspork-never-integrated-sdk-test"
+	_, err = gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+		Upstreams:          []gitspork.UpstreamSpec{{URL: bogus}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), bogus)
+}
+
+// captureLogger implements gitspork.Logger and records calls.
+type captureLogger struct {
+	entries []string
+}
+
+func (c *captureLogger) Log(msg string, args ...any)   { c.entries = append(c.entries, "log: "+msg) }
+func (c *captureLogger) Error(msg string, args ...any) { c.entries = append(c.entries, "err: "+msg) }


### PR DESCRIPTION
## Summary

Final phase of the SDK effort. Promotes gitspork's top-level operations to a public Go SDK at `github.com/rockholla/gitspork/v2`. Ready to tag as v2.0.0 after merge.

**Public API at module root:**
- Functions: `Integrate`, `IntegrateLocal`, `CheckDrift`, `NoopLogger`
- Types: `IntegrateOptions`, `IntegrateLocalOptions`, `CheckDriftOptions`, `UpstreamSpec`, `IntegrateResult`, `IntegratedUpstream`, `DriftReport`, `DriftedFile`, `DownstreamState`, `UpstreamState`, `Logger` (interface)
- Sentinel: `ErrDriftDetected`

**Public options structs slimmed to 4 fields each.** Internal drift-check wiring and legacy single-upstream flag fields removed from public `IntegrateOptions` / `IntegrateLocalOptions`; internal-only fields moved to an unexported `internalRequest`. Drift now uses `internal/integrate.IntegrateForDriftCheck` (an internal-package export).

**Import cycle avoided via type-alias pattern.** The type definitions physically live in `internal/sdktypes/` (renamed from `internal/types/`); the root `gitspork` package uses Go type aliases (`type IntegrateOptions = sdktypes.IntegrateOptions`) to expose them at `gitspork.<Type>`. External consumers see the same API as if types lived at root; internally this avoids the cycle where root imports `internal/drift` and `internal/drift` needs the option types. Aliases split with per-type godoc so `go doc github.com/rockholla/gitspork/v2 <Type>` and pkg.go.dev show type-specific documentation.

**Module path bumped to `/v2`.** Every internal import updated. `main.go` relocated under `cmd/gitspork/`. Build system (`.goreleaser.yaml`, `Makefile`, `test/functional/main_test.go`, `test/examples/main_test.go`) updated to build from the new path.

**New `test/sdk/` tier.** Black-box tests importing `github.com/rockholla/gitspork/v2` as an external caller — covering single/multi-upstream Integrate, IntegrateLocal state-file invariant, CheckDrift no-drift, drift-with-attribution + `ErrDriftDetected` sentinel, `DriftedFile.ColorizedDiff` ANSI content, Logger nil-silent contract, custom Logger implementations, and both error paths. New `sdk-tests` CI job.

**Nil-Logger silence honored throughout.** `internal/logutil.LoggerWriter` (io.Writer over `types.Logger`) routes go-git's clone Progress and migration script stdout/stderr through the caller's Logger. `Logger: nil` on any Options struct genuinely silences all output.

**CLI polish.** `check-drift --verbose` output re-colorized (bold headers, cyan hunks, green additions, red removals). SDK's `DriftedFile.Diff` stays plain text for machine consumers.

**`DriftedFile.ColorizedDiff` field.** SDK exposes an ANSI-colorized version of each per-file diff alongside the plain `Diff`. Always populated regardless of the process's TTY state so SDK consumers can render into arbitrary sinks (Slack webhooks, log aggregators, terminal UIs) without re-implementing colorization. The CLI now consumes this field for its `--verbose` output instead of colorizing at print time.

**Docs + dev-env refresh.**
- Root `README.md` announces SDK availability
- `docs/README.md` gains an SDK usage section
- `CLAUDE.md` fully refreshed (module path, layout, testing, CI, state storage, `resolveUpstreamURL` note)
- `.github/copilot-instructions.md` synced from `CLAUDE.md`
- `.github/PULL_REQUEST_TEMPLATE.md` adds `make test-sdk` to the test-plan checklist
- `.vscode/settings.json` adds `sdk` to the gopls build tags

Design spec: `docs/superpowers/specs/2026-07-03-golang-sdk-design.md` (Phase 3 section)
Implementation plan: `docs/superpowers/plans/2026-07-05-sdk-phase-3-exposure.md`

## Breaking changes for CLI users

None. Every CLI invocation and flag combination continues to work identically. Downstream state files are unchanged; auto-migration of legacy single-upstream state fields continues.

## Breaking changes for Go module consumers

The module path bumped from `github.com/rockholla/gitspork` to `github.com/rockholla/gitspork/v2`. This is Go's Semantic Import Versioning requirement for major version ≥ 2 and is standard for the ecosystem. There were no external Go consumers of the pre-v2 module (`internal/` restriction prevented importing anything meaningful), so this change is theoretical rather than disruptive.

## Test plan

- [x] `make test-unit` passes
- [x] `make test-functional` passes
- [x] `make test-functional-docker` passes
- [x] `make test-examples` passes
- [x] `make test-sdk` passes (new — 10 black-box tests)
- [x] External SDK import smoke test (scratch module with `replace` directive builds and links successfully)
- [ ] Manual sanity: build the CLI (`go build ./cmd/gitspork`) and run `gitspork --help`, `gitspork schema`, `gitspork check-drift --verbose` (color check)

## Post-merge

- Tag `v2.0.0` when ready.
- The `sync-copilot-instructions.yml` workflow will keep `.github/copilot-instructions.md` in sync with `CLAUDE.md` automatically on any future push to main.
- Consider adding a CI job that consumes the tagged v2 module from an external `go.mod` to catch pkg.go.dev / SIV regressions in future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)