### PR TITLE
fix: guarantee drift-check branch cleanup on all CheckDrift return paths

### DIFF
--- a/internal/drift/check_drift.go
+++ b/internal/drift/check_drift.go
@@ -122,13 +122,18 @@ func CheckDrift(opts *sdktypes.CheckDriftOptions) (*sdktypes.DriftReport, error)
 	if err := repo.Storer.SetReference(plumbing.NewHashReference(driftBranchRef, headRef.Hash())); err != nil {
 		return report, fmt.Errorf("error creating/resetting drift-check branch: %v", err)
 	}
+	// Register cleanup immediately: a subsequent Checkout (or any later step) may
+	// fail, and we must still delete the drift-check branch we just created and
+	// restore the caller's original HEAD. go-git's Repository.DeleteBranch only
+	// removes the branch config section (which we never created), so we drop the
+	// reference directly via the storer.
+	defer func() {
+		_ = wt.Checkout(restore)
+		_ = repo.Storer.RemoveReference(driftBranchRef)
+	}()
 	if err := wt.Checkout(&gogit.CheckoutOptions{Branch: driftBranchRef}); err != nil {
 		return report, fmt.Errorf("error checking out drift-check branch: %v", err)
 	}
-	defer func() {
-		_ = wt.Checkout(restore)
-		_ = repo.DeleteBranch(driftCheckBranch)
-	}()
 
 	// Re-integrate each upstream; track which files each one last touched.
 	// fileOwner maps relative file path -> upstream URL that last wrote it.

--- a/internal/drift/check_drift_test.go
+++ b/internal/drift/check_drift_test.go
@@ -229,6 +229,43 @@ func testWriteAndCommitInDownstream(t *testing.T, downstreamDir, relPath, conten
 	testharness.CommitAllWithMessage(t, repo, "drift edit: "+relPath)
 }
 
+func TestCheckDrift_cleansUpDriftCheckBranch(t *testing.T) {
+	// Whatever the outcome of CheckDrift, the transient _gitspork-check-drift
+	// branch must not linger in the downstream repo — otherwise subsequent
+	// invocations start from an unclean state and users see stray refs.
+	upstreamDir, _ := testharness.MinimalUpstream(t)
+	downstreamDir := testharness.EmptyDownstream(t)
+	testIntegrateAndCommitBaseline(t, upstreamDir, downstreamDir)
+
+	t.Run("no drift path", func(t *testing.T) {
+		_, err := CheckDrift(&sdktypes.CheckDriftOptions{
+			Logger:             logutil.New(),
+			DownstreamRepoPath: downstreamDir,
+		})
+		require.NoError(t, err)
+		assertDriftCheckBranchAbsent(t, downstreamDir)
+	})
+
+	t.Run("drift detected path", func(t *testing.T) {
+		testWriteAndCommitInDownstream(t, downstreamDir, "upstream-owned/file.txt", "drifted\n")
+		_, err := CheckDrift(&sdktypes.CheckDriftOptions{
+			Logger:             logutil.New(),
+			DownstreamRepoPath: downstreamDir,
+		})
+		require.ErrorIs(t, err, sdktypes.ErrDriftDetected)
+		assertDriftCheckBranchAbsent(t, downstreamDir)
+	})
+}
+
+func assertDriftCheckBranchAbsent(t *testing.T, downstreamDir string) {
+	t.Helper()
+	repo, err := gogit.PlainOpen(downstreamDir)
+	require.NoError(t, err)
+	_, err = repo.Reference(plumbing.NewBranchReferenceName(driftCheckBranch), false)
+	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound,
+		"transient drift-check branch %q must be cleaned up when CheckDrift returns", driftCheckBranch)
+}
+
 func TestCheckDrift_report_files_include_unified_diff(t *testing.T) {
 	upstreamDir, _ := testharness.MinimalUpstream(t)
 	downstreamDir := testharness.EmptyDownstream(t)


### PR DESCRIPTION
## Summary

Two related bugs were preventing the transient `_gitspork-check-drift` branch from being cleaned up in `CheckDrift`:

1. **Branch leak on Checkout failure.** The cleanup defer was registered *after* `wt.Checkout(driftBranchRef)`. If `SetReference` succeeded but the Checkout that immediately followed failed, the newly-created branch would leak. Registered the defer immediately after `SetReference` so the cleanup runs for any subsequent failure.
2. **Branch reference never actually deleted.** go-git v6's `Repository.DeleteBranch` only removes the `[branch "<name>"]` config section — it does not remove the ref under `refs/heads`. Since `CheckDrift` creates the drift-check branch via `Storer.SetReference` (no config section is ever written), `DeleteBranch` was a silent no-op and every previous invocation was leaving behind a `_gitspork-check-drift` ref. Switched to `Storer.RemoveReference` so the ref is actually deleted.

## Test plan

- [x] `go test ./internal/drift/ -run TestCheckDrift_cleansUpDriftCheckBranch` — new subtests exercise the no-drift and drift-detected paths and assert the ref does not exist after CheckDrift returns (this test fails against the previous behavior — that is what surfaced bug #2)
- [x] `make test-unit`

## Impact

Users of previous v2 preview releases who ran `check-drift` will have accumulated a `_gitspork-check-drift` branch in their downstream repos. It's harmless but noisy — they can delete it manually with `git branch -D _gitspork-check-drift` after upgrading, or ignore it and let this build's cleanup take care of it after their next `check-drift` invocation… except the ref was never being deleted at all, so a manual delete is the only way to remove existing stragglers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)