### PR TITLE
Pre-v2 follow-up polish: six adjacent cleanups from the bug-hunt triage

### DIFF
--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -749,7 +749,14 @@ func migrationCompletedInDownstream(migrationID string, downstreamRepoPath strin
 
 func runMigration(migrationInstructions *config.GitSporkConfigMigrationInstructions, upstreamRepoRootPath string, downstreamRepoPath string, logger sdktypes.Logger) error {
 	if migrationInstructions.Exec != "" {
-		execParts := strings.Split(migrationInstructions.Exec, " ")
+		// strings.Fields splits on any run of whitespace (spaces, tabs, newlines),
+		// so double-spaced or tab-separated commands tokenize correctly. Users
+		// needing arguments that contain literal spaces should invoke a shell
+		// explicitly: `sh -c 'my-script "arg with spaces"'`.
+		execParts := strings.Fields(migrationInstructions.Exec)
+		if len(execParts) == 0 {
+			return fmt.Errorf("migration exec %q resolved to zero tokens", migrationInstructions.Exec)
+		}
 		if _, err := os.Stat(filepath.Join(upstreamRepoRootPath, execParts[0])); err == nil {
 			// this is a case where the exec is calling a script that exists in the upstream, so call from that absolute path
 			execParts[0] = filepath.Join(upstreamRepoRootPath, execParts[0])

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -87,11 +87,17 @@ func NormalizeUpstreamURL(rawURL string, subpath string) string {
 	u = reHTTPProto.ReplaceAllString(u, "")
 	// strip trailing .git
 	u = strings.TrimSuffix(u, ".git")
+	// Lowercase the URL portion only. Git host+org+repo are case-insensitive on
+	// the major forges, so "GitHub.com/Org/Repo" and "github.com/org/repo"
+	// should be one entry. Subpath, on the other hand, is a path inside a
+	// case-sensitive filesystem — "infra" and "Infra" are legitimately
+	// distinct directories on Linux and must not collapse into the same key.
+	u = strings.ToLower(u)
 	subpath = config.NormalizeUpstreamPath(subpath)
 	if subpath != "" {
 		u = u + "::" + subpath
 	}
-	return strings.ToLower(u)
+	return u
 }
 
 // UpsertUpstreamState inserts entry into state.Upstreams, replacing any existing

--- a/internal/integrate/integrate.go
+++ b/internal/integrate/integrate.go
@@ -520,28 +520,27 @@ func resolveUpstreamVersionRef(url string, auth transport.AuthMethod, version st
 
 func getIntegrateFiles(inDir string, configuredGlobPatterns []string) ([]string, error) {
 	allFiles := []string{}
-	makeFileRelativePath := func(filePath string) (string, error) {
-		re, err := regexp.Compile(fmt.Sprintf("^%s%s", inDir, string(filepath.Separator)))
-		if err != nil {
-			return "", err
-		}
-		return re.ReplaceAllString(filePath, ""), nil
-	}
 	err := filepath.Walk(inDir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
+		}
+		// filepath.Rel replaces an earlier regexp.Compile("^" + inDir + "/") /
+		// ReplaceAllString approach: the old version treated inDir as a raw
+		// regex, so any regex metacharacter in the upstream clone path (rare
+		// but possible — parentheses, brackets) would either fail to compile
+		// or match unrelated prefixes. filepath.Rel is the stdlib canonical
+		// way to strip a directory prefix.
+		relPath, relErr := filepath.Rel(inDir, path)
+		if relErr != nil {
+			return relErr
 		}
 		for _, configuredGlobPattern := range configuredGlobPatterns {
 			g, inErr := glob.Compile(configuredGlobPattern)
 			if inErr != nil {
 				return inErr
 			}
-			path, inErr = makeFileRelativePath(path)
-			if inErr != nil {
-				return inErr
-			}
-			if g.Match(path) {
-				allFiles = append(allFiles, path)
+			if g.Match(relPath) {
+				allFiles = append(allFiles, relPath)
 				return nil
 			}
 		}

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -101,6 +101,21 @@ func Test_NormalizeUpstreamURL(t *testing.T) {
 			NormalizeUpstreamURL("https://github.com/org/repo.git", ""),
 			NormalizeUpstreamURL("https://github.com/org/repo.git", "/"))
 	})
+
+	// URL host+path is case-insensitive on the major forges, but subpath is a
+	// filesystem path (case-sensitive on Linux). Case-varying subpaths must
+	// stay distinct keys so two upstreams with subpaths that differ only in
+	// case don't collide into one state entry.
+	t.Run("URL host case is normalized but subpath case is preserved", func(t *testing.T) {
+		assert.Equal(t,
+			NormalizeUpstreamURL("https://GitHub.com/Org/Repo.git", "infra"),
+			NormalizeUpstreamURL("https://github.com/org/repo.git", "infra"),
+			"URL portion should be case-insensitive")
+		assert.NotEqual(t,
+			NormalizeUpstreamURL("https://github.com/org/repo.git", "Infra"),
+			NormalizeUpstreamURL("https://github.com/org/repo.git", "infra"),
+			"subpath case must be preserved so case-distinct directories stay distinct keys")
+	})
 }
 
 func Test_UpsertUpstreamState_newEntry(t *testing.T) {

--- a/internal/integrate/integrator_shared_ownership_merged.go
+++ b/internal/integrate/integrator_shared_ownership_merged.go
@@ -14,6 +14,11 @@ import (
 const (
 	sharedOwnershipMergedBeginUpstreamOwnedBlockMarker string = "begin-upstream-owned-block"
 	sharedOwnershipMergedEndUpstreamOwnedBlockMarker   string = "end-upstream-owned-block"
+	// sharedOwnershipMergedMaxLineSize is the per-line cap for bufio.Scanner when
+	// reading upstream and downstream files being merged. The stdlib default is
+	// 64 KiB (bufio.MaxScanTokenSize); real files under this integrator can be
+	// bigger (long lock files, single-line minified assets, generated code).
+	sharedOwnershipMergedMaxLineSize = 4 * 1024 * 1024
 )
 
 // IntegratorSharedOwnershipMerged will process a list of files to have shared ownership and generic merging based on blocks defined as owned by the upstream repo
@@ -34,117 +39,129 @@ func (i *IntegratorSharedOwnershipMerged) Integrate(configuredGlobPatterns []str
 		return fmt.Errorf("error determining the list of files to integrate in %s from %v: %v", upstreamPath, configuredGlobPatterns, err)
 	}
 	for _, integrateFile := range integrateFiles {
-		logger.Log("➰ parsing upstream file %s for owned blocks", integrateFile)
-		upstreamFile, err := os.Open(filepath.Join(upstreamPath, integrateFile))
-		if err != nil {
-			return fmt.Errorf("error opening upstream file %s: %v", integrateFile, err)
+		if err := mergeOneSharedOwnershipFile(upstreamPath, downstreamPath, integrateFile, logger); err != nil {
+			return err
 		}
-		defer upstreamFile.Close()
+	}
+	return nil
+}
 
-		upstreamScanner := bufio.NewScanner(upstreamFile)
+// mergeOneSharedOwnershipFile handles a single upstream/downstream file pair.
+// Extracted so the file-close defers scope to one iteration (avoiding
+// unbounded defer accumulation across the outer file loop) and so both
+// scanners get a common, per-file larger buffer.
+func mergeOneSharedOwnershipFile(upstreamPath, downstreamPath, integrateFile string, logger sdktypes.Logger) error {
+	logger.Log("➰ parsing upstream file %s for owned blocks", integrateFile)
+	upstreamFile, err := os.Open(filepath.Join(upstreamPath, integrateFile))
+	if err != nil {
+		return fmt.Errorf("error opening upstream file %s: %v", integrateFile, err)
+	}
+	defer upstreamFile.Close()
 
-		var currentUpstreamOwnedBlock *upstreamOwnedBlock
-		var upstreamOwnedBlocks []*upstreamOwnedBlock
-		for upstreamScanner.Scan() {
-			line := upstreamScanner.Text()
-			if currentUpstreamOwnedBlock == nil {
-				// not currently tracking/assembling an upstream-owned block
-				if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)) {
-					// beginning identification of an upstream-owned block
-					currentUpstreamOwnedBlock = &upstreamOwnedBlock{
-						beginMarker: line,
-						content:     "",
-					}
-					continue
+	upstreamScanner := bufio.NewScanner(upstreamFile)
+	upstreamScanner.Buffer(make([]byte, 0, 64*1024), sharedOwnershipMergedMaxLineSize)
+
+	var currentUpstreamOwnedBlock *upstreamOwnedBlock
+	var upstreamOwnedBlocks []*upstreamOwnedBlock
+	for upstreamScanner.Scan() {
+		line := upstreamScanner.Text()
+		if currentUpstreamOwnedBlock == nil {
+			// not currently tracking/assembling an upstream-owned block
+			if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)) {
+				// beginning identification of an upstream-owned block
+				currentUpstreamOwnedBlock = &upstreamOwnedBlock{
+					beginMarker: line,
+					content:     "",
 				}
-			} else {
-				// currently tracking/assembling an upstream-owned block
-				if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedEndUpstreamOwnedBlockMarker)) {
-					// detected end upstream owned block, finalize this block
-					currentUpstreamOwnedBlock.endMarker = line
-					upstreamOwnedBlocks = append(upstreamOwnedBlocks, currentUpstreamOwnedBlock)
-					currentUpstreamOwnedBlock = nil
-					continue
-				}
-				currentUpstreamOwnedBlock.content = fmt.Sprintf("%s%s\n", currentUpstreamOwnedBlock.content, line)
-			}
-		}
-
-		if err := upstreamScanner.Err(); err != nil {
-			return fmt.Errorf("error scanning/buffering upstream file %s: %v", integrateFile, err)
-		}
-
-		if _, err := os.Stat(filepath.Join(downstreamPath, integrateFile)); os.IsNotExist(err) {
-			if err := syncFile(filepath.Join(upstreamPath, integrateFile), filepath.Join(downstreamPath, integrateFile)); err != nil {
-				return fmt.Errorf("error copying upstream %s to downstream", integrateFile)
-			}
-		}
-
-		logger.Log("🔧 merging upstream file owned blocks from %s into downstream ", integrateFile)
-		mergedContent := ""
-		downstreamFile, err := os.Open(filepath.Join(downstreamPath, integrateFile))
-		if err != nil {
-			return fmt.Errorf("error opening downstream file %s: %v", integrateFile, err)
-		}
-		defer downstreamFile.Close()
-
-		downstreamScanner := bufio.NewScanner(downstreamFile)
-
-		waitingForUpstreamOwnedBlockEnd := false
-		for downstreamScanner.Scan() {
-			line := downstreamScanner.Text()
-			if waitingForUpstreamOwnedBlockEnd {
-				// we're continuing to silently bypass lines in the downstream in this case, as the block has been replaced
-				// from the relevant upstream defined block
-				if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedEndUpstreamOwnedBlockMarker)) {
-					waitingForUpstreamOwnedBlockEnd = false
-					continue
-				}
-			} else if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)) {
-				if len(upstreamOwnedBlocks) == 0 {
-					// Downstream carries an upstream-owned-block marker that has no counterpart
-					// in upstream (upstream likely removed the block, or downstream has a stray
-					// marker). Preserve the downstream line as-is so any content inside the
-					// unmatched pair is retained — it has effectively transitioned to downstream
-					// ownership — and warn so the user can reconcile.
-					logger.Log("⚠️  %s: downstream has an unmatched %s marker (no matching upstream block); preserving downstream content as-is", integrateFile, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)
-					mergedContent = fmt.Sprintf("%s%s\n", mergedContent, line)
-					continue
-				}
-				// found begin owned block begin, we can simply inject the upstream-defined owned block at the same index and then just
-				// continue scanning the downstream file until we see the next end upstream owned block marker
-				mergedContent = fmt.Sprintf("%s%s\n%s%s\n",
-					mergedContent,
-					upstreamOwnedBlocks[0].beginMarker,
-					upstreamOwnedBlocks[0].content,
-					upstreamOwnedBlocks[0].endMarker,
-				)
-				waitingForUpstreamOwnedBlockEnd = true
-				upstreamOwnedBlocks = upstreamOwnedBlocks[1:] // shifting the first element off the slice, previous second item becomes new first
 				continue
-			} else {
-				// every other case we should simply be merging the dowstream line back into merged content
-				mergedContent = fmt.Sprintf("%s%s\n", mergedContent, line)
 			}
-		}
-		// if we still have upstream owned blocks in our slice/list, we can just begin appending them here
-		for _, upstreamOwnedBlock := range upstreamOwnedBlocks {
-			mergedContent = fmt.Sprintf("%s%s\n%s%s\n",
-				mergedContent,
-				upstreamOwnedBlock.beginMarker,
-				upstreamOwnedBlock.content,
-				upstreamOwnedBlock.endMarker,
-			)
-		}
-
-		if err := downstreamScanner.Err(); err != nil {
-			return fmt.Errorf("error scanning/buffering downstream file %s: %v", integrateFile, err)
-		}
-
-		if err := os.WriteFile(filepath.Join(downstreamPath, integrateFile), []byte(mergedContent), 0644); err != nil {
-			return fmt.Errorf("error writing merged file %s to downstream: %v", integrateFile, err)
+		} else {
+			// currently tracking/assembling an upstream-owned block
+			if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedEndUpstreamOwnedBlockMarker)) {
+				// detected end upstream owned block, finalize this block
+				currentUpstreamOwnedBlock.endMarker = line
+				upstreamOwnedBlocks = append(upstreamOwnedBlocks, currentUpstreamOwnedBlock)
+				currentUpstreamOwnedBlock = nil
+				continue
+			}
+			currentUpstreamOwnedBlock.content = fmt.Sprintf("%s%s\n", currentUpstreamOwnedBlock.content, line)
 		}
 	}
 
+	if err := upstreamScanner.Err(); err != nil {
+		return fmt.Errorf("error scanning/buffering upstream file %s: %v", integrateFile, err)
+	}
+
+	if _, err := os.Stat(filepath.Join(downstreamPath, integrateFile)); os.IsNotExist(err) {
+		if err := syncFile(filepath.Join(upstreamPath, integrateFile), filepath.Join(downstreamPath, integrateFile)); err != nil {
+			return fmt.Errorf("error copying upstream %s to downstream", integrateFile)
+		}
+	}
+
+	logger.Log("🔧 merging upstream file owned blocks from %s into downstream ", integrateFile)
+	mergedContent := ""
+	downstreamFile, err := os.Open(filepath.Join(downstreamPath, integrateFile))
+	if err != nil {
+		return fmt.Errorf("error opening downstream file %s: %v", integrateFile, err)
+	}
+	defer downstreamFile.Close()
+
+	downstreamScanner := bufio.NewScanner(downstreamFile)
+	downstreamScanner.Buffer(make([]byte, 0, 64*1024), sharedOwnershipMergedMaxLineSize)
+
+	waitingForUpstreamOwnedBlockEnd := false
+	for downstreamScanner.Scan() {
+		line := downstreamScanner.Text()
+		if waitingForUpstreamOwnedBlockEnd {
+			// we're continuing to silently bypass lines in the downstream in this case, as the block has been replaced
+			// from the relevant upstream defined block
+			if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedEndUpstreamOwnedBlockMarker)) {
+				waitingForUpstreamOwnedBlockEnd = false
+				continue
+			}
+		} else if strings.Contains(line, fmt.Sprintf("%s%s", config.GitSporkCommentMarker, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)) {
+			if len(upstreamOwnedBlocks) == 0 {
+				// Downstream carries an upstream-owned-block marker that has no counterpart
+				// in upstream (upstream likely removed the block, or downstream has a stray
+				// marker). Preserve the downstream line as-is so any content inside the
+				// unmatched pair is retained — it has effectively transitioned to downstream
+				// ownership — and warn so the user can reconcile.
+				logger.Log("⚠️  %s: downstream has an unmatched %s marker (no matching upstream block); preserving downstream content as-is", integrateFile, sharedOwnershipMergedBeginUpstreamOwnedBlockMarker)
+				mergedContent = fmt.Sprintf("%s%s\n", mergedContent, line)
+				continue
+			}
+			// found begin owned block begin, we can simply inject the upstream-defined owned block at the same index and then just
+			// continue scanning the downstream file until we see the next end upstream owned block marker
+			mergedContent = fmt.Sprintf("%s%s\n%s%s\n",
+				mergedContent,
+				upstreamOwnedBlocks[0].beginMarker,
+				upstreamOwnedBlocks[0].content,
+				upstreamOwnedBlocks[0].endMarker,
+			)
+			waitingForUpstreamOwnedBlockEnd = true
+			upstreamOwnedBlocks = upstreamOwnedBlocks[1:] // shifting the first element off the slice, previous second item becomes new first
+			continue
+		} else {
+			// every other case we should simply be merging the dowstream line back into merged content
+			mergedContent = fmt.Sprintf("%s%s\n", mergedContent, line)
+		}
+	}
+	// if we still have upstream owned blocks in our slice/list, we can just begin appending them here
+	for _, upstreamOwnedBlock := range upstreamOwnedBlocks {
+		mergedContent = fmt.Sprintf("%s%s\n%s%s\n",
+			mergedContent,
+			upstreamOwnedBlock.beginMarker,
+			upstreamOwnedBlock.content,
+			upstreamOwnedBlock.endMarker,
+		)
+	}
+
+	if err := downstreamScanner.Err(); err != nil {
+		return fmt.Errorf("error scanning/buffering downstream file %s: %v", integrateFile, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(downstreamPath, integrateFile), []byte(mergedContent), 0644); err != nil {
+		return fmt.Errorf("error writing merged file %s to downstream: %v", integrateFile, err)
+	}
 	return nil
 }

--- a/internal/integrate/integrator_shared_ownership_test.go
+++ b/internal/integrate/integrator_shared_ownership_test.go
@@ -244,6 +244,27 @@ func TestIntegratorSharedOwnershipMerged(t *testing.T) {
 			"the unmatched begin-marker itself should be preserved so the user can reconcile explicitly")
 	})
 
+	t.Run("handles lines larger than the stdlib bufio.Scanner default (64 KiB)", func(t *testing.T) {
+		// Real-world files under this integrator include Makefiles and lock
+		// files that occasionally carry very long lines (minified content,
+		// generated code). The default bufio.Scanner buffer capped at 64 KiB
+		// per line would return bufio.ErrTooLong; bumped to a per-file limit
+		// large enough for reasonable content.
+		const longLineLen = 200 * 1024 // 200 KiB > default 64 KiB
+		longLine := strings.Repeat("x", longLineLen)
+		upstream := beginMarker + "\n" + longLine + "\n" + endMarker + "\n"
+		downstream := beginMarker + "\nstale short line\n" + endMarker + "\n"
+		upstreamDir, downstreamDir := setupStructuredPair(t, "generated.txt", upstream, downstream)
+
+		integrator := &IntegratorSharedOwnershipMerged{}
+		require.NoError(t, integrator.Integrate([]string{"generated.txt"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+		got, err := os.ReadFile(filepath.Join(downstreamDir, "generated.txt"))
+		require.NoError(t, err)
+		assert.Contains(t, string(got), longLine, "long upstream-owned line should be preserved intact")
+		assert.NotContains(t, string(got), "stale short line", "downstream block content should be replaced by upstream content")
+	})
+
 	t.Run("downstream has second unmatched begin-marker after a matched one", func(t *testing.T) {
 		// Mixed case: first begin-marker in downstream matches the single upstream block;
 		// second begin-marker in downstream has nothing to match. Must not panic.

--- a/internal/integrate/integrator_templated.go
+++ b/internal/integrate/integrator_templated.go
@@ -147,27 +147,36 @@ func (i *IntegratorTemplated) Integrate(templatedInstructions []config.GitSporkC
 			return fmt.Errorf("error rendering template data: %v", err)
 		}
 		if performPostMergeStructured != "" {
-			tmpDir, err := os.MkdirTemp("", config.GitSpork)
-			if err != nil {
-				return fmt.Errorf("error creating temp directory: %v", err)
-			}
-			defer os.RemoveAll(tmpDir)
-			tmpFilePath := filepath.Join(tmpDir, filepath.Base(fullDestinationPath))
-			if err := os.WriteFile(tmpFilePath, renderedBytes.Bytes(), 0644); err != nil {
-				return fmt.Errorf("error writing rendered template to temporary location: %v", err)
-			}
-			newData, existingData, structuredDataType, err := getStructuredData(tmpFilePath, fullDestinationPath)
-			if err != nil {
-				return fmt.Errorf("error loading structured data from existing/new template render process in %s: %v", templatedInstruction.Template, err)
-			}
-			var merged *node
-			if performPostMergeStructured == config.TemplatedMergeStructuredPreferDownstream {
-				merged = mergeNodes(newData, existingData, true)
-			} else {
-				merged = mergeNodes(existingData, newData, true)
-			}
-			if err := writeStructuredData(merged, structuredDataType, fullDestinationPath); err != nil {
-				return fmt.Errorf("error writing merged structured data in templated instruction from %s: %v", templatedInstruction.Template, err)
+			// Wrapped in a closure so the tmpDir RemoveAll defer scopes to a
+			// single templated instruction — otherwise every render in the
+			// outer loop accumulated another defer that only ran at Integrate
+			// return, holding onto multiple temp directories for the whole run.
+			if err := func() error {
+				tmpDir, err := os.MkdirTemp("", config.GitSpork)
+				if err != nil {
+					return fmt.Errorf("error creating temp directory: %v", err)
+				}
+				defer os.RemoveAll(tmpDir)
+				tmpFilePath := filepath.Join(tmpDir, filepath.Base(fullDestinationPath))
+				if err := os.WriteFile(tmpFilePath, renderedBytes.Bytes(), 0644); err != nil {
+					return fmt.Errorf("error writing rendered template to temporary location: %v", err)
+				}
+				newData, existingData, structuredDataType, err := getStructuredData(tmpFilePath, fullDestinationPath)
+				if err != nil {
+					return fmt.Errorf("error loading structured data from existing/new template render process in %s: %v", templatedInstruction.Template, err)
+				}
+				var merged *node
+				if performPostMergeStructured == config.TemplatedMergeStructuredPreferDownstream {
+					merged = mergeNodes(newData, existingData, true)
+				} else {
+					merged = mergeNodes(existingData, newData, true)
+				}
+				if err := writeStructuredData(merged, structuredDataType, fullDestinationPath); err != nil {
+					return fmt.Errorf("error writing merged structured data in templated instruction from %s: %v", templatedInstruction.Template, err)
+				}
+				return nil
+			}(); err != nil {
+				return err
 			}
 		} else {
 			if err := os.WriteFile(fullDestinationPath, renderedBytes.Bytes(), 0644); err != nil {

--- a/internal/integrate/integrator_templated.go
+++ b/internal/integrate/integrator_templated.go
@@ -74,11 +74,14 @@ func (i *IntegratorTemplated) Integrate(templatedInstructions []config.GitSporkC
 				if err != nil {
 					return fmt.Errorf("error reading json_data_path at %s: %v", jsonDataPath, err)
 				}
-				err = json.Unmarshal(jsonData, &templateData.Inputs)
-				maps.Copy(capturedInputValues[templatedInstruction.Template], templateData.Inputs)
-				if err != nil {
+				if err := json.Unmarshal(jsonData, &templateData.Inputs); err != nil {
 					return fmt.Errorf("error parsing json_data_path file %s into inputs: %v", jsonDataPath, err)
 				}
+				// Only propagate inputs to capturedInputValues after a successful
+				// unmarshal — otherwise a JSON parse error would leak partially-
+				// populated data into the previous_input chain for subsequent
+				// templated instructions in this run.
+				maps.Copy(capturedInputValues[templatedInstruction.Template], templateData.Inputs)
 			} else if input.Prompt != "" {
 				if templateData.Inputs[input.Name] == "" || forceRePrompt {
 					requestInputOpts := &inputpkg.RequestInputOptions{


### PR DESCRIPTION
## Summary

Sixth and final PR in the pre-v2 bug-hunt series. Groups six unrelated but small cleanups from the "follow-up items" bucket of the original triage — each independently a minor defect, none individually worth a dedicated PR, all worth landing before v2.

### 1. Scanner buffer + defer scoping in shared-ownership merge (items #10 + #16)

`shared_ownership_merged`'s per-file loop opened upstream and downstream files with `defer file.Close()` in the loop body, so every file processed added two more defers that only ran at function return — FDs accumulating for the entire ownership list. The two `bufio.Scanner` instances also used the stdlib default 64 KiB per-line buffer, which fails on real files with long lines (lock files, minified assets, generated code) with `bufio.ErrTooLong`.

Refactored the loop body into `mergeOneSharedOwnershipFile` so file-close defers scope per-iteration, and set both scanners to a 4 MiB per-line cap in one place. Regression test asserts a 200 KiB upstream-owned line survives intact.

### 2. `runMigration` uses `strings.Fields` (item #11)

Migration `Exec` was split with `strings.Split(s, " ")` which produced empty tokens for any run of whitespace (`"./script  --flag"` → `["./script", "", "--flag"]`). Switched to `strings.Fields`. Added a zero-token guard so an empty exec produces a clear error instead of index-out-of-range. Full shell tokenization (quoted args, escapes) is documented as out of scope — users needing that can invoke `sh -c '…'` explicitly.

### 3. `NormalizeUpstreamURL` preserves subpath case (item #13)

The whole URL+subpath key was `strings.ToLower`'d, which collapsed subpath case — `"Infra"` and `"infra"` on a case-sensitive filesystem (Linux) mapped to the same state key. Git host+org+repo remain case-insensitive; only the URL portion is lowercased now.

### 4. Templated integrator: check JSON error before copying inputs (item #15)

`json.Unmarshal` writes partial data into the destination map even when it later returns an error. The previous ordering ran `maps.Copy` into `capturedInputValues` before the error check, leaking partial data into the `previous_input` chain for subsequent templated instructions in the same run. Swapped so the error check runs first.

### 5. Templated tmpDir defer scoping (item #16, templated half)

The structured-merge branch inside the templated per-instruction loop deferred `os.RemoveAll(tmpDir)` — every triggering instruction accumulated another defer. Wrapped in an anonymous function so cleanup scopes per-iteration.

### 6. Drop regex-based path stripping from `getIntegrateFiles` (item #17)

`regexp.Compile(fmt.Sprintf("^%s%s", inDir, filepath.Separator))` put raw path bytes into a regex pattern without escaping, so regex metacharacters in an upstream clone path could either fail to compile or match unrelated prefixes. Replaced with `filepath.Rel` — the stdlib canonical way to strip a directory prefix.

## Skipped from the triage

The remaining triage items were reviewed and skipped as either not real defects or out of scope for this pre-release polish:

- **#12** (drift-check with unreachable pinned commit): already errors clearly with the commit hash named. Improvement here is UX polish, not correctness.
- **#14** (duplicate override URL detection): the file-owner attribution loop is idempotent under duplicates. Nice-to-have UX validation only.
- **#18** (rename-entry parallel prefix desync in mv): couldn't construct a concrete failure case — the current behaviour (rewrite `From`, leave `To`) is intentional and correct because `To` is a downstream landing path.
- **#19** (`.gitignore`-covered drift not detected): intentional — if the user chose to ignore a file, drift on that file isn't something drift-check should surface.
- **#20** (state commit-hash format validation): a garbage commit hash flows through `plumbing.NewHash` → zero-hash → `plumbing.ErrObjectNotFound`, which after #9's fix is a legitimate silent no-op path. No further validation needed.

## Test plan

- [x] `make test-unit`
- [x] `make test-functional`

🤖 Generated with [Claude Code](https://claude.com/claude-code)