### PR TITLE
Order-preserving deep merge for structured shared-ownership integrators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/rockholla/gitspork/v2
 go 1.26.0
 
 require (
-	dario.cat/mergo v1.0.1
 	github.com/buger/goterm v1.0.4
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v6 v6.0.0-20250701074610-5d6af409877b
@@ -16,6 +15,7 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/gobwas/glob"
-	"github.com/goccy/go-yaml"
 	"github.com/rockholla/gitspork/v2/internal/config"
 	"github.com/rockholla/gitspork/v2/internal/logutil"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
@@ -589,11 +588,7 @@ func syncFile(src, dst string) error {
 	return nil
 }
 
-func getStructuredData(upstreamPath string, downstreamPath string) (*map[string]any, *map[string]any, string, error) {
-	var err error
-	upstreamData := &map[string]any{}
-	downstreamData := &map[string]any{}
-
+func getStructuredData(upstreamPath string, downstreamPath string) (*node, *node, string, error) {
 	structuredDataType := ""
 	for _, yamlExt := range structuredDataYAMLExtensions {
 		if filepath.Ext(upstreamPath) == yamlExt {
@@ -606,62 +601,51 @@ func getStructuredData(upstreamPath string, downstreamPath string) (*map[string]
 		}
 	}
 	if structuredDataType == "" {
-		return upstreamData, downstreamData, "", fmt.Errorf("upstream file %s is not a supported structured data file, supported: %v", upstreamPath, append(structuredDataYAMLExtensions, structuredDataJSONExtensions...))
+		return nil, nil, "", fmt.Errorf("upstream file %s is not a supported structured data file, supported: %v", upstreamPath, append(structuredDataYAMLExtensions, structuredDataJSONExtensions...))
 	}
 
-	upstreamPathBytes, err := os.ReadFile(upstreamPath)
+	upstreamBytes, err := os.ReadFile(upstreamPath)
 	if err != nil {
-		return upstreamData, downstreamData, structuredDataType, fmt.Errorf("error reading file %s", upstreamPath)
+		return nil, nil, structuredDataType, fmt.Errorf("error reading file %s", upstreamPath)
 	}
 	if _, err := os.Stat(downstreamPath); os.IsNotExist(err) {
-		// the downstream doesn't exist yet, we can just copy the file
 		if err := syncFile(upstreamPath, downstreamPath); err != nil {
-			return upstreamData, downstreamData, structuredDataType, fmt.Errorf("error copying structured data file %s to downstream: %v", upstreamPath, err)
+			return nil, nil, structuredDataType, fmt.Errorf("error copying structured data file %s to downstream: %v", upstreamPath, err)
 		}
 	}
-	downstreamPathBytes, err := os.ReadFile(downstreamPath)
+	downstreamBytes, err := os.ReadFile(downstreamPath)
 	if err != nil {
-		return upstreamData, downstreamData, structuredDataType, fmt.Errorf("error reading file %s", upstreamPath)
-	}
-	switch structuredDataType {
-	case structuredDataTypeYAML:
-		if err := yaml.Unmarshal(upstreamPathBytes, upstreamData); err != nil {
-			return upstreamData, downstreamData, structuredDataType, fmt.Errorf("error parsing upstream file %s: %v", upstreamPath, err)
-		}
-		if err := yaml.Unmarshal(downstreamPathBytes, downstreamData); err != nil {
-			return upstreamData, downstreamData, structuredDataType, fmt.Errorf("error parsing downstream file %s: %v", upstreamPath, err)
-		}
-	case structuredDataTypeJSON:
-		if err := json.Unmarshal(upstreamPathBytes, upstreamData); err != nil {
-			return upstreamData, downstreamData, structuredDataType, fmt.Errorf("error parsing upstream file %s: %v", upstreamPath, err)
-		}
-		if err := json.Unmarshal(downstreamPathBytes, downstreamData); err != nil {
-			return upstreamData, downstreamData, structuredDataType, fmt.Errorf("error parsing downstream file %s: %v", upstreamPath, err)
-		}
+		return nil, nil, structuredDataType, fmt.Errorf("error reading file %s", downstreamPath)
 	}
 
-	return upstreamData, downstreamData, structuredDataType, err
+	parse := parseYAML
+	if structuredDataType == structuredDataTypeJSON {
+		parse = parseJSON
+	}
+	upstreamNode, err := parse(upstreamBytes)
+	if err != nil {
+		return nil, nil, structuredDataType, fmt.Errorf("error parsing upstream file %s: %v", upstreamPath, err)
+	}
+	downstreamNode, err := parse(downstreamBytes)
+	if err != nil {
+		return nil, nil, structuredDataType, fmt.Errorf("error parsing downstream file %s: %v", downstreamPath, err)
+	}
+	return upstreamNode, downstreamNode, structuredDataType, nil
 }
 
-func writeStructuredData(structuredData *map[string]interface{}, structuredDataType string, toPath string) error {
+func writeStructuredData(data *node, structuredDataType string, toPath string) error {
 	var b []byte
 	var err error
 	switch structuredDataType {
 	case structuredDataTypeYAML:
-		b, err = yaml.Marshal(structuredData)
-		if err != nil {
-			return err
-		}
+		b, err = writeYAML(data)
 	case structuredDataTypeJSON:
-		b, err = json.MarshalIndent(structuredData, "", "  ")
-		if err != nil {
-			return err
-		}
+		b, err = writeJSON(data)
 	}
-	if err := os.WriteFile(toPath, b, 0644); err != nil {
+	if err != nil {
 		return err
 	}
-	return nil
+	return os.WriteFile(toPath, b, 0644)
 }
 
 func ensureDownstreamMetaDir(downstreamRepoPath string) (string, error) {

--- a/internal/integrate/integrator_shared_ownership_structured_prefer_downstream.go
+++ b/internal/integrate/integrator_shared_ownership_structured_prefer_downstream.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"dario.cat/mergo"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
@@ -21,15 +20,13 @@ func (i *IntegratorSharedOwnershipStructuredPreferDownstream) Integrate(configur
 	}
 	for _, integrateFile := range integrateFiles {
 		logger.Log("📝 gathering structured data for %s", integrateFile)
-		upstreamStructuredData, downstreamStructuredData, structuredDataType, err := getStructuredData(filepath.Join(upstreamPath, integrateFile), filepath.Join(downstreamPath, integrateFile))
+		upstreamData, downstreamData, structuredDataType, err := getStructuredData(filepath.Join(upstreamPath, integrateFile), filepath.Join(downstreamPath, integrateFile))
 		if err != nil {
 			return err
 		}
 		logger.Log("🔧 merging upstream and downstream data, prefering downstream data")
-		if err := mergo.Merge(upstreamStructuredData, *downstreamStructuredData, mergo.WithOverride); err != nil {
-			return fmt.Errorf("error merging structured data from %s to downstream: %v", integrateFile, err)
-		}
-		if err := writeStructuredData(upstreamStructuredData, structuredDataType, filepath.Join(downstreamPath, integrateFile)); err != nil {
+		merged := mergeNodes(upstreamData, downstreamData, true)
+		if err := writeStructuredData(merged, structuredDataType, filepath.Join(downstreamPath, integrateFile)); err != nil {
 			return fmt.Errorf("error writing merged structured data: %v", err)
 		}
 	}

--- a/internal/integrate/integrator_shared_ownership_structured_prefer_upstream.go
+++ b/internal/integrate/integrator_shared_ownership_structured_prefer_upstream.go
@@ -29,7 +29,7 @@ func (i *IntegratorSharedOwnershipStructuredPreferUpstream) Integrate(configured
 		if err := mergo.Merge(downstreamStructuredData, *upstreamStructuredData, mergo.WithOverride); err != nil {
 			return fmt.Errorf("error merging structured data from %s to downstream: %v", integrateFile, err)
 		}
-		if err := writeStructuredData(upstreamStructuredData, structuredDataType, filepath.Join(downstreamPath, integrateFile)); err != nil {
+		if err := writeStructuredData(downstreamStructuredData, structuredDataType, filepath.Join(downstreamPath, integrateFile)); err != nil {
 			return fmt.Errorf("error writing merged structured data: %v", err)
 		}
 	}

--- a/internal/integrate/integrator_shared_ownership_structured_prefer_upstream.go
+++ b/internal/integrate/integrator_shared_ownership_structured_prefer_upstream.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"dario.cat/mergo"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 )
 
@@ -21,15 +20,13 @@ func (i *IntegratorSharedOwnershipStructuredPreferUpstream) Integrate(configured
 	}
 	for _, integrateFile := range integrateFiles {
 		logger.Log("📝 gathering structured data for %s", integrateFile)
-		upstreamStructuredData, downstreamStructuredData, structuredDataType, err := getStructuredData(filepath.Join(upstreamPath, integrateFile), filepath.Join(downstreamPath, integrateFile))
+		upstreamData, downstreamData, structuredDataType, err := getStructuredData(filepath.Join(upstreamPath, integrateFile), filepath.Join(downstreamPath, integrateFile))
 		if err != nil {
 			return err
 		}
 		logger.Log("🔧 merging upstream and downstream data, prefering upstream data")
-		if err := mergo.Merge(downstreamStructuredData, *upstreamStructuredData, mergo.WithOverride); err != nil {
-			return fmt.Errorf("error merging structured data from %s to downstream: %v", integrateFile, err)
-		}
-		if err := writeStructuredData(downstreamStructuredData, structuredDataType, filepath.Join(downstreamPath, integrateFile)); err != nil {
+		merged := mergeNodes(downstreamData, upstreamData, true)
+		if err := writeStructuredData(merged, structuredDataType, filepath.Join(downstreamPath, integrateFile)); err != nil {
 			return fmt.Errorf("error writing merged structured data: %v", err)
 		}
 	}

--- a/internal/integrate/integrator_shared_ownership_test.go
+++ b/internal/integrate/integrator_shared_ownership_test.go
@@ -1,0 +1,190 @@
+package integrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupStructuredPair(t *testing.T, filename, upstreamContent, downstreamContent string) (string, string) {
+	t.Helper()
+	upstreamDir := t.TempDir()
+	downstreamDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, filename), []byte(upstreamContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(downstreamDir, filename), []byte(downstreamContent), 0644))
+	return upstreamDir, downstreamDir
+}
+
+func readYAMLMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	m := map[string]any{}
+	require.NoError(t, yaml.Unmarshal(b, &m))
+	return m
+}
+
+func readJSONMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	m := map[string]any{}
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+func TestIntegratorSharedOwnershipStructuredPreferUpstream_YAML(t *testing.T) {
+	upstreamYAML := "shared_key: from-upstream\nupstream_only: value-u\n"
+	downstreamYAML := "shared_key: from-downstream\ndownstream_only: value-d\n"
+	upstreamDir, downstreamDir := setupStructuredPair(t, "config.yaml", upstreamYAML, downstreamYAML)
+
+	integrator := &IntegratorSharedOwnershipStructuredPreferUpstream{}
+	require.NoError(t, integrator.Integrate([]string{"config.yaml"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+	result := readYAMLMap(t, filepath.Join(downstreamDir, "config.yaml"))
+
+	t.Run("upstream wins on collision", func(t *testing.T) {
+		assert.Equal(t, "from-upstream", result["shared_key"])
+	})
+	t.Run("upstream-only keys land in downstream", func(t *testing.T) {
+		assert.Equal(t, "value-u", result["upstream_only"])
+	})
+	t.Run("downstream-only keys survive", func(t *testing.T) {
+		assert.Equal(t, "value-d", result["downstream_only"],
+			"downstream-only keys should be preserved in a prefer-upstream merge (shared ownership means downstream can add keys of its own)")
+	})
+}
+
+func TestIntegratorSharedOwnershipStructuredPreferUpstream_JSON(t *testing.T) {
+	upstreamJSON := `{"shared_key":"from-upstream","upstream_only":"value-u"}`
+	downstreamJSON := `{"shared_key":"from-downstream","downstream_only":"value-d"}`
+	upstreamDir, downstreamDir := setupStructuredPair(t, "config.json", upstreamJSON, downstreamJSON)
+
+	integrator := &IntegratorSharedOwnershipStructuredPreferUpstream{}
+	require.NoError(t, integrator.Integrate([]string{"config.json"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+	result := readJSONMap(t, filepath.Join(downstreamDir, "config.json"))
+
+	t.Run("upstream wins on collision", func(t *testing.T) {
+		assert.Equal(t, "from-upstream", result["shared_key"])
+	})
+	t.Run("upstream-only keys land in downstream", func(t *testing.T) {
+		assert.Equal(t, "value-u", result["upstream_only"])
+	})
+	t.Run("downstream-only keys survive", func(t *testing.T) {
+		assert.Equal(t, "value-d", result["downstream_only"],
+			"downstream-only keys should be preserved in a prefer-upstream merge (shared ownership means downstream can add keys of its own)")
+	})
+}
+
+func TestIntegratorSharedOwnershipStructuredPreferDownstream_YAML(t *testing.T) {
+	upstreamYAML := "shared_key: from-upstream\nupstream_only: value-u\n"
+	downstreamYAML := "shared_key: from-downstream\ndownstream_only: value-d\n"
+	upstreamDir, downstreamDir := setupStructuredPair(t, "config.yaml", upstreamYAML, downstreamYAML)
+
+	integrator := &IntegratorSharedOwnershipStructuredPreferDownstream{}
+	require.NoError(t, integrator.Integrate([]string{"config.yaml"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+	result := readYAMLMap(t, filepath.Join(downstreamDir, "config.yaml"))
+
+	t.Run("downstream wins on collision", func(t *testing.T) {
+		assert.Equal(t, "from-downstream", result["shared_key"])
+	})
+	t.Run("downstream-only keys survive", func(t *testing.T) {
+		assert.Equal(t, "value-d", result["downstream_only"])
+	})
+	t.Run("upstream-only keys land in downstream", func(t *testing.T) {
+		assert.Equal(t, "value-u", result["upstream_only"])
+	})
+}
+
+func TestIntegratorSharedOwnershipStructuredPreferDownstream_JSON(t *testing.T) {
+	upstreamJSON := `{"shared_key":"from-upstream","upstream_only":"value-u"}`
+	downstreamJSON := `{"shared_key":"from-downstream","downstream_only":"value-d"}`
+	upstreamDir, downstreamDir := setupStructuredPair(t, "config.json", upstreamJSON, downstreamJSON)
+
+	integrator := &IntegratorSharedOwnershipStructuredPreferDownstream{}
+	require.NoError(t, integrator.Integrate([]string{"config.json"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+	result := readJSONMap(t, filepath.Join(downstreamDir, "config.json"))
+
+	t.Run("downstream wins on collision", func(t *testing.T) {
+		assert.Equal(t, "from-downstream", result["shared_key"])
+	})
+	t.Run("downstream-only keys survive", func(t *testing.T) {
+		assert.Equal(t, "value-d", result["downstream_only"])
+	})
+	t.Run("upstream-only keys land in downstream", func(t *testing.T) {
+		assert.Equal(t, "value-u", result["upstream_only"])
+	})
+}
+
+func TestIntegratorSharedOwnershipMerged(t *testing.T) {
+	beginMarker := "# ::gitspork::begin-upstream-owned-block"
+	endMarker := "# ::gitspork::end-upstream-owned-block"
+
+	t.Run("upstream block content replaces downstream block content", func(t *testing.T) {
+		upstream := beginMarker + "\nupstream owned line A\nupstream owned line B\n" + endMarker + "\n"
+		downstream := beginMarker + "\nstale downstream block content\n" + endMarker + "\n"
+		upstreamDir, downstreamDir := setupStructuredPair(t, "Makefile", upstream, downstream)
+
+		integrator := &IntegratorSharedOwnershipMerged{}
+		require.NoError(t, integrator.Integrate([]string{"Makefile"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+		got, err := os.ReadFile(filepath.Join(downstreamDir, "Makefile"))
+		require.NoError(t, err)
+		assert.Contains(t, string(got), "upstream owned line A")
+		assert.Contains(t, string(got), "upstream owned line B")
+		assert.NotContains(t, string(got), "stale downstream block content")
+	})
+
+	t.Run("downstream lines outside upstream blocks are preserved", func(t *testing.T) {
+		upstream := beginMarker + "\nupstream owned\n" + endMarker + "\n"
+		downstream := "downstream-only line above\n" +
+			beginMarker + "\nstale\n" + endMarker + "\n" +
+			"downstream-only line below\n"
+		upstreamDir, downstreamDir := setupStructuredPair(t, "Makefile", upstream, downstream)
+
+		integrator := &IntegratorSharedOwnershipMerged{}
+		require.NoError(t, integrator.Integrate([]string{"Makefile"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+		got, err := os.ReadFile(filepath.Join(downstreamDir, "Makefile"))
+		require.NoError(t, err)
+		assert.Contains(t, string(got), "downstream-only line above")
+		assert.Contains(t, string(got), "downstream-only line below")
+		assert.Contains(t, string(got), "upstream owned")
+		assert.NotContains(t, string(got), "stale")
+
+		aboveIdx := strings.Index(string(got), "downstream-only line above")
+		upstreamIdx := strings.Index(string(got), "upstream owned")
+		belowIdx := strings.Index(string(got), "downstream-only line below")
+		assert.True(t, aboveIdx < upstreamIdx && upstreamIdx < belowIdx,
+			"downstream lines should retain their original relative position around the upstream block")
+	})
+
+	t.Run("upstream block appended when missing in downstream", func(t *testing.T) {
+		upstream := beginMarker + "\nfresh upstream content\n" + endMarker + "\n"
+		downstream := "downstream only content\nno markers here\n"
+		upstreamDir, downstreamDir := setupStructuredPair(t, "Makefile", upstream, downstream)
+
+		integrator := &IntegratorSharedOwnershipMerged{}
+		require.NoError(t, integrator.Integrate([]string{"Makefile"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+		got, err := os.ReadFile(filepath.Join(downstreamDir, "Makefile"))
+		require.NoError(t, err)
+		assert.Contains(t, string(got), "downstream only content")
+		assert.Contains(t, string(got), "fresh upstream content")
+
+		downstreamIdx := strings.Index(string(got), "downstream only content")
+		upstreamIdx := strings.Index(string(got), "fresh upstream content")
+		assert.True(t, downstreamIdx < upstreamIdx,
+			"an upstream block not present in downstream should be appended after existing downstream content")
+	})
+}

--- a/internal/integrate/integrator_shared_ownership_test.go
+++ b/internal/integrate/integrator_shared_ownership_test.go
@@ -40,6 +40,24 @@ func readJSONMap(t *testing.T, path string) map[string]any {
 	return m
 }
 
+func readOrderedYAMLKeys(t *testing.T, path string) []string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	n, err := parseYAML(b)
+	require.NoError(t, err)
+	return n.mapping.Keys()
+}
+
+func readOrderedJSONKeys(t *testing.T, path string) []string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	n, err := parseJSON(b)
+	require.NoError(t, err)
+	return n.mapping.Keys()
+}
+
 func TestIntegratorSharedOwnershipStructuredPreferUpstream_YAML(t *testing.T) {
 	upstreamYAML := "shared_key: from-upstream\nupstream_only: value-u\n"
 	downstreamYAML := "shared_key: from-downstream\ndownstream_only: value-d\n"
@@ -59,6 +77,9 @@ func TestIntegratorSharedOwnershipStructuredPreferUpstream_YAML(t *testing.T) {
 	t.Run("downstream-only keys survive", func(t *testing.T) {
 		assert.Equal(t, "value-d", result["downstream_only"],
 			"downstream-only keys should be preserved in a prefer-upstream merge (shared ownership means downstream can add keys of its own)")
+	})
+	t.Run("preserves upstream key order first, downstream-only appended", func(t *testing.T) {
+		assert.Equal(t, []string{"shared_key", "upstream_only", "downstream_only"}, readOrderedYAMLKeys(t, filepath.Join(downstreamDir, "config.yaml")))
 	})
 }
 
@@ -82,6 +103,9 @@ func TestIntegratorSharedOwnershipStructuredPreferUpstream_JSON(t *testing.T) {
 		assert.Equal(t, "value-d", result["downstream_only"],
 			"downstream-only keys should be preserved in a prefer-upstream merge (shared ownership means downstream can add keys of its own)")
 	})
+	t.Run("preserves upstream key order first, downstream-only appended", func(t *testing.T) {
+		assert.Equal(t, []string{"shared_key", "upstream_only", "downstream_only"}, readOrderedJSONKeys(t, filepath.Join(downstreamDir, "config.json")))
+	})
 }
 
 func TestIntegratorSharedOwnershipStructuredPreferDownstream_YAML(t *testing.T) {
@@ -103,6 +127,9 @@ func TestIntegratorSharedOwnershipStructuredPreferDownstream_YAML(t *testing.T) 
 	t.Run("upstream-only keys land in downstream", func(t *testing.T) {
 		assert.Equal(t, "value-u", result["upstream_only"])
 	})
+	t.Run("preserves downstream key order first, upstream-only appended", func(t *testing.T) {
+		assert.Equal(t, []string{"shared_key", "downstream_only", "upstream_only"}, readOrderedYAMLKeys(t, filepath.Join(downstreamDir, "config.yaml")))
+	})
 }
 
 func TestIntegratorSharedOwnershipStructuredPreferDownstream_JSON(t *testing.T) {
@@ -123,6 +150,9 @@ func TestIntegratorSharedOwnershipStructuredPreferDownstream_JSON(t *testing.T) 
 	})
 	t.Run("upstream-only keys land in downstream", func(t *testing.T) {
 		assert.Equal(t, "value-u", result["upstream_only"])
+	})
+	t.Run("preserves downstream key order first, upstream-only appended", func(t *testing.T) {
+		assert.Equal(t, []string{"shared_key", "downstream_only", "upstream_only"}, readOrderedJSONKeys(t, filepath.Join(downstreamDir, "config.json")))
 	})
 }
 

--- a/internal/integrate/integrator_templated.go
+++ b/internal/integrate/integrator_templated.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"text/template"
 
-	"dario.cat/mergo"
 	"github.com/rockholla/gitspork/v2/internal/config"
 	inputpkg "github.com/rockholla/gitspork/v2/internal/input"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
@@ -147,22 +146,16 @@ func (i *IntegratorTemplated) Integrate(templatedInstructions []config.GitSporkC
 				return fmt.Errorf("error writing rendered template to temporary location: %v", err)
 			}
 			newData, existingData, structuredDataType, err := getStructuredData(tmpFilePath, fullDestinationPath)
-			var preferredData *map[string]any
-			var secondaryData *map[string]any
 			if err != nil {
 				return fmt.Errorf("error loading structured data from existing/new template render process in %s: %v", templatedInstruction.Template, err)
 			}
+			var merged *node
 			if performPostMergeStructured == config.TemplatedMergeStructuredPreferDownstream {
-				preferredData = existingData
-				secondaryData = newData
+				merged = mergeNodes(newData, existingData, true)
 			} else {
-				preferredData = newData
-				secondaryData = existingData
+				merged = mergeNodes(existingData, newData, true)
 			}
-			if err := mergo.Merge(secondaryData, *preferredData, mergo.WithOverride); err != nil {
-				return fmt.Errorf("error merging structured data in templated instruction from %s: %v", templatedInstruction.Template, err)
-			}
-			if err := writeStructuredData(preferredData, structuredDataType, fullDestinationPath); err != nil {
+			if err := writeStructuredData(merged, structuredDataType, fullDestinationPath); err != nil {
 				return fmt.Errorf("error writing merged structured data in templated instruction from %s: %v", templatedInstruction.Template, err)
 			}
 		} else {

--- a/internal/integrate/structured_json.go
+++ b/internal/integrate/structured_json.go
@@ -1,0 +1,151 @@
+package integrate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseJSON(data []byte) (*node, error) {
+	if len(data) == 0 {
+		return newMappingNode(), nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	return parseJSONFromToken(dec, tok)
+}
+
+func parseJSONFromToken(dec *json.Decoder, tok json.Token) (*node, error) {
+	if delim, ok := tok.(json.Delim); ok {
+		switch delim {
+		case '{':
+			return parseJSONObject(dec)
+		case '[':
+			return parseJSONArray(dec)
+		default:
+			return nil, fmt.Errorf("unexpected json delim %q", delim)
+		}
+	}
+	return newScalarNode(tok), nil
+}
+
+func parseJSONObject(dec *json.Decoder) (*node, error) {
+	m := newMappingNode()
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected json object key string, got %T", keyTok)
+		}
+		valTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		val, err := parseJSONFromToken(dec, valTok)
+		if err != nil {
+			return nil, err
+		}
+		m.mapping.Set(key, val)
+	}
+	if _, err := dec.Token(); err != nil { // consume '}'
+		return nil, err
+	}
+	return m, nil
+}
+
+func parseJSONArray(dec *json.Decoder) (*node, error) {
+	seq := newSequenceNode()
+	for dec.More() {
+		valTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		val, err := parseJSONFromToken(dec, valTok)
+		if err != nil {
+			return nil, err
+		}
+		seq.seq = append(seq.seq, val)
+	}
+	if _, err := dec.Token(); err != nil { // consume ']'
+		return nil, err
+	}
+	return seq, nil
+}
+
+func writeJSON(n *node) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := writeJSONNode(&buf, n, "", "  "); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeJSONNode(buf *bytes.Buffer, n *node, currentIndent, indentUnit string) error {
+	if n == nil {
+		buf.WriteString("null")
+		return nil
+	}
+	switch n.kind {
+	case nodeScalar:
+		b, err := json.Marshal(n.scalar)
+		if err != nil {
+			return err
+		}
+		buf.Write(b)
+		return nil
+	case nodeMapping:
+		if len(n.mapping.keys) == 0 {
+			buf.WriteString("{}")
+			return nil
+		}
+		buf.WriteString("{\n")
+		inner := currentIndent + indentUnit
+		for i, k := range n.mapping.keys {
+			buf.WriteString(inner)
+			keyBytes, err := json.Marshal(k)
+			if err != nil {
+				return err
+			}
+			buf.Write(keyBytes)
+			buf.WriteString(": ")
+			if err := writeJSONNode(buf, n.mapping.values[k], inner, indentUnit); err != nil {
+				return err
+			}
+			if i < len(n.mapping.keys)-1 {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString(currentIndent)
+		buf.WriteString("}")
+		return nil
+	case nodeSequence:
+		if len(n.seq) == 0 {
+			buf.WriteString("[]")
+			return nil
+		}
+		buf.WriteString("[\n")
+		inner := currentIndent + indentUnit
+		for i, item := range n.seq {
+			buf.WriteString(inner)
+			if err := writeJSONNode(buf, item, inner, indentUnit); err != nil {
+				return err
+			}
+			if i < len(n.seq)-1 {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString(currentIndent)
+		buf.WriteString("]")
+		return nil
+	}
+	return nil
+}

--- a/internal/integrate/structured_json_test.go
+++ b/internal/integrate/structured_json_test.go
@@ -1,0 +1,105 @@
+package integrate
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseJSON_preservesTopLevelKeyOrder(t *testing.T) {
+	in := []byte(`{"zebra":1,"apple":2,"mango":3}`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	require.Equal(t, nodeMapping, n.kind)
+	assert.Equal(t, []string{"zebra", "apple", "mango"}, n.mapping.Keys())
+}
+
+func TestParseJSON_preservesNestedKeyOrder(t *testing.T) {
+	in := []byte(`{"outer":{"b":"bee","a":"apple"},"other":"value"}`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"outer", "other"}, n.mapping.Keys())
+	outer, ok := n.mapping.Get("outer")
+	require.True(t, ok)
+	assert.Equal(t, []string{"b", "a"}, outer.mapping.Keys())
+}
+
+func TestParseJSON_parsesArrays(t *testing.T) {
+	in := []byte(`{"langs":["go","node","python"]}`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	langs, ok := n.mapping.Get("langs")
+	require.True(t, ok)
+	require.Equal(t, nodeSequence, langs.kind)
+	require.Len(t, langs.seq, 3)
+	assert.Equal(t, "go", langs.seq[0].scalar)
+}
+
+func TestParseJSON_parsesScalarTypes(t *testing.T) {
+	in := []byte(`{"s":"hello","i":42,"f":3.14,"b":true,"n":null}`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+
+	s, _ := n.mapping.Get("s")
+	i, _ := n.mapping.Get("i")
+	f, _ := n.mapping.Get("f")
+	b, _ := n.mapping.Get("b")
+	nul, _ := n.mapping.Get("n")
+
+	assert.Equal(t, "hello", s.scalar)
+	assert.Equal(t, json.Number("42"), i.scalar)
+	assert.Equal(t, json.Number("3.14"), f.scalar)
+	assert.Equal(t, true, b.scalar)
+	assert.Nil(t, nul.scalar)
+}
+
+func TestWriteJSON_roundTripPreservesKeyOrder(t *testing.T) {
+	in := []byte(`{"zebra":1,"apple":2,"mango":3}`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	out, err := writeJSON(n)
+	require.NoError(t, err)
+
+	roundTripped, err := parseJSON(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"zebra", "apple", "mango"}, roundTripped.mapping.Keys())
+}
+
+func TestWriteJSON_roundTripPreservesNestedKeyOrder(t *testing.T) {
+	in := []byte(`{"outer":{"b":"bee","a":"apple"},"other":"value"}`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	out, err := writeJSON(n)
+	require.NoError(t, err)
+
+	roundTripped, err := parseJSON(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"outer", "other"}, roundTripped.mapping.Keys())
+	outer, ok := roundTripped.mapping.Get("outer")
+	require.True(t, ok)
+	assert.Equal(t, []string{"b", "a"}, outer.mapping.Keys())
+}
+
+func TestWriteJSON_usesTwoSpaceIndent(t *testing.T) {
+	n := newMappingNode()
+	n.mapping.Set("a", newScalarNode("one"))
+	n.mapping.Set("b", newScalarNode("two"))
+	out, err := writeJSON(n)
+	require.NoError(t, err)
+	assert.Equal(t, "{\n  \"a\": \"one\",\n  \"b\": \"two\"\n}", string(out))
+}
+
+func TestWriteJSON_emptyStructures(t *testing.T) {
+	t.Run("empty mapping", func(t *testing.T) {
+		out, err := writeJSON(newMappingNode())
+		require.NoError(t, err)
+		assert.Equal(t, "{}", string(out))
+	})
+	t.Run("empty sequence", func(t *testing.T) {
+		out, err := writeJSON(newSequenceNode())
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(out))
+	})
+}

--- a/internal/integrate/structured_merge.go
+++ b/internal/integrate/structured_merge.go
@@ -1,0 +1,99 @@
+package integrate
+
+// mergeNodes returns a merged tree of dst and src. On any collision (differing kinds,
+// scalar-vs-scalar, or scalar within a sequence), the side named by preferSrc wins.
+//
+// Mapping merge is deep: keys present on both sides recurse; keys present on only one
+// side are preserved. Output key order is [preferred-side keys in preferred order,
+// followed by other-side-only keys in their original order].
+//
+// Sequence merge policy depends on element kinds:
+//   - all elements on both sides are scalars → concat + dedupe (preferred first)
+//   - anything else → wholesale replace with the preferred side
+//
+// Nil handling: if one side is nil the other side is returned as-is; if both are nil,
+// nil is returned.
+func mergeNodes(dst, src *node, preferSrc bool) *node {
+	if dst == nil {
+		return src
+	}
+	if src == nil {
+		return dst
+	}
+
+	preferred, other := dst, src
+	if preferSrc {
+		preferred, other = src, dst
+	}
+
+	if preferred.kind != other.kind {
+		return preferred
+	}
+
+	switch preferred.kind {
+	case nodeScalar:
+		return preferred
+	case nodeMapping:
+		return mergeMappings(preferred, other, preferSrc)
+	case nodeSequence:
+		return mergeSequences(preferred, other)
+	}
+	return preferred
+}
+
+func mergeMappings(preferred, other *node, preferSrc bool) *node {
+	result := newMappingNode()
+	// preferred-side keys first (in preferred order), recursing on collisions
+	for _, k := range preferred.mapping.keys {
+		pv := preferred.mapping.values[k]
+		if ov, ok := other.mapping.Get(k); ok {
+			// call mergeNodes with the original dst/src orientation so nested merges honor preferSrc
+			var dst, src *node
+			if preferSrc {
+				dst, src = ov, pv
+			} else {
+				dst, src = pv, ov
+			}
+			result.mapping.Set(k, mergeNodes(dst, src, preferSrc))
+		} else {
+			result.mapping.Set(k, pv)
+		}
+	}
+	// other-side-only keys appended in their original order
+	for _, k := range other.mapping.keys {
+		if _, ok := preferred.mapping.Get(k); ok {
+			continue
+		}
+		result.mapping.Set(k, other.mapping.values[k])
+	}
+	return result
+}
+
+func mergeSequences(preferred, other *node) *node {
+	if !allScalars(preferred) || !allScalars(other) {
+		return preferred
+	}
+	result := newSequenceNode()
+	seen := make(map[any]struct{}, len(preferred.seq)+len(other.seq))
+	appendUnique := func(items []*node) {
+		for _, item := range items {
+			if _, dup := seen[item.scalar]; dup {
+				continue
+			}
+			seen[item.scalar] = struct{}{}
+			result.seq = append(result.seq, item)
+		}
+	}
+	appendUnique(preferred.seq)
+	appendUnique(other.seq)
+	return result
+}
+
+func allScalars(n *node) bool {
+	for _, item := range n.seq {
+		if item.kind != nodeScalar {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/integrate/structured_merge_test.go
+++ b/internal/integrate/structured_merge_test.go
@@ -1,0 +1,211 @@
+package integrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nodeToPlain flattens a *node into ordinary Go values so table-driven tests can compare
+// expected output against actual using assert.Equal. Mapping order is preserved via a
+// slice of alternating key/value entries (`[]any{k1, v1, k2, v2, ...}`) so we can check
+// both the values AND the key order in a single assertion.
+func nodeToPlain(n *node) any {
+	if n == nil {
+		return nil
+	}
+	switch n.kind {
+	case nodeScalar:
+		return n.scalar
+	case nodeMapping:
+		flat := make([]any, 0, len(n.mapping.keys)*2)
+		for _, k := range n.mapping.keys {
+			flat = append(flat, k, nodeToPlain(n.mapping.values[k]))
+		}
+		return flat
+	case nodeSequence:
+		out := make([]any, len(n.seq))
+		for i, item := range n.seq {
+			out[i] = nodeToPlain(item)
+		}
+		return out
+	}
+	return nil
+}
+
+// mapping builds a mapping node from an alternating (key, value) sequence for terse
+// test fixtures. Values may be *node instances or plain primitives (auto-wrapped as
+// scalars). Panics if given an odd number of args or a non-string key.
+func mapping(kv ...any) *node {
+	if len(kv)%2 != 0 {
+		panic("mapping requires an even number of args (k1, v1, k2, v2, ...)")
+	}
+	n := newMappingNode()
+	for i := 0; i < len(kv); i += 2 {
+		key, ok := kv[i].(string)
+		if !ok {
+			panic("mapping keys must be strings")
+		}
+		var val *node
+		switch v := kv[i+1].(type) {
+		case *node:
+			val = v
+		default:
+			val = newScalarNode(v)
+		}
+		n.mapping.Set(key, val)
+	}
+	return n
+}
+
+// seq builds a sequence node. Items may be *node instances or plain primitives.
+func seq(items ...any) *node {
+	n := newSequenceNode()
+	for _, item := range items {
+		switch v := item.(type) {
+		case *node:
+			n.seq = append(n.seq, v)
+		default:
+			n.seq = append(n.seq, newScalarNode(v))
+		}
+	}
+	return n
+}
+
+func TestMergeNodes_scalarPreferSrc(t *testing.T) {
+	dst := newScalarNode("dst")
+	src := newScalarNode("src")
+	result := mergeNodes(dst, src, true)
+	assert.Equal(t, "src", result.scalar)
+}
+
+func TestMergeNodes_scalarPreferDst(t *testing.T) {
+	dst := newScalarNode("dst")
+	src := newScalarNode("src")
+	result := mergeNodes(dst, src, false)
+	assert.Equal(t, "dst", result.scalar)
+}
+
+func TestMergeNodes_kindMismatch_preferredWins(t *testing.T) {
+	t.Run("scalar vs mapping, prefer src (mapping)", func(t *testing.T) {
+		dst := newScalarNode("dst")
+		src := mapping("k", "v")
+		result := mergeNodes(dst, src, true)
+		assert.Equal(t, nodeMapping, result.kind)
+	})
+	t.Run("scalar vs mapping, prefer dst (scalar)", func(t *testing.T) {
+		dst := newScalarNode("dst")
+		src := mapping("k", "v")
+		result := mergeNodes(dst, src, false)
+		assert.Equal(t, nodeScalar, result.kind)
+		assert.Equal(t, "dst", result.scalar)
+	})
+}
+
+func TestMergeNodes_mapping_deepMergeNoCollisions(t *testing.T) {
+	dst := mapping("a", "dst-a", "b", "dst-b")
+	src := mapping("c", "src-c", "d", "src-d")
+	result := mergeNodes(dst, src, true)
+
+	// preferSrc=true → src keys first, dst-only appended
+	assert.Equal(t, []any{"c", "src-c", "d", "src-d", "a", "dst-a", "b", "dst-b"}, nodeToPlain(result))
+}
+
+func TestMergeNodes_mapping_preferSrcCollisionSrcWins(t *testing.T) {
+	dst := mapping("shared", "dst-value", "dst-only", "d")
+	src := mapping("shared", "src-value", "src-only", "s")
+	result := mergeNodes(dst, src, true)
+
+	// preferSrc=true → src key order first, dst-only appended after
+	assert.Equal(t, []any{"shared", "src-value", "src-only", "s", "dst-only", "d"}, nodeToPlain(result))
+}
+
+func TestMergeNodes_mapping_preferDstCollisionDstWins(t *testing.T) {
+	dst := mapping("shared", "dst-value", "dst-only", "d")
+	src := mapping("shared", "src-value", "src-only", "s")
+	result := mergeNodes(dst, src, false)
+
+	// preferSrc=false → dst key order first, src-only appended after
+	assert.Equal(t, []any{"shared", "dst-value", "dst-only", "d", "src-only", "s"}, nodeToPlain(result))
+}
+
+func TestMergeNodes_mapping_recursesIntoNestedMaps(t *testing.T) {
+	dst := mapping("outer", mapping("inner1", "dst-1", "shared", "dst-shared"))
+	src := mapping("outer", mapping("inner2", "src-2", "shared", "src-shared"))
+	result := mergeNodes(dst, src, true)
+
+	// src.outer key order is [inner2, shared] → preferred-order iteration produces
+	// [inner2, shared] first, then dst-only keys [inner1] appended.
+	assert.Equal(t,
+		[]any{"outer", []any{"inner2", "src-2", "shared", "src-shared", "inner1", "dst-1"}},
+		nodeToPlain(result),
+	)
+}
+
+func TestMergeNodes_mapping_downstreamOnlyKeysSurvive(t *testing.T) {
+	// this is the semantic that the prefer-upstream write-target bug used to violate:
+	// even with preferSrc=true, non-conflicting dst keys must land in the output
+	dst := mapping("dst-only", "d-value")
+	src := mapping("src-only", "s-value")
+	result := mergeNodes(dst, src, true)
+
+	found, ok := result.mapping.Get("dst-only")
+	require.True(t, ok, "dst-only key must survive merge under preferSrc=true")
+	assert.Equal(t, "d-value", found.scalar)
+}
+
+func TestMergeNodes_primitiveSequence_concatAndDedupe(t *testing.T) {
+	t.Run("preferSrc: src items first then dst-only items", func(t *testing.T) {
+		dst := seq("node", "python")
+		src := seq("go", "node")
+		result := mergeNodes(dst, src, true)
+		assert.Equal(t, []any{"go", "node", "python"}, nodeToPlain(result))
+	})
+	t.Run("preferDst: dst items first then src-only items", func(t *testing.T) {
+		dst := seq("node", "python")
+		src := seq("go", "node")
+		result := mergeNodes(dst, src, false)
+		assert.Equal(t, []any{"node", "python", "go"}, nodeToPlain(result))
+	})
+	t.Run("mixed primitive types dedupe by value", func(t *testing.T) {
+		dst := seq(1, 2, "same")
+		src := seq(2, 3, "same")
+		result := mergeNodes(dst, src, true)
+		assert.Equal(t, []any{2, 3, "same", 1}, nodeToPlain(result))
+	})
+}
+
+func TestMergeNodes_objectSequence_wholesaleReplaceByPreferred(t *testing.T) {
+	dst := seq(mapping("name", "d1"), mapping("name", "d2"))
+	src := seq(mapping("name", "s1"))
+	t.Run("preferSrc: result is src slice unchanged", func(t *testing.T) {
+		result := mergeNodes(dst, src, true)
+		assert.Equal(t, []any{[]any{"name", "s1"}}, nodeToPlain(result))
+	})
+	t.Run("preferDst: result is dst slice unchanged", func(t *testing.T) {
+		result := mergeNodes(dst, src, false)
+		assert.Equal(t, []any{[]any{"name", "d1"}, []any{"name", "d2"}}, nodeToPlain(result))
+	})
+}
+
+func TestMergeNodes_mixedSequence_wholesaleReplaceByPreferred(t *testing.T) {
+	// if either side has any non-scalar element, safe default is wholesale replace
+	dst := seq("a", mapping("k", "v"))
+	src := seq("b", "c")
+	result := mergeNodes(dst, src, true)
+	assert.Equal(t, []any{"b", "c"}, nodeToPlain(result))
+}
+
+func TestMergeNodes_nilHandling(t *testing.T) {
+	t.Run("nil dst returns src", func(t *testing.T) {
+		src := mapping("k", "v")
+		result := mergeNodes(nil, src, true)
+		assert.Same(t, src, result)
+	})
+	t.Run("nil src returns dst", func(t *testing.T) {
+		dst := mapping("k", "v")
+		result := mergeNodes(dst, nil, true)
+		assert.Same(t, dst, result)
+	})
+}

--- a/internal/integrate/structured_tree.go
+++ b/internal/integrate/structured_tree.go
@@ -1,0 +1,53 @@
+package integrate
+
+type nodeKind int
+
+const (
+	nodeScalar nodeKind = iota
+	nodeMapping
+	nodeSequence
+)
+
+type node struct {
+	kind    nodeKind
+	scalar  any
+	mapping *orderedMap
+	seq     []*node
+}
+
+type orderedMap struct {
+	keys   []string
+	values map[string]*node
+}
+
+func newScalarNode(v any) *node {
+	return &node{kind: nodeScalar, scalar: v}
+}
+
+func newMappingNode() *node {
+	return &node{kind: nodeMapping, mapping: newOrderedMap()}
+}
+
+func newSequenceNode(items ...*node) *node {
+	return &node{kind: nodeSequence, seq: items}
+}
+
+func newOrderedMap() *orderedMap {
+	return &orderedMap{values: map[string]*node{}}
+}
+
+func (m *orderedMap) Set(k string, v *node) {
+	if _, ok := m.values[k]; !ok {
+		m.keys = append(m.keys, k)
+	}
+	m.values[k] = v
+}
+
+func (m *orderedMap) Get(k string) (*node, bool) {
+	v, ok := m.values[k]
+	return v, ok
+}
+
+func (m *orderedMap) Keys() []string {
+	return m.keys
+}

--- a/internal/integrate/structured_tree_test.go
+++ b/internal/integrate/structured_tree_test.go
@@ -1,0 +1,59 @@
+package integrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderedMap_setNewKeyAppends(t *testing.T) {
+	m := newOrderedMap()
+	m.Set("first", newScalarNode("a"))
+	m.Set("second", newScalarNode("b"))
+	m.Set("third", newScalarNode("c"))
+	assert.Equal(t, []string{"first", "second", "third"}, m.Keys())
+}
+
+func TestOrderedMap_setExistingKeyReplacesValueButKeepsPosition(t *testing.T) {
+	m := newOrderedMap()
+	m.Set("first", newScalarNode("a"))
+	m.Set("second", newScalarNode("b"))
+	m.Set("third", newScalarNode("c"))
+	m.Set("second", newScalarNode("replaced"))
+
+	assert.Equal(t, []string{"first", "second", "third"}, m.Keys())
+	v, ok := m.Get("second")
+	require.True(t, ok)
+	require.Equal(t, nodeScalar, v.kind)
+	assert.Equal(t, "replaced", v.scalar)
+}
+
+func TestOrderedMap_getMissingReturnsFalse(t *testing.T) {
+	m := newOrderedMap()
+	_, ok := m.Get("nope")
+	assert.False(t, ok)
+}
+
+func TestNewScalarNode_carriesValueAndKind(t *testing.T) {
+	n := newScalarNode(42)
+	assert.Equal(t, nodeScalar, n.kind)
+	assert.Equal(t, 42, n.scalar)
+}
+
+func TestNewMappingNode_initializesEmptyOrderedMap(t *testing.T) {
+	n := newMappingNode()
+	require.Equal(t, nodeMapping, n.kind)
+	require.NotNil(t, n.mapping)
+	assert.Empty(t, n.mapping.Keys())
+}
+
+func TestNewSequenceNode_carriesItemsAndKind(t *testing.T) {
+	a := newScalarNode("a")
+	b := newScalarNode("b")
+	n := newSequenceNode(a, b)
+	assert.Equal(t, nodeSequence, n.kind)
+	require.Len(t, n.seq, 2)
+	assert.Same(t, a, n.seq[0])
+	assert.Same(t, b, n.seq[1])
+}

--- a/internal/integrate/structured_yaml.go
+++ b/internal/integrate/structured_yaml.go
@@ -1,0 +1,68 @@
+package integrate
+
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+)
+
+func parseYAML(data []byte) (*node, error) {
+	if len(data) == 0 {
+		return newMappingNode(), nil
+	}
+	var raw any
+	if err := yaml.UnmarshalWithOptions(data, &raw, yaml.UseOrderedMap()); err != nil {
+		return nil, err
+	}
+	return yamlValueToNode(raw), nil
+}
+
+func writeYAML(n *node) ([]byte, error) {
+	return yaml.Marshal(nodeToYAMLValue(n))
+}
+
+func yamlValueToNode(v any) *node {
+	switch val := v.(type) {
+	case yaml.MapSlice:
+		m := newMappingNode()
+		for _, item := range val {
+			key, ok := item.Key.(string)
+			if !ok {
+				key = fmt.Sprint(item.Key)
+			}
+			m.mapping.Set(key, yamlValueToNode(item.Value))
+		}
+		return m
+	case []any:
+		items := make([]*node, len(val))
+		for i, item := range val {
+			items[i] = yamlValueToNode(item)
+		}
+		return newSequenceNode(items...)
+	default:
+		return newScalarNode(v)
+	}
+}
+
+func nodeToYAMLValue(n *node) any {
+	if n == nil {
+		return nil
+	}
+	switch n.kind {
+	case nodeScalar:
+		return n.scalar
+	case nodeMapping:
+		items := make(yaml.MapSlice, 0, len(n.mapping.keys))
+		for _, k := range n.mapping.keys {
+			items = append(items, yaml.MapItem{Key: k, Value: nodeToYAMLValue(n.mapping.values[k])})
+		}
+		return items
+	case nodeSequence:
+		items := make([]any, len(n.seq))
+		for i, item := range n.seq {
+			items[i] = nodeToYAMLValue(item)
+		}
+		return items
+	}
+	return nil
+}

--- a/internal/integrate/structured_yaml_test.go
+++ b/internal/integrate/structured_yaml_test.go
@@ -1,0 +1,87 @@
+package integrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseYAML_preservesMappingKeyOrder(t *testing.T) {
+	yamlBytes := []byte("zebra: 1\napple: 2\nmango: 3\n")
+	n, err := parseYAML(yamlBytes)
+	require.NoError(t, err)
+	require.Equal(t, nodeMapping, n.kind)
+	assert.Equal(t, []string{"zebra", "apple", "mango"}, n.mapping.Keys())
+}
+
+func TestParseYAML_recursesIntoNestedMaps(t *testing.T) {
+	yamlBytes := []byte("outer:\n  b: bee\n  a: apple\n")
+	n, err := parseYAML(yamlBytes)
+	require.NoError(t, err)
+	outer, ok := n.mapping.Get("outer")
+	require.True(t, ok)
+	require.Equal(t, nodeMapping, outer.kind)
+	assert.Equal(t, []string{"b", "a"}, outer.mapping.Keys())
+}
+
+func TestParseYAML_parsesSequences(t *testing.T) {
+	yamlBytes := []byte("langs:\n  - go\n  - node\n  - python\n")
+	n, err := parseYAML(yamlBytes)
+	require.NoError(t, err)
+	langs, ok := n.mapping.Get("langs")
+	require.True(t, ok)
+	require.Equal(t, nodeSequence, langs.kind)
+	require.Len(t, langs.seq, 3)
+	assert.Equal(t, "go", langs.seq[0].scalar)
+	assert.Equal(t, "python", langs.seq[2].scalar)
+}
+
+func TestWriteYAML_roundTripPreservesKeyOrder(t *testing.T) {
+	in := []byte("zebra: 1\napple: 2\nmango: 3\n")
+	n, err := parseYAML(in)
+	require.NoError(t, err)
+	out, err := writeYAML(n)
+	require.NoError(t, err)
+
+	// re-parse the output and confirm key order survived the round trip
+	roundTripped, err := parseYAML(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"zebra", "apple", "mango"}, roundTripped.mapping.Keys())
+}
+
+func TestWriteYAML_roundTripPreservesNestedKeyOrder(t *testing.T) {
+	in := []byte("outer:\n  b: bee\n  a: apple\nother: value\n")
+	n, err := parseYAML(in)
+	require.NoError(t, err)
+	out, err := writeYAML(n)
+	require.NoError(t, err)
+
+	roundTripped, err := parseYAML(out)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"outer", "other"}, roundTripped.mapping.Keys())
+	outer, ok := roundTripped.mapping.Get("outer")
+	require.True(t, ok)
+	assert.Equal(t, []string{"b", "a"}, outer.mapping.Keys())
+}
+
+func TestWriteYAML_preservesScalarTypes(t *testing.T) {
+	in := []byte("s: hello\ni: 42\nb: true\nn:\n")
+	n, err := parseYAML(in)
+	require.NoError(t, err)
+	out, err := writeYAML(n)
+	require.NoError(t, err)
+
+	roundTripped, err := parseYAML(out)
+	require.NoError(t, err)
+
+	sVal, _ := roundTripped.mapping.Get("s")
+	iVal, _ := roundTripped.mapping.Get("i")
+	bVal, _ := roundTripped.mapping.Get("b")
+	nVal, _ := roundTripped.mapping.Get("n")
+
+	assert.Equal(t, "hello", sVal.scalar)
+	assert.Equal(t, uint64(42), iVal.scalar) // goccy uses uint64 for positive integers
+	assert.Equal(t, true, bVal.scalar)
+	assert.Nil(t, nVal.scalar)
+}


### PR DESCRIPTION
## Summary

- **Fix**: the prefer-upstream shared-ownership structured integrator was writing the untouched upstream data back to disk after merging into downstream, dropping any downstream-only keys. Same class of bug fixed in the templated integrator, where on \`merged.structured=prefer_downstream\` the freshly-rendered template was being discarded each run.
- **Refactor**: replaced \`dario.cat/mergo\` (order-blind, and structured to encourage the write-target bug above) with a small internal deep merger that preserves key order and gives us smarter slice-merge defaults.
- **Test backfill**: added unit coverage for all three shared-ownership integrators (prefer-upstream YAML+JSON, prefer-downstream YAML+JSON, merged line-level) and for the new merge engine.

## What the new merger does

Semantics on collision:

- **Scalar or kind mismatch** → preferred side wins.
- **Mapping** → deep merge; output key order = preferred-side keys in preferred order, then other-side-only keys appended.
- **Sequence**:
  - all-scalar on both sides → concat + dedupe, preferred first (helps the common "shared dependency list" case)
  - anything else → wholesale replace with preferred (safe default for ordinal-meaningful lists of objects)

Annotation-driven slice strategies (\`merge=by-key(name)\`, \`merge=append\`, etc.) are intentionally deferred to a future PR.

## Files

New under \`internal/integrate/\`:

- \`structured_tree.go\` — common node/orderedMap types
- \`structured_merge.go\` — recursive \`mergeNodes(dst, src, preferSrc)\`
- \`structured_yaml.go\` — parse/write via goccy \`MapSlice\`
- \`structured_json.go\` — hand-rolled ordered decoder/encoder using \`json.Decoder\` tokens (no new deps)

\`dario.cat/mergo\` moves to \`// indirect\` — go-git still pulls it transitively.

## Test plan

- [x] \`make test-unit\` — includes the new engine tests + shared-ownership integrator tests with order-preservation assertions
- [x] \`make test-functional\` — templated + shared-ownership scenarios exercised end-to-end
- [x] \`make test-sdk\` — black-box library consumers
- [x] \`make test-examples\` — runs against \`docs/examples/\` upstreams

## Behavior changes worth calling out

- \`shared_ownership_structured\` prefer-upstream: downstream-only keys now survive (previously dropped).
- \`templated\` with \`merged.structured=prefer_downstream\`: subsequent template renderings now actually take effect (previously the freshly-rendered content was written to a scratch buffer and then discarded).
- YAML/JSON output preserves key order matching the preferred side's authoring order — should meaningfully reduce spurious diffs on re-integrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)