### PR TITLE
fix: normalize trailing slash on gitspork mv/rm paths

### DIFF
--- a/internal/config/upstream_mv_rm.go
+++ b/internal/config/upstream_mv_rm.go
@@ -30,6 +30,10 @@ func ComputeUpstreamMv(configPath, oldPath, newPath string) (*GitSporkConfig, []
 // ComputeUpstreamMvFromConfig applies a move rewrite to an already-parsed config.
 // Used to chain multiple source rewrites without re-reading the file between each.
 func ComputeUpstreamMvFromConfig(config *GitSporkConfig, oldPath, newPath string) (*GitSporkConfig, []string, error) {
+	// Shell tab-completion routinely appends "/" to directory arguments; strip it
+	// so the pattern-prefix comparisons below match as the user intends.
+	oldPath = strings.TrimSuffix(oldPath, "/")
+	newPath = strings.TrimSuffix(newPath, "/")
 	var warnings []string
 
 	rewritePatterns := func(patterns []string) []string {
@@ -130,6 +134,9 @@ func ComputeUpstreamRm(configPath, path string, recursive bool) (*GitSporkConfig
 // ComputeUpstreamRmFromConfig applies a removal to an already-parsed config.
 // Used to chain multiple path removals without re-reading the file between each.
 func ComputeUpstreamRmFromConfig(config *GitSporkConfig, path string, recursive bool) (*GitSporkConfig, []string, error) {
+	// Shell tab-completion routinely appends "/" to directory arguments; strip it
+	// so the pattern-prefix comparisons below match as the user intends.
+	path = strings.TrimSuffix(path, "/")
 	var warnings []string
 
 	filterPatterns := func(patterns []string) []string {

--- a/internal/config/upstream_mv_rm_test.go
+++ b/internal/config/upstream_mv_rm_test.go
@@ -147,6 +147,45 @@ func Test_UpstreamMv(t *testing.T) {
 		result := loadConfigFile(t, cfg)
 		assert.Equal(t, []OwnedEntry{{From: "renamed-seed.md", To: "seed-to.md"}}, result.DownstreamOwned)
 	})
+
+	// Shell tab-completion routinely appends "/" to directory arguments.
+	// mv/rm must treat "docs/cloud-native/" the same as "docs/cloud-native",
+	// otherwise the git operation succeeds but no config entries are rewritten
+	// and the resulting commit is silently broken.
+	t.Run("trailing slash on oldPath still rewrites matching glob", func(t *testing.T) {
+		cfg := makeConfigFile(t, &GitSporkConfig{
+			UpstreamOwned: []OwnedEntry{{Pattern: "docs/cloud-native/**"}},
+		})
+		warnings, err := UpstreamMv(cfg, "docs/cloud-native/", "docs/cloud")
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+		result := loadConfigFile(t, cfg)
+		assert.Equal(t, []OwnedEntry{{Pattern: "docs/cloud/**"}}, result.UpstreamOwned)
+	})
+
+	t.Run("trailing slash on newPath does not corrupt rewrite", func(t *testing.T) {
+		cfg := makeConfigFile(t, &GitSporkConfig{
+			UpstreamOwned: []OwnedEntry{{Pattern: "docs/cloud-native/**"}},
+		})
+		warnings, err := UpstreamMv(cfg, "docs/cloud-native", "docs/cloud/")
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+		result := loadConfigFile(t, cfg)
+		assert.Equal(t, []OwnedEntry{{Pattern: "docs/cloud/**"}}, result.UpstreamOwned)
+	})
+
+	t.Run("trailing slashes on both paths rewrite templated destination", func(t *testing.T) {
+		cfg := makeConfigFile(t, &GitSporkConfig{
+			Templated: []GitSporkConfigTemplated{
+				{Template: "templates/foo.tmpl", Destination: "out/cloud/foo.txt"},
+			},
+		})
+		warnings, err := UpstreamMv(cfg, "out/cloud/", "out/cloud-v2/")
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+		result := loadConfigFile(t, cfg)
+		assert.Equal(t, "out/cloud-v2/foo.txt", result.Templated[0].Destination)
+	})
 }
 
 func Test_FindGitSporkConfig(t *testing.T) {
@@ -353,5 +392,33 @@ func Test_UpstreamRm(t *testing.T) {
 		assert.Empty(t, warnings)
 		result := loadConfigFile(t, cfg)
 		assert.Equal(t, []OwnedEntry{{Pattern: "keep.md"}}, result.DownstreamOwned)
+	})
+
+	// Shell tab-completion routinely appends "/" to directory arguments; rm must
+	// treat "docs/cloud-native/" the same as "docs/cloud-native".
+	t.Run("trailing slash on path still removes matching glob (recursive)", func(t *testing.T) {
+		cfg := makeConfigFile(t, &GitSporkConfig{
+			UpstreamOwned: []OwnedEntry{{Pattern: "docs/cloud-native/**"}, {Pattern: "docs/other.md"}},
+		})
+		warnings, err := UpstreamRm(cfg, "docs/cloud-native/", true)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+		result := loadConfigFile(t, cfg)
+		assert.Equal(t, []OwnedEntry{{Pattern: "docs/other.md"}}, result.UpstreamOwned)
+	})
+
+	t.Run("trailing slash on path still removes matching templated entry (recursive)", func(t *testing.T) {
+		cfg := makeConfigFile(t, &GitSporkConfig{
+			Templated: []GitSporkConfigTemplated{
+				{Template: "templates/cloud-native/foo.tmpl", Destination: "out/foo.txt"},
+				{Template: "templates/bar.tmpl", Destination: "out/bar.txt"},
+			},
+		})
+		warnings, err := UpstreamRm(cfg, "templates/cloud-native/", true)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+		result := loadConfigFile(t, cfg)
+		require.Len(t, result.Templated, 1)
+		assert.Equal(t, "templates/bar.tmpl", result.Templated[0].Template)
 	})
 }


### PR DESCRIPTION
## Summary

Shell tab-completion routinely appends `/` to directory arguments (e.g. `gitspork rm docs/cloud-native/`). Before this fix, the trailing slash made every pattern-prefix comparison in `ComputeUpstreamMvFromConfig` and `ComputeUpstreamRmFromConfig` fall through to the "no match" branch — so `git mv` / `git rm` succeeded but no `.gitspork.yml` entries were rewritten and the resulting staged commit silently drifted from upstream reality.

Strip the trailing `/` at the top of both `FromConfig` entrypoints so the subsequent comparisons behave the same whether or not tab-completion tacked one on. Applied on both `oldPath` and `newPath` for mv, and on the single path arg for rm.

## Test plan

- [x] `go test ./internal/config/ -run 'Test_Upstream(Mv|Rm)'` — new subtests exercise trailing-slash on old path, new path, both paths, glob rewrite, and templated rewrite (all fail against the pre-fix code)
- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)