### PR TITLE
fix: prevent panic when downstream has unmatched upstream-owned-block marker

### DIFF
--- a/internal/integrate/integrator_shared_ownership_merged.go
+++ b/internal/integrate/integrator_shared_ownership_merged.go
@@ -101,6 +101,16 @@ func (i *IntegratorSharedOwnershipMerged) Integrate(configuredGlobPatterns []str
 					continue
 				}
 			} else if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)) {
+				if len(upstreamOwnedBlocks) == 0 {
+					// Downstream carries an upstream-owned-block marker that has no counterpart
+					// in upstream (upstream likely removed the block, or downstream has a stray
+					// marker). Preserve the downstream line as-is so any content inside the
+					// unmatched pair is retained — it has effectively transitioned to downstream
+					// ownership — and warn so the user can reconcile.
+					logger.Log("⚠️  %s: downstream has an unmatched %s marker (no matching upstream block); preserving downstream content as-is", integrateFile, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)
+					mergedContent = fmt.Sprintf("%s%s\n", mergedContent, line)
+					continue
+				}
 				// found begin owned block begin, we can simply inject the upstream-defined owned block at the same index and then just
 				// continue scanning the downstream file until we see the next end upstream owned block marker
 				mergedContent = fmt.Sprintf("%s%s\n%s%s\n",

--- a/internal/integrate/integrator_shared_ownership_test.go
+++ b/internal/integrate/integrator_shared_ownership_test.go
@@ -217,4 +217,52 @@ func TestIntegratorSharedOwnershipMerged(t *testing.T) {
 		assert.True(t, downstreamIdx < upstreamIdx,
 			"an upstream block not present in downstream should be appended after existing downstream content")
 	})
+
+	t.Run("downstream has more begin-markers than upstream: no panic, orphan block preserved", func(t *testing.T) {
+		// Upstream provides zero upstream-owned blocks (e.g. block was removed by upstream);
+		// downstream still carries a marker pair from a previous integration. This must not
+		// panic and the orphaned downstream block should be preserved verbatim so the user
+		// can reconcile — it has effectively transitioned to downstream ownership.
+		upstream := "regular upstream content\n"
+		downstream := "downstream head\n" +
+			beginMarker + "\norphan block content\n" + endMarker + "\n" +
+			"downstream tail\n"
+		upstreamDir, downstreamDir := setupStructuredPair(t, "Makefile", upstream, downstream)
+
+		integrator := &IntegratorSharedOwnershipMerged{}
+		require.NotPanics(t, func() {
+			require.NoError(t, integrator.Integrate([]string{"Makefile"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+		})
+
+		got, err := os.ReadFile(filepath.Join(downstreamDir, "Makefile"))
+		require.NoError(t, err)
+		assert.Contains(t, string(got), "downstream head")
+		assert.Contains(t, string(got), "downstream tail")
+		assert.Contains(t, string(got), "orphan block content",
+			"content inside an unmatched downstream begin/end marker pair should be preserved (now downstream-owned)")
+		assert.Contains(t, string(got), beginMarker,
+			"the unmatched begin-marker itself should be preserved so the user can reconcile explicitly")
+	})
+
+	t.Run("downstream has second unmatched begin-marker after a matched one", func(t *testing.T) {
+		// Mixed case: first begin-marker in downstream matches the single upstream block;
+		// second begin-marker in downstream has nothing to match. Must not panic.
+		upstream := beginMarker + "\nupstream block\n" + endMarker + "\n"
+		downstream := beginMarker + "\nstale first block\n" + endMarker + "\n" +
+			"middle downstream line\n" +
+			beginMarker + "\norphan second block\n" + endMarker + "\n"
+		upstreamDir, downstreamDir := setupStructuredPair(t, "Makefile", upstream, downstream)
+
+		integrator := &IntegratorSharedOwnershipMerged{}
+		require.NotPanics(t, func() {
+			require.NoError(t, integrator.Integrate([]string{"Makefile"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+		})
+
+		got, err := os.ReadFile(filepath.Join(downstreamDir, "Makefile"))
+		require.NoError(t, err)
+		assert.Contains(t, string(got), "upstream block")
+		assert.NotContains(t, string(got), "stale first block")
+		assert.Contains(t, string(got), "middle downstream line")
+		assert.Contains(t, string(got), "orphan second block")
+	})
 }


### PR DESCRIPTION
## Summary

- `shared_ownership_merged` panicked with `index out of range [0] with length 0` on `upstreamOwnedBlocks[0]` when a downstream file carried more `begin-upstream-owned-block` markers than the current upstream provided (e.g. upstream removed a block since the last integration, or downstream introduced a stray marker).
- Guarded the empty-slice case: the orphaned downstream marker line is preserved verbatim, any content inside the pair is retained (the block has effectively transitioned to downstream ownership), and the logger emits a warning so the user can reconcile explicitly.

## Test plan

- [x] `go test ./internal/integrate/ -run TestIntegratorSharedOwnershipMerged` — new subtests exercise both the zero-block case and the mixed matched+unmatched case
- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)