### PR TITLE
fix: normalize UpstreamSpec.Subpath at the integrate funnel and state-key builder

### DIFF
--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -73,8 +73,10 @@ type TemplatedIntegrator interface {
 }
 
 // NormalizeUpstreamURL returns a canonical key for an upstream URL+subpath pair
-// so that SSH and HTTPS forms of the same repo compare equal. Used to look up
-// stored state entries regardless of how the upstream URL was originally spelled.
+// so that SSH and HTTPS forms of the same repo compare equal, and so that
+// subpath shape variants ("infra", "infra/", "/infra", "./infra") produce the
+// same key. Used to look up stored state entries regardless of how the upstream
+// URL or subpath was originally spelled.
 func NormalizeUpstreamURL(rawURL string, subpath string) string {
 	u := rawURL
 	// SSH git@host:org/repo -> host/org/repo
@@ -85,6 +87,7 @@ func NormalizeUpstreamURL(rawURL string, subpath string) string {
 	u = reHTTPProto.ReplaceAllString(u, "")
 	// strip trailing .git
 	u = strings.TrimSuffix(u, ".git")
+	subpath = config.NormalizeUpstreamPath(subpath)
 	if subpath != "" {
 		u = u + "::" + subpath
 	}
@@ -158,6 +161,14 @@ func integrateOne(opts *sdktypes.IntegrateOptions, upstream sdktypes.UpstreamSpe
 // carrying the drift-check flag and pinned commit hash, and is called from
 // both integrateOne (public path) and IntegrateForDriftCheck.
 func integrateOneInternal(req *internalRequest, upstream sdktypes.UpstreamSpec) (sdktypes.IntegratedUpstream, error) {
+	// Canonicalize the user-supplied subpath once at the funnel so every
+	// downstream consumer (state lookup key, filepath.Join for the clone root,
+	// computeUpstreamDelta, and the value we persist to state) sees the same
+	// shape. Otherwise "infra/" and "infra" spelled across separate invocations
+	// look like different upstreams to the state matcher — the delta propagation
+	// skips silently and UpsertUpstreamState appends a duplicate entry.
+	upstream.Subpath = config.NormalizeUpstreamPath(upstream.Subpath)
+
 	prevHash := ""
 	if !req.forDriftCheck {
 		existingState, err := LoadDownstreamState(req.DownstreamRepoPath)

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -82,6 +82,25 @@ func Test_NormalizeUpstreamURL(t *testing.T) {
 			NormalizeUpstreamURL("https://github.com/org/repo.git", ""),
 			NormalizeUpstreamURL("https://github.com/org/repo", ""))
 	})
+
+	// Subpath shape must not affect the state-lookup key — otherwise "infra"
+	// (persisted from a prior integrate) and "infra/" (fresh CLI arg from
+	// shell tab-completion) look like two different upstreams and the state
+	// matcher misses.
+	t.Run("subpath shape variants produce the same key", func(t *testing.T) {
+		want := NormalizeUpstreamURL("https://github.com/org/repo.git", "infra")
+		for _, variant := range []string{"infra/", "/infra", "/infra/", "./infra", "infra//"} {
+			assert.Equal(t, want,
+				NormalizeUpstreamURL("https://github.com/org/repo.git", variant),
+				"subpath variant %q should normalize to the same key as %q", variant, "infra")
+		}
+	})
+
+	t.Run("empty subpath and root-slash subpath produce the same key", func(t *testing.T) {
+		assert.Equal(t,
+			NormalizeUpstreamURL("https://github.com/org/repo.git", ""),
+			NormalizeUpstreamURL("https://github.com/org/repo.git", "/"))
+	})
 }
 
 func Test_UpsertUpstreamState_newEntry(t *testing.T) {
@@ -99,6 +118,19 @@ func Test_UpsertUpstreamState_updateExisting(t *testing.T) {
 	// SSH and HTTPS forms of same repo — should match and update in place
 	UpsertUpstreamState(state, sdktypes.UpstreamState{URL: "https://github.com/org/repo.git", CommitHash: "new"})
 	require.Len(t, state.Upstreams, 1)
+	assert.Equal(t, "new", state.Upstreams[0].CommitHash)
+}
+
+func Test_UpsertUpstreamState_subpathShapeVariantsUpdateInPlace(t *testing.T) {
+	// State entry persisted with "infra"; caller now passes "infra/" (shell
+	// tab-completion). Must update in place rather than append a duplicate.
+	state := &sdktypes.DownstreamState{Upstreams: []sdktypes.UpstreamState{
+		{URL: "git@github.com:org/repo.git", Subpath: "infra", CommitHash: "old"},
+	}}
+	UpsertUpstreamState(state, sdktypes.UpstreamState{
+		URL: "git@github.com:org/repo.git", Subpath: "infra/", CommitHash: "new",
+	})
+	require.Len(t, state.Upstreams, 1, "trailing-slash subpath must not create a duplicate state entry")
 	assert.Equal(t, "new", state.Upstreams[0].CommitHash)
 }
 


### PR DESCRIPTION
## Summary

Sibling to the subpath fix in #62 (already merged). `UpstreamSpec.Subpath` enters the integrate flow from three places — the CLI (`ParseUpstreamFlag` stores `kv[1]` verbatim), the SDK (public `Integrate` / `CheckDrift` options), and prior state entries — and every downstream consumer needs the same shape or comparisons fail:

- `NormalizeUpstreamURL` concatenates `subpath` into the state-lookup key raw, so `"infra"` and `"infra/"` produce different keys. A user who integrates once with `"infra"` and again with tab-completed `"infra/"` misses their prior state entry: `prevHash` stays empty, upstream delta propagation skips silently, and `UpsertUpstreamState` appends a second entry that will drift from the first.
- `filepath.Join(cloneDir, upstream.Subpath)` tolerates trailing slash but `"./infra"` or `"infra//sub"` would still produce oddly-shaped paths that later comparisons could trip on.

## Approach

Normalized at two complementary points:

1. **Inside `NormalizeUpstreamURL`** — the state-key builder is now subpath-shape-insensitive regardless of how the caller spelled things. Reads of already-persisted state with non-canonical values match freshly-normalized inputs.
2. **At the top of `integrateOneInternal`** — the funnel every integrate flow (public `Integrate` + `IntegrateForDriftCheck`) passes through. `upstream.Subpath` is canonicalized once, so `filepath.Join`, delta computation, and the value persisted back to state all see the canonical form.

## Test plan

- [x] `go test ./internal/integrate/ -run 'Test_NormalizeUpstreamURL|Test_UpsertUpstreamState'`
  - `Test_NormalizeUpstreamURL/subpath_shape_variants_produce_the_same_key` — `"infra/"`, `"/infra"`, `"/infra/"`, `"./infra"`, `"infra//"` all yield the same key as `"infra"`
  - `Test_NormalizeUpstreamURL/empty_subpath_and_root-slash_subpath_produce_the_same_key`
  - `Test_UpsertUpstreamState_subpathShapeVariantsUpdateInPlace` — state entry persisted with `"infra"` is updated in place (not duplicated) when the caller passes `"infra/"`
- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)