### PR TITLE
feat: fail fast when git binary is missing from PATH

### DIFF
--- a/gitspork.go
+++ b/gitspork.go
@@ -80,6 +80,13 @@ type Logger = sdktypes.Logger
 // downstream relative to its recorded upstream state.
 var ErrDriftDetected = sdktypes.ErrDriftDetected
 
+// ErrGitBinaryMissing is returned by CheckDrift (and the CLI's mv/rm subcommands)
+// when the git binary is not found on PATH. gitspork uses go-git for most git
+// operations, but a few paths — reading the downstream's working-tree cleanliness,
+// staging renames/removals from `gitspork mv` and `gitspork rm` — require the
+// git CLI. Detect via errors.Is(err, gitspork.ErrGitBinaryMissing).
+var ErrGitBinaryMissing = sdktypes.ErrGitBinaryMissing
+
 // NoopLogger returns a Logger implementation that discards all messages.
 // SDK consumers can pass this (or nil, which is treated equivalently by the
 // coordinator entry-points) to silence gitspork output.

--- a/internal/cli/mv.go
+++ b/internal/cli/mv.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/gitbin"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,9 @@ func (s *MvSubcommand) GetCmd() *cobra.Command {
 		Long:               fmt.Sprintf("%s\n\n%s", mvHelpShort, mvHelpLong),
 		DisableFlagParsing: true,
 		Args:               cobra.MinimumNArgs(2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return gitbin.Require()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath, err := config.FindGitSporkConfig(".")
 			if err != nil {

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/gitbin"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,9 @@ func (s *RmSubcommand) GetCmd() *cobra.Command {
 		Long:               fmt.Sprintf("%s\n\n%s", rmHelpShort, rmHelpLong),
 		DisableFlagParsing: true,
 		Args:               cobra.MinimumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return gitbin.Require()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			recursive := slices.Contains(args, "-r")
 

--- a/internal/drift/check_drift.go
+++ b/internal/drift/check_drift.go
@@ -16,6 +16,7 @@ import (
 	fdiff "github.com/go-git/go-git/v6/plumbing/format/diff"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/gitbin"
 	"github.com/rockholla/gitspork/v2/internal/integrate"
 	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
@@ -30,6 +31,12 @@ func CheckDrift(opts *sdktypes.CheckDriftOptions) (*sdktypes.DriftReport, error)
 
 	if opts.Logger == nil {
 		opts.Logger = sdktypes.NoopLogger()
+	}
+
+	// Fail fast if the git binary is not available: the working-tree cleanliness
+	// check below (checkCleanWorkingTree) shells out to git.
+	if err := gitbin.Require(); err != nil {
+		return report, err
 	}
 
 	if opts.DownstreamRepoPath == "" {

--- a/internal/gitbin/gitbin.go
+++ b/internal/gitbin/gitbin.go
@@ -1,0 +1,23 @@
+// Package gitbin centralizes the fail-fast check for the git binary in PATH.
+// gitspork uses go-git for most git operations, but a small number of paths
+// (CheckDrift's working-tree cleanliness check, `gitspork mv`, `gitspork rm`)
+// still shell out to the git CLI. Callers on those paths invoke Require() at
+// entry so users get a clear error before any work has been done.
+package gitbin
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
+)
+
+// Require returns nil when the git binary is on PATH. When missing, it returns
+// a wrapped sdktypes.ErrGitBinaryMissing with an actionable message. SDK
+// consumers can detect the failure with errors.Is(err, gitspork.ErrGitBinaryMissing).
+func Require() error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return fmt.Errorf("%w: %v — install git and ensure it is on PATH", sdktypes.ErrGitBinaryMissing, err)
+	}
+	return nil
+}

--- a/internal/gitbin/gitbin_test.go
+++ b/internal/gitbin/gitbin_test.go
@@ -1,0 +1,32 @@
+package gitbin
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
+)
+
+func TestRequire_present(t *testing.T) {
+	// Sanity check: the test host should have git installed.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed on this host; cannot test the happy path")
+	}
+	require.NoError(t, Require())
+}
+
+func TestRequire_missing(t *testing.T) {
+	// Scrub PATH so exec.LookPath cannot find git.
+	t.Setenv("PATH", "/nonexistent-path-for-gitspork-tests")
+
+	err := Require()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sdktypes.ErrGitBinaryMissing),
+		"error should wrap sdktypes.ErrGitBinaryMissing so callers can errors.Is against it")
+	assert.Contains(t, err.Error(), "install git",
+		"error message should point users at the fix")
+}

--- a/internal/sdktypes/errors.go
+++ b/internal/sdktypes/errors.go
@@ -4,3 +4,8 @@ import "errors"
 
 // ErrDriftDetected is returned by CheckDrift when drift is found in the downstream.
 var ErrDriftDetected = errors.New("drift detected")
+
+// ErrGitBinaryMissing is returned when gitspork needs to shell out to the git
+// binary but it is not present on PATH. SDK consumers can check via
+// errors.Is(err, gitspork.ErrGitBinaryMissing) to detect this condition.
+var ErrGitBinaryMissing = errors.New("git binary not found on PATH")

--- a/test/sdk/sdk_test.go
+++ b/test/sdk/sdk_test.go
@@ -183,6 +183,21 @@ func TestCheckDrift_overrideMissingState_errors(t *testing.T) {
 	assert.Contains(t, err.Error(), bogus)
 }
 
+// CheckDrift fails fast with gitspork.ErrGitBinaryMissing when git is not on PATH.
+func TestCheckDrift_gitBinaryMissing_errorsWithSentinel(t *testing.T) {
+	downstreamDir := emptyDownstream(t)
+
+	// Scrub PATH so exec.LookPath cannot find git.
+	t.Setenv("PATH", "/nonexistent-path-for-gitspork-tests")
+
+	_, err := gitspork.CheckDrift(&gitspork.CheckDriftOptions{
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, gitspork.ErrGitBinaryMissing),
+		"CheckDrift should fail with ErrGitBinaryMissing when git is not on PATH")
+}
+
 // captureLogger implements gitspork.Logger and records calls.
 type captureLogger struct {
 	entries []string


### PR DESCRIPTION
## Summary

gitspork uses go-git for most git operations but still shells out to the \`git\` binary in three places:

- \`CheckDrift\`'s working-tree cleanliness check (SDK + CLI path)
- \`gitspork mv\` (CLI-only)
- \`gitspork rm\` (CLI-only)

Before this change, a missing git binary produced a generic \`exec: \"git\": executable file not found in $PATH\` mid-flow, after meaningful work had already been done. Now each entry point calls a small \`internal/gitbin.Require()\` helper up-front that returns an actionable error.

## New public sentinel

\`gitspork.ErrGitBinaryMissing\` lets SDK consumers detect the failure programmatically:

\`\`\`go
_, err := gitspork.CheckDrift(opts)
if errors.Is(err, gitspork.ErrGitBinaryMissing) {
    // guide the user to install git
}
\`\`\`

## Scope discipline

\`Integrate\` and \`IntegrateLocal\` do NOT call \`Require()\` — those paths use go-git and don't need the binary. An SDK consumer that only calls \`Integrate\` never sees a false-positive missing-git error.

## Tests

- \`internal/gitbin/gitbin_test.go\` — happy path (skips gracefully if the host has no git) + missing-git path with scrubbed PATH; asserts the wrapped error satisfies \`errors.Is(err, sdktypes.ErrGitBinaryMissing)\` and the message points at the fix
- \`test/sdk/sdk_test.go\` — new \`TestCheckDrift_gitBinaryMissing_errorsWithSentinel\` verifies the SDK-side sentinel behavior from an external caller's perspective

## Test plan

- [x] \`make test-unit\` passes (2 new tests in \`internal/gitbin\`)
- [x] \`make test-functional\` passes
- [x] \`make test-sdk\` passes (1 new test)
- [ ] Manual: \`PATH=/nonexistent gitspork check-drift\` → clear error naming git; \`PATH=/nonexistent gitspork mv a b\` → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)