### PR TITLE
fix: detect -r in bundled short flags for gitspork rm

### DIFF
--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/rockholla/gitspork/v2/internal/config"
@@ -33,7 +32,7 @@ func (s *RmSubcommand) GetCmd() *cobra.Command {
 			return gitbin.Require()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			recursive := slices.Contains(args, "-r")
+			recursive := isRmRecursive(args)
 
 			configPath, err := config.FindGitSporkConfig(".")
 			if err != nil {
@@ -87,4 +86,26 @@ func (s *RmSubcommand) GetCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// isRmRecursive reports whether any of args carries a `-r` short flag,
+// including bundled forms like `-rf`, `-fr`, or `-rfn`. git rm does not
+// accept a long `--recursive` form. Everything after a `--` separator is
+// treated as positional and not scanned for flags.
+func isRmRecursive(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if len(a) < 2 || a[0] != '-' {
+			continue
+		}
+		if strings.HasPrefix(a, "--") {
+			continue
+		}
+		if strings.ContainsRune(a[1:], 'r') {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isRmRecursive(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no args", args: nil, want: false},
+		{name: "no flags, just path", args: []string{"docs/foo"}, want: false},
+
+		{name: "-r alone", args: []string{"-r", "docs/foo"}, want: true},
+		{name: "-rf combined", args: []string{"-rf", "docs/foo"}, want: true},
+		{name: "-fr combined (reversed order)", args: []string{"-fr", "docs/foo"}, want: true},
+		{name: "-rn combined with dry-run", args: []string{"-rn", "docs/foo"}, want: true},
+		{name: "-rfn triple-bundle", args: []string{"-rfn", "docs/foo"}, want: true},
+
+		{name: "-f alone (not recursive)", args: []string{"-f", "docs/foo"}, want: false},
+		{name: "-n alone (not recursive)", args: []string{"-n", "docs/foo"}, want: false},
+		{name: "-fq combined without r", args: []string{"-fq", "docs/foo"}, want: false},
+
+		{name: "-- separator hides subsequent -r", args: []string{"--", "-r"}, want: false},
+		{name: "flag before -- separator still counts", args: []string{"-r", "--", "docs/foo"}, want: true},
+
+		{name: "path with r in name is not a flag", args: []string{"docs/references/thing.md"}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isRmRecursive(tc.args))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The previous check `slices.Contains(args, "-r")` only matched a bare `-r` token. Common shell forms like `gitspork rm -rf docs/foo/`, `-fr docs/foo/`, or `-rfn docs/foo/` (dry-run + recursive + force) all passed the `-r` through to `git rm` — which happily removed the tree — while `gitspork` silently skipped the recursive-config-cleanup branch, leaving `docs/foo/**` in `.gitspork.yml` and staging a broken commit.

Introduced `isRmRecursive` that scans arg-by-arg, treats `--` as an end-of-flags marker, and returns true when any short flag token contains `r`. Long flags are ignored (`git rm` has no `--recursive`).

Triage originally cited `--recursive` as an affected form; `git rm` does not accept it, so the detector only needs to cover short-flag bundles.

## Test plan

- [x] `go test ./internal/cli/ -run Test_isRmRecursive` — table-driven coverage of `-r`, `-rf`, `-fr`, `-rn`, `-rfn`, non-recursive flags, and the `--` separator edge cases
- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)