### PR TITLE
fix: honor -n/--dry-run in gitspork mv/rm

### DIFF
--- a/internal/cli/dry_run.go
+++ b/internal/cli/dry_run.go
@@ -1,0 +1,28 @@
+package cli
+
+import "strings"
+
+// isDryRun reports whether args carries a git-style dry-run flag: the long
+// form `--dry-run`, a bare `-n`, or `-n` bundled into a short-flag group
+// like `-rn`, `-nf`, or `-rfn`. Everything after a `--` separator is treated
+// as positional and not scanned.
+func isDryRun(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if len(a) < 2 || a[0] != '-' {
+			continue
+		}
+		if a == "--dry-run" {
+			return true
+		}
+		if strings.HasPrefix(a, "--") {
+			continue
+		}
+		if strings.ContainsRune(a[1:], 'n') {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/dry_run_test.go
+++ b/internal/cli/dry_run_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isDryRun(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "no args", args: nil, want: false},
+		{name: "no flags", args: []string{"docs/foo.md"}, want: false},
+
+		{name: "-n alone", args: []string{"-n", "docs/foo.md"}, want: true},
+		{name: "--dry-run long form", args: []string{"--dry-run", "docs/foo.md"}, want: true},
+		{name: "-nf bundled", args: []string{"-nf", "docs/foo.md"}, want: true},
+		{name: "-rn bundled with recursive", args: []string{"-rn", "docs/foo"}, want: true},
+		{name: "-rfn triple-bundle", args: []string{"-rfn", "docs/foo"}, want: true},
+
+		{name: "-r alone (not dry-run)", args: []string{"-r", "docs/foo"}, want: false},
+		{name: "-f alone (not dry-run)", args: []string{"-f", "docs/foo"}, want: false},
+		{name: "-fq combined without n", args: []string{"-fq", "docs/foo"}, want: false},
+		{name: "--force long form", args: []string{"--force", "docs/foo"}, want: false},
+
+		{name: "-- separator hides subsequent -n", args: []string{"--", "-n"}, want: false},
+		{name: "flag before -- separator still counts", args: []string{"-n", "--", "docs/foo"}, want: true},
+
+		{name: "path with n in name is not a flag", args: []string{"docs/notes.md"}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isDryRun(tc.args))
+		})
+	}
+}

--- a/internal/cli/mv.go
+++ b/internal/cli/mv.go
@@ -67,23 +67,34 @@ func (s *MvSubcommand) GetCmd() *cobra.Command {
 				warnings = append(warnings, w...)
 			}
 
+			dryRun := isDryRun(args)
+
 			gitCmd := exec.Command("git", append([]string{"-c", "safe.directory=*", "mv"}, args...)...)
 			gitCmd.Dir = repoPath
 			if out, err := gitCmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("git mv failed: %v\n%s", err, out)
 			}
 
-			if err := config.WriteGitSporkConfig(configPath, cfg); err != nil {
-				return fmt.Errorf("error writing .gitspork.yml: %v", err)
-			}
-			if out, err := exec.Command("git", "-c", "safe.directory=*", "add", configPath).CombinedOutput(); err != nil {
-				return fmt.Errorf("git add .gitspork.yml failed: %v\n%s", err, out)
+			// dry-run: git mv did not touch the tree, so we must not rewrite or
+			// stage .gitspork.yml either — otherwise "dry-run" would still
+			// silently mutate the config.
+			if !dryRun {
+				if err := config.WriteGitSporkConfig(configPath, cfg); err != nil {
+					return fmt.Errorf("error writing .gitspork.yml: %v", err)
+				}
+				if out, err := exec.Command("git", "-c", "safe.directory=*", "add", configPath).CombinedOutput(); err != nil {
+					return fmt.Errorf("git add .gitspork.yml failed: %v\n%s", err, out)
+				}
 			}
 
 			for _, w := range warnings {
 				logger.Log("⚠️  %s", w)
 			}
-			logger.Log("✅ git mv complete and .gitspork.yml staged — ready to commit")
+			if dryRun {
+				logger.Log("🔍 dry-run: .gitspork.yml would also be rewritten — no changes made")
+			} else {
+				logger.Log("✅ git mv complete and .gitspork.yml staged — ready to commit")
+			}
 			return nil
 		},
 	}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -66,23 +66,34 @@ func (s *RmSubcommand) GetCmd() *cobra.Command {
 				warnings = append(warnings, w...)
 			}
 
+			dryRun := isDryRun(args)
+
 			gitCmd := exec.Command("git", append([]string{"-c", "safe.directory=*", "rm"}, args...)...)
 			gitCmd.Dir = repoPath
 			if out, err := gitCmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("git rm failed: %v\n%s", err, out)
 			}
 
-			if err := config.WriteGitSporkConfig(configPath, cfg); err != nil {
-				return fmt.Errorf("error writing .gitspork.yml: %v", err)
-			}
-			if out, err := exec.Command("git", "-c", "safe.directory=*", "add", configPath).CombinedOutput(); err != nil {
-				return fmt.Errorf("git add .gitspork.yml failed: %v\n%s", err, out)
+			// dry-run: git rm did not touch the tree, so we must not rewrite or
+			// stage .gitspork.yml either — otherwise "dry-run" would still
+			// silently mutate the config.
+			if !dryRun {
+				if err := config.WriteGitSporkConfig(configPath, cfg); err != nil {
+					return fmt.Errorf("error writing .gitspork.yml: %v", err)
+				}
+				if out, err := exec.Command("git", "-c", "safe.directory=*", "add", configPath).CombinedOutput(); err != nil {
+					return fmt.Errorf("git add .gitspork.yml failed: %v\n%s", err, out)
+				}
 			}
 
 			for _, w := range warnings {
 				logger.Log("⚠️  %s", w)
 			}
-			logger.Log("✅ git rm complete and .gitspork.yml staged — ready to commit")
+			if dryRun {
+				logger.Log("🔍 dry-run: .gitspork.yml would also be rewritten — no changes made")
+			} else {
+				logger.Log("✅ git rm complete and .gitspork.yml staged — ready to commit")
+			}
 			return nil
 		},
 	}

--- a/test/functional/mv_rm_test.go
+++ b/test/functional/mv_rm_test.go
@@ -112,6 +112,36 @@ func TestMv_multi_source(t *testing.T) {
 	assert.Contains(t, string(staged), "docs/archive/second.md")
 }
 
+func TestMv_dry_run_leaves_config_and_tree_untouched(t *testing.T) {
+	// git mv -n only reports what would happen; gitspork mv must mirror that
+	// by leaving both the working tree AND .gitspork.yml unchanged (and
+	// unstaged), otherwise "--dry-run" silently rewrites and stages the config.
+	upstreamDir := NewUpstreamRepo(t, map[string]string{
+		"docs/old.md":  "# old doc\n",
+		"docs/keep.md": "# keep\n",
+	}, mvRmGitsporkYML)
+
+	runner := resolveRunner(t, upstreamDir, "")
+
+	origCfg := ReadFile(t, upstreamDir, ".gitspork.yml")
+
+	out, code := runner.Run(t, []string{"mv", "-n", "docs/old.md", "docs/new.md"}, upstreamDir)
+	require.Equal(t, 0, code, "gitspork mv -n failed:\n%s", out)
+
+	AssertFileContains(t, upstreamDir, "docs/old.md", "old doc")
+	AssertFileAbsent(t, upstreamDir, "docs/new.md")
+
+	postCfg := ReadFile(t, upstreamDir, ".gitspork.yml")
+	assert.Equal(t, origCfg, postCfg, ".gitspork.yml must be byte-identical after dry-run")
+
+	cmd := exec.Command("git", "diff", "--cached", "--name-only")
+	cmd.Dir = upstreamDir
+	staged, err := cmd.Output()
+	require.NoError(t, err)
+	assert.NotContains(t, string(staged), ".gitspork.yml",
+		"dry-run must not stage .gitspork.yml, got staged files:\n%s", staged)
+}
+
 func TestRm_updates_config_and_stages(t *testing.T) {
 	upstreamDir := NewUpstreamRepo(t, map[string]string{
 		"docs/old.md":  "# old doc\n",
@@ -136,6 +166,35 @@ func TestRm_updates_config_and_stages(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(staged), ".gitspork.yml")
 	assert.Contains(t, string(staged), "docs/old.md")
+}
+
+func TestRm_dry_run_leaves_config_and_tree_untouched(t *testing.T) {
+	// git rm -n only reports what would happen; gitspork rm must mirror that
+	// by leaving both the working tree AND .gitspork.yml unchanged (and
+	// unstaged), otherwise "--dry-run" silently rewrites and stages the config.
+	upstreamDir := NewUpstreamRepo(t, map[string]string{
+		"docs/old.md":  "# old doc\n",
+		"docs/keep.md": "# keep\n",
+	}, mvRmGitsporkYML)
+
+	runner := resolveRunner(t, upstreamDir, "")
+
+	origCfg := ReadFile(t, upstreamDir, ".gitspork.yml")
+
+	out, code := runner.Run(t, []string{"rm", "-n", "docs/old.md"}, upstreamDir)
+	require.Equal(t, 0, code, "gitspork rm -n failed:\n%s", out)
+
+	AssertFileContains(t, upstreamDir, "docs/old.md", "old doc")
+
+	postCfg := ReadFile(t, upstreamDir, ".gitspork.yml")
+	assert.Equal(t, origCfg, postCfg, ".gitspork.yml must be byte-identical after dry-run")
+
+	cmd := exec.Command("git", "diff", "--cached", "--name-only")
+	cmd.Dir = upstreamDir
+	staged, err := cmd.Output()
+	require.NoError(t, err)
+	assert.NotContains(t, string(staged), ".gitspork.yml",
+		"dry-run must not stage .gitspork.yml, got staged files:\n%s", staged)
 }
 
 // TestRm_downstream_exact runs gitspork rm on an exact path, commits the upstream


### PR DESCRIPTION
## Summary

`gitspork mv` / `gitspork rm` passed `-n` / `--dry-run` through to `git mv` / `git rm` (which correctly print what they would do and leave the tree alone) but then proceeded to rewrite `.gitspork.yml` and `git add` it anyway. The "dry-run" invocation therefore silently mutated and staged the config file — the opposite of the user's intent, and the resulting commit would drift from upstream reality on the next real `gitspork rm`.

Introduced `isDryRun` (long form `--dry-run`, bare `-n`, or `-n` bundled into short flags like `-rn`, `-nf`, `-rfn`; respects `--` end-of-flags), and skipped both the `WriteGitSporkConfig` call and the `git add` for the config file when it returns true. Warning output still runs; the success message becomes a "dry-run: no changes made" note.

## Test plan

- [x] `go test ./internal/cli/ -run Test_isDryRun` — table-driven coverage of `-n`, `--dry-run`, bundled short flags, non-dry-run flags, and the `--` separator edge cases
- [x] `make test-functional` — new `TestMv_dry_run_leaves_config_and_tree_untouched` and `TestRm_dry_run_leaves_config_and_tree_untouched` assert `.gitspork.yml` is byte-identical after the run and is not staged (both fail against the pre-fix code)
- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)