### PR TITLE
fix: UpstreamSpec.Version accepts bare tags + commit hashes (short and full)

### DIFF
--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/go-git/go-git/v6"
+	gitconfig "github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/plumbing/transport/http"
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh"
+	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/gobwas/glob"
 	"github.com/goccy/go-yaml"
 	"github.com/rockholla/gitspork/v2/internal/config"
@@ -37,6 +39,8 @@ var (
 	structuredDataJSONExtensions []string = []string{".json"}
 	reSSHURL                               = regexp.MustCompile(`^git@([^:]+):(.+)$`)
 	reHTTPProto                            = regexp.MustCompile(`^https?://`)
+	// commitHashRe matches short (7-char) through full (40-char) git commit hashes.
+	commitHashRe = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
 )
 
 // internalRequest carries wiring needed by integrateOneInternal that is not
@@ -394,24 +398,37 @@ func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest, upstream s
 		authMethod = agentAuth
 	}
 	cloneOptions := &git.CloneOptions{
-		URL:          upstreamURL,
-		SingleBranch: true,
-		Progress:     &logutil.LoggerWriter{L: req.Logger},
+		URL:      upstreamURL,
+		Progress: &logutil.LoggerWriter{L: req.Logger},
 	}
 	if authMethod != nil {
 		cloneOptions.Auth = authMethod
 	}
-	if upstream.Version != "" {
-		refName := fmt.Sprintf("refs/heads/%s", upstream.Version)
-		isTag, err := regexp.MatchString("^tags\\/", upstream.Version)
+
+	// Interpret upstream.Version:
+	//   1. Empty              → clone the default branch (SingleBranch).
+	//   2. Hex hash 7-40 chars → full-history clone; resolve + checkout below.
+	//   3. "tags/..." prefix   → refs/<v> (explicit tag, backward compat).
+	//   4. Otherwise           → probe remote; prefer tag, fall back to branch.
+	versionIsCommitHash := false
+	switch {
+	case upstream.Version == "":
+		cloneOptions.SingleBranch = true
+	case commitHashRe.MatchString(upstream.Version):
+		versionIsCommitHash = true
+		cloneOptions.SingleBranch = false
+	case strings.HasPrefix(upstream.Version, "tags/"):
+		cloneOptions.ReferenceName = plumbing.ReferenceName("refs/" + upstream.Version)
+		cloneOptions.SingleBranch = true
+	default:
+		resolvedRef, err := resolveUpstreamVersionRef(upstreamURL, authMethod, upstream.Version)
 		if err != nil {
-			return "", fmt.Errorf("error processing upstream gitspork repo version to use: %v", err)
+			return "", err
 		}
-		if isTag {
-			refName = fmt.Sprintf("refs/%s", upstream.Version)
-		}
-		cloneOptions.ReferenceName = plumbing.ReferenceName(refName)
+		cloneOptions.ReferenceName = resolvedRef
+		cloneOptions.SingleBranch = true
 	}
+
 	if req.upstreamCommit != "" || req.prevUpstreamCommitHash != "" {
 		// need full history to checkout a specific commit
 		cloneOptions.SingleBranch = false
@@ -432,11 +449,57 @@ func cloneUpstreamForIntegrate(cloneDir string, req *internalRequest, upstream s
 		}
 		return req.upstreamCommit, nil
 	}
+	if versionIsCommitHash {
+		resolvedHash, err := repo.ResolveRevision(plumbing.Revision(upstream.Version))
+		if err != nil {
+			return "", fmt.Errorf("could not resolve upstream version %q as commit: %v", upstream.Version, err)
+		}
+		worktree, err := repo.Worktree()
+		if err != nil {
+			return "", fmt.Errorf("error getting worktree for commit checkout: %v", err)
+		}
+		if err := worktree.Checkout(&git.CheckoutOptions{Hash: *resolvedHash}); err != nil {
+			return "", fmt.Errorf("error checking out commit %s: %v", upstream.Version, err)
+		}
+		return resolvedHash.String(), nil
+	}
 	ref, err := repo.Head()
 	if err != nil {
 		return "", fmt.Errorf("error resolving HEAD commit from upstream clone: %v", err)
 	}
 	return ref.Hash().String(), nil
+}
+
+// resolveUpstreamVersionRef probes the remote to disambiguate a bare Version
+// value between a tag and a branch. Tags win over branches when both exist,
+// matching `git checkout`'s precedence for ambiguous refs.
+func resolveUpstreamVersionRef(url string, auth transport.AuthMethod, version string) (plumbing.ReferenceName, error) {
+	rem := git.NewRemote(memory.NewStorage(), &gitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{url},
+	})
+	refs, err := rem.List(&git.ListOptions{Auth: auth})
+	if err != nil {
+		return "", fmt.Errorf("could not list remote refs to resolve upstream version %q: %v", version, err)
+	}
+	tagRef := plumbing.ReferenceName("refs/tags/" + version)
+	branchRef := plumbing.ReferenceName("refs/heads/" + version)
+	var haveTag, haveBranch bool
+	for _, r := range refs {
+		switch r.Name() {
+		case tagRef:
+			haveTag = true
+		case branchRef:
+			haveBranch = true
+		}
+	}
+	if haveTag {
+		return tagRef, nil
+	}
+	if haveBranch {
+		return branchRef, nil
+	}
+	return "", fmt.Errorf("upstream version %q not found as branch or tag on remote", version)
 }
 
 func getIntegrateFiles(inDir string, configuredGlobPatterns []string) ([]string, error) {

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -177,6 +177,89 @@ func TestIntegrateForDriftCheck_honors_UpstreamCommit(t *testing.T) {
 		"IntegrateForDriftCheck with UpstreamCommit set to v1 should produce v1 content, not HEAD (v2)")
 }
 
+// upstreamWithTag builds on testharness.MinimalUpstream by creating a
+// lightweight tag pointing at HEAD. Returns the repo dir and the commit hash.
+func upstreamWithTag(t *testing.T, tagName string) (string, plumbing.Hash) {
+	t.Helper()
+	dir, hash := testharness.MinimalUpstream(t)
+	repo, err := gogit.PlainOpen(dir)
+	require.NoError(t, err)
+	_, err = repo.CreateTag(tagName, hash, nil)
+	require.NoError(t, err)
+	return dir, hash
+}
+
+func TestIntegrate_version_bareTag(t *testing.T) {
+	upstreamDir, upstreamHash := upstreamWithTag(t, "v1.0.0")
+	downstreamDir := testharness.EmptyDownstream(t)
+
+	result, err := Integrate(&sdktypes.IntegrateOptions{
+		Logger:             logutil.New(),
+		Upstreams:          []sdktypes.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "v1.0.0"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "bare tag name should resolve as a tag")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+func TestIntegrate_version_tagsPrefixed(t *testing.T) {
+	upstreamDir, upstreamHash := upstreamWithTag(t, "v1.0.0")
+	downstreamDir := testharness.EmptyDownstream(t)
+
+	result, err := Integrate(&sdktypes.IntegrateOptions{
+		Logger:             logutil.New(),
+		Upstreams:          []sdktypes.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "tags/v1.0.0"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "tags/ prefix should still work (backward compat)")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+func TestIntegrate_version_fullCommitHash(t *testing.T) {
+	upstreamDir, upstreamHash := testharness.MinimalUpstream(t)
+	downstreamDir := testharness.EmptyDownstream(t)
+
+	result, err := Integrate(&sdktypes.IntegrateOptions{
+		Logger:             logutil.New(),
+		Upstreams:          []sdktypes.UpstreamSpec{{URL: "file://" + upstreamDir, Version: upstreamHash.String()}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "full commit hash should be resolvable")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+func TestIntegrate_version_shortCommitHash(t *testing.T) {
+	upstreamDir, upstreamHash := testharness.MinimalUpstream(t)
+	downstreamDir := testharness.EmptyDownstream(t)
+	shortHash := upstreamHash.String()[:7]
+
+	result, err := Integrate(&sdktypes.IntegrateOptions{
+		Logger:             logutil.New(),
+		Upstreams:          []sdktypes.UpstreamSpec{{URL: "file://" + upstreamDir, Version: shortHash}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "short commit hash should be resolvable")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash,
+		"short hash should resolve to the full commit hash in the result")
+}
+
+func TestIntegrate_version_unknownRef(t *testing.T) {
+	upstreamDir, _ := testharness.MinimalUpstream(t)
+	downstreamDir := testharness.EmptyDownstream(t)
+
+	_, err := Integrate(&sdktypes.IntegrateOptions{
+		Logger:             logutil.New(),
+		Upstreams:          []sdktypes.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "no-such-ref"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.Error(t, err, "unknown ref should fail with a clear error")
+	assert.Contains(t, err.Error(), "no-such-ref", "error should name the unresolved ref")
+}
+
 func TestIntegrate_returns_result_with_upstream_url_and_hash(t *testing.T) {
 	upstreamDir, upstreamHash := testharness.MinimalUpstream(t)
 	downstreamDir := testharness.EmptyDownstream(t)

--- a/internal/sdktypes/options.go
+++ b/internal/sdktypes/options.go
@@ -28,6 +28,19 @@ type CheckDriftOptions struct {
 }
 
 // UpstreamSpec identifies a single upstream to integrate from.
+//
+// Version may be one of:
+//   - A branch name (e.g. "main", "feature/x") — resolved as refs/heads/<v>.
+//   - A tag name (e.g. "v1.2.3") — resolved as refs/tags/<v>. When both a
+//     branch and a tag share a name (rare), the tag wins, matching
+//     `git checkout`'s precedence for ambiguous refs.
+//   - An explicit "tags/<name>" form — always treated as a tag, useful
+//     when the caller wants to bypass tag/branch disambiguation.
+//   - A commit hash — 7 to 40 hex characters, short or full. The upstream
+//     is cloned with full history and the hash is resolved via git's
+//     revision parser, so `abc1234` and the full 40-char SHA both work.
+//
+// An empty Version selects the remote's default branch.
 type UpstreamSpec struct {
 	URL     string
 	Version string


### PR DESCRIPTION
## Summary

Before this change, \`UpstreamSpec.Version\` only worked for branch names and the explicit \`tags/<name>\` form. Users writing a bare tag (\`v1.2.3\`), a short commit hash (\`abc1234\`), or a full 40-char commit hash all silently mis-routed to a branch lookup and failed with \`couldn't find remote ref: refs/heads/<...>\`.

The docs (root README, \`docs/README.md\`, CLI \`--upstream-repo-version\` help text) all imply \`[branch, tag, or commit hash]\` are supported — this fixes the code to match.

## Disambiguation logic

1. **Empty** → clone the remote's default branch (unchanged)
2. **Hex hash 7–40 chars** — full-history clone + \`ResolveRevision\` + \`Checkout(Hash: …)\`. Handles both short (\`abc1234\`) and full-length hashes.
3. **\`tags/<name>\` prefix** → \`refs/<v>\` (backward compat, unchanged)
4. **Otherwise** — probe the remote via \`git ls-remote\`; prefer tag over branch when both exist (matches \`git checkout\`'s precedence), error clearly if neither matches.

The public godoc on \`UpstreamSpec.Version\` documents the rules explicitly so SDK consumers know exactly what's supported.

## Tests

Added 5 new tests to \`internal/integrate/integrate_test.go\`:
- \`TestIntegrate_version_bareTag\` — \`Version: "v1.0.0"\` resolves as tag
- \`TestIntegrate_version_tagsPrefixed\` — \`Version: "tags/v1.0.0"\` still works
- \`TestIntegrate_version_fullCommitHash\` — 40-char hash resolves via \`ResolveRevision\`
- \`TestIntegrate_version_shortCommitHash\` — 7-char hash resolves; result still contains full hash
- \`TestIntegrate_version_unknownRef\` — \`Version: "no-such-ref"\` fails with a clear error naming the ref

RED confirmed for the three failing cases before the fix; all 5 pass after.

## Backward compatibility

- All existing callers that pass branch names continue to work identically.
- \`tags/<name>\` form continues to work.
- Cost trade-off: unqualified names (\`v1.2.3\`, \`main\`) now do one \`ls-remote\` before the clone. Fast (single lightweight RPC), and avoids the previous silent-failure mode.

## Test plan

- [x] \`make test-unit\` passes (5 new tests + no regressions)
- [x] \`make test-functional\` passes
- [x] \`make test-sdk\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)