### PR TITLE
fix: normalize UpstreamSpec.Subpath slashes so upstream delta propagates

### DIFF
--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"path"
+	"strings"
+)
+
+// NormalizeUpstreamPath returns a canonical, forward-slash logical path for
+// user-supplied inputs like mv/rm arguments and UpstreamSpec.Subpath values.
+//
+// It leans on path.Clean to collapse "//" segments, resolve "." and ".."
+// segments, and strip trailing slashes — all of which shell tab-completion,
+// autocomplete, or human error routinely produce. It also normalizes a leading
+// slash away (git tree entries and .gitspork.yml patterns never carry one) and
+// maps the "no path" input to the empty string rather than path.Clean's "."
+// sentinel, so callers can special-case the root/no-subpath case naturally.
+//
+// Examples:
+//
+//	""              -> ""
+//	"/"             -> ""
+//	"docs/foo"      -> "docs/foo"
+//	"docs/foo/"     -> "docs/foo"
+//	"/docs/foo"     -> "docs/foo"
+//	"./docs/foo"    -> "docs/foo"
+//	"docs//foo"     -> "docs/foo"
+//	"docs/./foo"    -> "docs/foo"
+//	"docs/bar/../foo" -> "docs/foo"
+func NormalizeUpstreamPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	cleaned := path.Clean(p)
+	if cleaned == "." {
+		return ""
+	}
+	return strings.TrimPrefix(cleaned, "/")
+}

--- a/internal/config/normalize_test.go
+++ b/internal/config/normalize_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NormalizeUpstreamPath(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		// Empty / root
+		{in: "", want: ""},
+		{in: ".", want: ""},
+		{in: "/", want: ""},
+
+		// Already clean
+		{in: "docs", want: "docs"},
+		{in: "docs/foo.md", want: "docs/foo.md"},
+		{in: "docs/foo/bar.md", want: "docs/foo/bar.md"},
+
+		// Trailing slash (tab-completion)
+		{in: "docs/", want: "docs"},
+		{in: "docs/foo/", want: "docs/foo"},
+
+		// Leading slash
+		{in: "/docs", want: "docs"},
+		{in: "/docs/foo", want: "docs/foo"},
+
+		// Both
+		{in: "/docs/", want: "docs"},
+
+		// Doubled slashes
+		{in: "docs//foo", want: "docs/foo"},
+		{in: "docs///foo", want: "docs/foo"},
+
+		// Explicit-cwd prefix
+		{in: "./docs/foo", want: "docs/foo"},
+		{in: "./docs", want: "docs"},
+
+		// Interior "." and ".."
+		{in: "docs/./foo", want: "docs/foo"},
+		{in: "docs/bar/../foo", want: "docs/foo"},
+		{in: "docs/foo/..", want: "docs"},
+
+		// Combinations
+		{in: "./docs/foo/", want: "docs/foo"},
+		{in: "/docs//./foo/", want: "docs/foo"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeUpstreamPath(tc.in))
+		})
+	}
+}

--- a/internal/integrate/upstream_delta.go
+++ b/internal/integrate/upstream_delta.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -27,6 +28,9 @@ type upstreamDelta struct {
 }
 
 func computeUpstreamDelta(repo *gogit.Repository, prevHash, newHash string, cfg *config.GitSporkConfig, upstreamSubpath string) (*upstreamDelta, error) {
+	// Users may specify UpstreamSpec.Subpath with leading or trailing slashes
+	// (e.g. "infra/"). Normalize once here so downstream helpers don't have to.
+	upstreamSubpath = strings.Trim(upstreamSubpath, "/")
 	delta := &upstreamDelta{}
 	if prevHash == "" {
 		return delta, nil
@@ -161,6 +165,10 @@ func resolveManagedDest(srcPath string, matchers []managedMatcher) (string, bool
 }
 
 func stripSubpath(path, subpath string) string {
+	// Defense-in-depth: normalize slashes even though computeUpstreamDelta
+	// already trims its input, so a future caller can't silently break the
+	// prefix comparison by passing "infra/".
+	subpath = strings.Trim(subpath, "/")
 	if subpath == "" {
 		return path
 	}
@@ -205,6 +213,9 @@ func applyTemplatedConfigDelta(prevCommit, newCommit *object.Commit, upstreamSub
 }
 
 func readConfigFromCommit(commit *object.Commit, subpath string) (*config.GitSporkConfig, error) {
+	// Defense-in-depth: normalize slashes so a "foo/" or "/foo" subpath doesn't
+	// produce a "foo//.gitspork.yml" lookup that misses the file.
+	subpath = strings.Trim(subpath, "/")
 	tree, err := commit.Tree()
 	if err != nil {
 		return &config.GitSporkConfig{}, err

--- a/internal/integrate/upstream_delta.go
+++ b/internal/integrate/upstream_delta.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -28,9 +27,11 @@ type upstreamDelta struct {
 }
 
 func computeUpstreamDelta(repo *gogit.Repository, prevHash, newHash string, cfg *config.GitSporkConfig, upstreamSubpath string) (*upstreamDelta, error) {
-	// Users may specify UpstreamSpec.Subpath with leading or trailing slashes
-	// (e.g. "infra/"). Normalize once here so downstream helpers don't have to.
-	upstreamSubpath = strings.Trim(upstreamSubpath, "/")
+	// UpstreamSpec.Subpath is user-supplied and often carries slashes or "."
+	// segments that shell tab-completion and human error routinely produce
+	// ("infra/", "/infra", "./infra", "infra//"). Normalize once here so
+	// downstream helpers see a canonical forward-slash logical path.
+	upstreamSubpath = config.NormalizeUpstreamPath(upstreamSubpath)
 	delta := &upstreamDelta{}
 	if prevHash == "" {
 		return delta, nil
@@ -164,19 +165,19 @@ func resolveManagedDest(srcPath string, matchers []managedMatcher) (string, bool
 	return "", false
 }
 
-func stripSubpath(path, subpath string) string {
-	// Defense-in-depth: normalize slashes even though computeUpstreamDelta
-	// already trims its input, so a future caller can't silently break the
-	// prefix comparison by passing "infra/".
-	subpath = strings.Trim(subpath, "/")
+func stripSubpath(p, subpath string) string {
+	// Defense-in-depth: normalize even though computeUpstreamDelta already
+	// canonicalizes its input, so a future caller can't silently break the
+	// prefix comparison by passing "infra/", "./infra", "infra//sub", etc.
+	subpath = config.NormalizeUpstreamPath(subpath)
 	if subpath == "" {
-		return path
+		return p
 	}
 	prefix := subpath + "/"
-	if len(path) > len(prefix) && path[:len(prefix)] == prefix {
-		return path[len(prefix):]
+	if len(p) > len(prefix) && p[:len(prefix)] == prefix {
+		return p[len(prefix):]
 	}
-	return path
+	return p
 }
 
 func applyTemplatedConfigDelta(prevCommit, newCommit *object.Commit, upstreamSubpath string, delta *upstreamDelta) error {
@@ -213,9 +214,9 @@ func applyTemplatedConfigDelta(prevCommit, newCommit *object.Commit, upstreamSub
 }
 
 func readConfigFromCommit(commit *object.Commit, subpath string) (*config.GitSporkConfig, error) {
-	// Defense-in-depth: normalize slashes so a "foo/" or "/foo" subpath doesn't
-	// produce a "foo//.gitspork.yml" lookup that misses the file.
-	subpath = strings.Trim(subpath, "/")
+	// Defense-in-depth: normalize so "foo/", "/foo", "./foo", "foo//sub" all
+	// resolve to the same canonical prefix before we build the config path.
+	subpath = config.NormalizeUpstreamPath(subpath)
 	tree, err := commit.Tree()
 	if err != nil {
 		return &config.GitSporkConfig{}, err

--- a/internal/integrate/upstream_delta_test.go
+++ b/internal/integrate/upstream_delta_test.go
@@ -212,6 +212,50 @@ func Test_computeUpstreamDelta(t *testing.T) {
 		assert.Contains(t, delta.Deletions, "out/foo.txt",
 			"trailing-slash subpath must not prevent nested .gitspork.yml discovery")
 	})
+
+	// path.Clean-backed normalization catches more than a naive TrimSuffix would;
+	// lock these adjacent shapes down as regressions too.
+	t.Run("upstreamSubpath with ./ prefix still strips", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "gitspork-delta-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		repo, prevHash, newHash := makeUpstreamWithDeletedFile(t, dir, "upstream/docs/guide.md")
+		cfg := &config.GitSporkConfig{UpstreamOwned: []config.OwnedEntry{{Pattern: "docs/**"}}}
+
+		delta, err := computeUpstreamDelta(repo, prevHash, newHash, cfg, "./upstream")
+		require.NoError(t, err)
+		assert.Contains(t, delta.Deletions, "docs/guide.md",
+			"./ prefix on subpath must normalize away")
+	})
+
+	t.Run("upstreamSubpath with doubled slashes still strips", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "gitspork-delta-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		repo, prevHash, newHash := makeUpstreamWithDeletedFile(t, dir, "up/stream/docs/guide.md")
+		cfg := &config.GitSporkConfig{UpstreamOwned: []config.OwnedEntry{{Pattern: "docs/**"}}}
+
+		delta, err := computeUpstreamDelta(repo, prevHash, newHash, cfg, "up//stream")
+		require.NoError(t, err)
+		assert.Contains(t, delta.Deletions, "docs/guide.md",
+			"doubled slashes in subpath must be collapsed")
+	})
+
+	t.Run("upstreamSubpath with interior .. resolves", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "gitspork-delta-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		repo, prevHash, newHash := makeUpstreamWithDeletedFile(t, dir, "upstream/docs/guide.md")
+		cfg := &config.GitSporkConfig{UpstreamOwned: []config.OwnedEntry{{Pattern: "docs/**"}}}
+
+		delta, err := computeUpstreamDelta(repo, prevHash, newHash, cfg, "sibling/../upstream")
+		require.NoError(t, err)
+		assert.Contains(t, delta.Deletions, "docs/guide.md",
+			"interior .. in subpath must be resolved before prefix comparison")
+	})
 }
 
 func Test_buildManagedMatchers_resolvesRenameDest(t *testing.T) {

--- a/internal/integrate/upstream_delta_test.go
+++ b/internal/integrate/upstream_delta_test.go
@@ -159,6 +159,59 @@ func Test_computeUpstreamDelta(t *testing.T) {
 		assert.Equal(t, "out/old.txt", delta.Renames[0].OldPath)
 		assert.Equal(t, "out/new.txt", delta.Renames[0].NewPath)
 	})
+
+	// UpstreamSpec.Subpath may be supplied by users with trailing or leading
+	// slashes (e.g. "upstream/"). Pre-normalization such inputs made
+	// stripSubpath build a "upstream//" prefix that matched nothing, silently
+	// dropping every delta from the propagation.
+	t.Run("upstreamSubpath with trailing slash still strips prefix", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "gitspork-delta-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		repo, prevHash, newHash := makeUpstreamWithDeletedFile(t, dir, "upstream/docs/guide.md")
+		cfg := &config.GitSporkConfig{UpstreamOwned: []config.OwnedEntry{{Pattern: "docs/**"}}}
+
+		delta, err := computeUpstreamDelta(repo, prevHash, newHash, cfg, "upstream/")
+		require.NoError(t, err)
+		assert.Contains(t, delta.Deletions, "docs/guide.md",
+			"trailing-slash subpath must still strip the prefix so deletions propagate")
+	})
+
+	t.Run("upstreamSubpath with leading slash still strips prefix", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "gitspork-delta-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		repo, prevHash, newHash := makeUpstreamWithDeletedFile(t, dir, "upstream/docs/guide.md")
+		cfg := &config.GitSporkConfig{UpstreamOwned: []config.OwnedEntry{{Pattern: "docs/**"}}}
+
+		delta, err := computeUpstreamDelta(repo, prevHash, newHash, cfg, "/upstream")
+		require.NoError(t, err)
+		assert.Contains(t, delta.Deletions, "docs/guide.md",
+			"leading-slash subpath must still strip the prefix so deletions propagate")
+	})
+
+	t.Run("upstreamSubpath with trailing slash still finds nested .gitspork.yml for templated delta", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "gitspork-delta-test")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir)
+
+		prevCfg := &config.GitSporkConfig{
+			Templated: []config.GitSporkConfigTemplated{
+				{Template: "tmpl/foo.go.tmpl", Destination: "out/foo.txt"},
+			},
+		}
+		newCfg := &config.GitSporkConfig{}
+		// Config lives at upstream/.gitspork.yml; readConfigFromCommit must not
+		// paste an extra "/" when the caller passed "upstream/" as the subpath.
+		repo, prevHash, newHash := makeUpstreamWithTemplatedConfigChangeInSubpath(t, dir, "upstream", prevCfg, newCfg)
+
+		delta, err := computeUpstreamDelta(repo, prevHash, newHash, newCfg, "upstream/")
+		require.NoError(t, err)
+		assert.Contains(t, delta.Deletions, "out/foo.txt",
+			"trailing-slash subpath must not prevent nested .gitspork.yml discovery")
+	})
 }
 
 func Test_buildManagedMatchers_resolvesRenameDest(t *testing.T) {
@@ -306,6 +359,38 @@ func Test_applyUpstreamDelta(t *testing.T) {
 		_, err = os.Stat(filepath.Join(dir, "config/new.yml"))
 		assert.True(t, os.IsNotExist(err))
 	})
+}
+
+// makeUpstreamWithTemplatedConfigChangeInSubpath is a variant that places
+// .gitspork.yml under <dir>/<subpath>/.gitspork.yml instead of at the repo root.
+func makeUpstreamWithTemplatedConfigChangeInSubpath(t *testing.T, dir, subpath string, prevCfg, newCfg *config.GitSporkConfig) (*gogit.Repository, string, string) {
+	t.Helper()
+	repo, err := gogit.PlainInit(dir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	sig := &object.Signature{Name: config.GitSpork, Email: config.GitSpork + "@localhost", When: time.Now()}
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, subpath), 0755))
+	configPath := filepath.Join(dir, subpath, config.GitSporkConfigFileName)
+
+	b, err := yaml.Marshal(prevCfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, b, 0644))
+	require.NoError(t, wt.AddWithOptions(&gogit.AddOptions{All: true}))
+	prev, err := wt.Commit("add subpath config", &gogit.CommitOptions{Author: sig})
+	require.NoError(t, err)
+
+	b, err = yaml.Marshal(newCfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, b, 0644))
+	require.NoError(t, wt.AddWithOptions(&gogit.AddOptions{All: true}))
+	next, err := wt.Commit("update subpath config", &gogit.CommitOptions{Author: sig})
+	require.NoError(t, err)
+
+	return repo, prev.String(), next.String()
 }
 
 func makeUpstreamWithTemplatedConfigChange(t *testing.T, dir string, prevCfg, newCfg *config.GitSporkConfig) (*gogit.Repository, string, string) {


### PR DESCRIPTION
## Summary

When `UpstreamSpec.Subpath` was written with a trailing (or leading) slash, e.g. `"infra/"`, every downstream call in `computeUpstreamDelta` built a malformed path:

- `stripSubpath("infra/foo/x.md", "infra/")` compared against the prefix `"infra//"` — nothing matched, so the raw path fell through and no manager pattern could resolve it → deletion silently dropped.
- `readConfigFromCommit` tried to open `"infra//.gitspork.yml"` from the tree — file not found, error swallowed by `computeUpstreamDelta` and `prevConfig` fell back to the new config (losing `gitspork rm` propagation), and `applyTemplatedConfigDelta` returned early, missing every templated rename/delete.

## Approach

An initial pass used `strings.Trim(subpath, "/")`. Review pushback pointed out that that leaves an entire adjacent class of shell-produced inputs still broken — `docs//foo`, `./docs`, `docs/./foo`, `docs/bar/../foo` — all of which produce non-canonical paths that miss the same comparisons exactly the same way `"infra/"` did.

Replaced with `config.NormalizeUpstreamPath`, a small helper that:
- runs `path.Clean` (the stdlib's canonicalizer for forward-slash logical paths — the right family here, since `.gitspork.yml` patterns and git tree entries never use OS separators),
- maps the `"."` sentinel back to `""` so callers can special-case root/no-subpath naturally,
- drops any leading `/` (git tree entries never carry one).

Applied at three sites: `computeUpstreamDelta`, `stripSubpath`, `readConfigFromCommit`.

## Test plan

- [x] `go test ./internal/config/ -run Test_NormalizeUpstreamPath` — table-driven coverage of empty, root, trailing slash, leading slash, doubled slashes, `./` prefix, interior `.` and `..`, and combined shapes
- [x] `go test ./internal/integrate/ -run Test_computeUpstreamDelta` — six new subtests: trailing slash + leading slash (delete propagation), trailing slash (nested `.gitspork.yml` discovery for templated delta), and the newly-caught `./`, `//`, and `..` shapes
- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)