### PR TITLE
test: coverage for migration hook flow end-to-end

### DIFF
--- a/internal/config/migration_parse_test.go
+++ b/internal/config/migration_parse_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseMigrationConfig(t *testing.T) {
+	writeYAML := func(t *testing.T, contents string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "migration.yml")
+		require.NoError(t, os.WriteFile(p, []byte(contents), 0644))
+		return p
+	}
+
+	t.Run("only pre_integrate present", func(t *testing.T) {
+		p := writeYAML(t, "pre_integrate:\n  exec: ./setup.sh --v2\n")
+		m, err := ParseMigrationConfig(p)
+		require.NoError(t, err)
+		require.NotNil(t, m.PreIntegrate)
+		assert.Equal(t, "./setup.sh --v2", m.PreIntegrate.Exec)
+		assert.Nil(t, m.PostIntegrate)
+	})
+
+	t.Run("only post_integrate present", func(t *testing.T) {
+		p := writeYAML(t, "post_integrate:\n  exec: ./cleanup.sh\n")
+		m, err := ParseMigrationConfig(p)
+		require.NoError(t, err)
+		assert.Nil(t, m.PreIntegrate)
+		require.NotNil(t, m.PostIntegrate)
+		assert.Equal(t, "./cleanup.sh", m.PostIntegrate.Exec)
+	})
+
+	t.Run("both present", func(t *testing.T) {
+		p := writeYAML(t, "pre_integrate:\n  exec: pre.sh\npost_integrate:\n  exec: post.sh\n")
+		m, err := ParseMigrationConfig(p)
+		require.NoError(t, err)
+		require.NotNil(t, m.PreIntegrate)
+		require.NotNil(t, m.PostIntegrate)
+		assert.Equal(t, "pre.sh", m.PreIntegrate.Exec)
+		assert.Equal(t, "post.sh", m.PostIntegrate.Exec)
+	})
+
+	t.Run("empty file yields both-nil migration", func(t *testing.T) {
+		p := writeYAML(t, "")
+		m, err := ParseMigrationConfig(p)
+		require.NoError(t, err)
+		assert.Nil(t, m.PreIntegrate)
+		assert.Nil(t, m.PostIntegrate)
+	})
+
+	t.Run("missing file returns wrapped read error", func(t *testing.T) {
+		_, err := ParseMigrationConfig(filepath.Join(t.TempDir(), "nonexistent.yml"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error reading gitspork migration config file")
+	})
+
+	t.Run("malformed YAML returns wrapped parse error", func(t *testing.T) {
+		p := writeYAML(t, "pre_integrate: [invalid: mapping\n  under: sequence]\n")
+		_, err := ParseMigrationConfig(p)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing gitspork migration config file")
+	})
+}

--- a/internal/integrate/migration_test.go
+++ b/internal/integrate/migration_test.go
@@ -1,0 +1,164 @@
+package integrate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/rockholla/gitspork/v2/internal/config"
+	"github.com/rockholla/gitspork/v2/internal/sdktypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_runMigration(t *testing.T) {
+	t.Run("empty Exec is a no-op", func(t *testing.T) {
+		err := runMigration(&config.GitSporkConfigMigrationInstructions{Exec: ""}, t.TempDir(), t.TempDir(), sdktypes.NoopLogger())
+		assert.NoError(t, err)
+	})
+
+	t.Run("whitespace-only Exec returns zero-token error", func(t *testing.T) {
+		err := runMigration(&config.GitSporkConfigMigrationInstructions{Exec: "   \t  "}, t.TempDir(), t.TempDir(), sdktypes.NoopLogger())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolved to zero tokens")
+	})
+
+	if runtime.GOOS == "windows" {
+		t.Skip("remaining subtests use POSIX shell scripts")
+		return
+	}
+
+	t.Run("upstream script is resolved to absolute upstream path and executes from downstream cwd", func(t *testing.T) {
+		upstreamDir := t.TempDir()
+		downstreamDir := t.TempDir()
+
+		scriptRel := "migrate.sh"
+		// pwd -P forces physical-path resolution so the sentinel matches
+		// filepath.EvalSymlinks on the Go side (macOS's /var/folders is a
+		// symlink to /private/var/folders and `pwd` alone would keep the
+		// logical form the Go stdlib used to chdir).
+		scriptContents := "#!/bin/sh\npwd -P > cwd.txt\necho migration ran > ran.txt\n"
+		require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, scriptRel), []byte(scriptContents), 0755))
+
+		err := runMigration(&config.GitSporkConfigMigrationInstructions{Exec: "./" + scriptRel}, upstreamDir, downstreamDir, sdktypes.NoopLogger())
+		require.NoError(t, err)
+
+		// Script wrote to cwd — asserts it ran with cmd.Dir == downstreamDir,
+		// NOT upstream (since runMigration should scope side effects to the
+		// downstream tree).
+		gotCwd, readErr := os.ReadFile(filepath.Join(downstreamDir, "cwd.txt"))
+		require.NoError(t, readErr, "expected downstream cwd sentinel; runMigration should execute with cmd.Dir=downstreamDir")
+
+		// macOS resolves /tmp -> /private/tmp; compare via EvalSymlinks.
+		resolvedDownstream, err := filepath.EvalSymlinks(downstreamDir)
+		require.NoError(t, err)
+		assert.Equal(t, resolvedDownstream, strings.TrimSpace(string(gotCwd)),
+			"pwd inside the migration script must match downstream repo path")
+
+		gotMarker, err := os.ReadFile(filepath.Join(downstreamDir, "ran.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "migration ran\n", string(gotMarker))
+
+		// Sanity: the upstream directory should be untouched.
+		_, err = os.Stat(filepath.Join(upstreamDir, "cwd.txt"))
+		assert.True(t, os.IsNotExist(err), "script should not have written into the upstream tree")
+	})
+
+	t.Run("command not present in upstream falls through to PATH", func(t *testing.T) {
+		upstreamDir := t.TempDir()
+		downstreamDir := t.TempDir()
+		// "true" is not a file at upstreamDir/true; runMigration should
+		// leave execParts[0] alone and exec.LookPath resolves it from $PATH.
+		err := runMigration(&config.GitSporkConfigMigrationInstructions{Exec: "true"}, upstreamDir, downstreamDir, sdktypes.NoopLogger())
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-zero exit propagates as error", func(t *testing.T) {
+		upstreamDir := t.TempDir()
+		downstreamDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, "fail.sh"), []byte("#!/bin/sh\nexit 3\n"), 0755))
+		err := runMigration(&config.GitSporkConfigMigrationInstructions{Exec: "./fail.sh"}, upstreamDir, downstreamDir, sdktypes.NoopLogger())
+		require.Error(t, err, "subprocess non-zero exit must propagate")
+		assert.Contains(t, err.Error(), "exit status 3")
+	})
+
+	t.Run("tab-separated and double-spaced arguments tokenize via strings.Fields", func(t *testing.T) {
+		upstreamDir := t.TempDir()
+		downstreamDir := t.TempDir()
+		// The script writes its argv, so we can verify tokens flowed through
+		// intact regardless of the whitespace shape the user wrote.
+		scriptContents := "#!/bin/sh\nprintf %s \"$1|$2|$3\" > argv.txt\n"
+		require.NoError(t, os.WriteFile(filepath.Join(upstreamDir, "args.sh"), []byte(scriptContents), 0755))
+
+		// Two tabs, three spaces, mixed — should still yield three arguments.
+		err := runMigration(&config.GitSporkConfigMigrationInstructions{Exec: "./args.sh\talpha  beta \tgamma"}, upstreamDir, downstreamDir, sdktypes.NoopLogger())
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(downstreamDir, "argv.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "alpha|beta|gamma", string(got))
+	})
+}
+
+func Test_migrationCompletedInDownstream(t *testing.T) {
+	t.Run("returns true when ID is present in state", func(t *testing.T) {
+		dir := t.TempDir()
+		state := &sdktypes.DownstreamState{MigrationsComplete: []string{"m/one:pre_integrate", "m/two:post_integrate"}}
+		require.NoError(t, SaveDownstreamState(dir, state))
+
+		got, err := migrationCompletedInDownstream("m/one:pre_integrate", dir)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("returns false when ID is not in state", func(t *testing.T) {
+		dir := t.TempDir()
+		state := &sdktypes.DownstreamState{MigrationsComplete: []string{"m/one:pre_integrate"}}
+		require.NoError(t, SaveDownstreamState(dir, state))
+
+		got, err := migrationCompletedInDownstream("m/absent:post_integrate", dir)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("returns false against a fresh downstream with no state file", func(t *testing.T) {
+		got, err := migrationCompletedInDownstream("anything", t.TempDir())
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}
+
+func Test_recordCompleteMigration(t *testing.T) {
+	t.Run("creates fresh state and records the ID", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, recordCompleteMigration("m/one:pre_integrate", dir))
+
+		state, err := LoadDownstreamState(dir)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"m/one:pre_integrate"}, state.MigrationsComplete)
+	})
+
+	t.Run("recording the same ID twice does not duplicate the entry", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, recordCompleteMigration("m/one:pre_integrate", dir))
+		require.NoError(t, recordCompleteMigration("m/one:pre_integrate", dir))
+
+		state, err := LoadDownstreamState(dir)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"m/one:pre_integrate"}, state.MigrationsComplete,
+			"recordCompleteMigration must be idempotent — this guarantees migrations run at most once")
+	})
+
+	t.Run("recording distinct IDs preserves order and grows the list", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, recordCompleteMigration("m/one:pre_integrate", dir))
+		require.NoError(t, recordCompleteMigration("m/two:post_integrate", dir))
+		require.NoError(t, recordCompleteMigration("m/three:pre_integrate", dir))
+
+		state, err := LoadDownstreamState(dir)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"m/one:pre_integrate", "m/two:post_integrate", "m/three:pre_integrate"}, state.MigrationsComplete)
+	})
+}

--- a/test/functional/migration_test.go
+++ b/test/functional/migration_test.go
@@ -1,0 +1,101 @@
+//go:build functional || functional_docker
+
+package functional
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// migrationGitsporkYML wires a single migration file into the upstream config.
+const migrationGitsporkYML = `upstream_owned:
+- upstream-owned/**
+migrations:
+- .gitspork/migrations/0001/migration.yml
+`
+
+// migrationYML declares both a pre_integrate and post_integrate hook. The
+// scripts each append their name plus a timestamp-like counter to a sentinel
+// file in the downstream — running twice must yield exactly one appended line
+// per hook (the once-only property enforced by state.MigrationsComplete).
+const migrationYML = `pre_integrate:
+  exec: ./.gitspork/migrations/0001/pre.sh
+post_integrate:
+  exec: ./.gitspork/migrations/0001/post.sh
+`
+
+const preScript = `#!/bin/sh
+echo pre-ran >> migration-log.txt
+`
+
+const postScript = `#!/bin/sh
+echo post-ran >> migration-log.txt
+`
+
+// TestIntegrate_migration_hooks_run_end_to_end verifies:
+//   1. pre_integrate and post_integrate hooks both execute against the downstream.
+//   2. On a second integrate, neither hook re-runs — the once-only guarantee
+//      via .gitspork/downstream-state.json migrations_complete.
+//
+// Skipped on Windows because the migration scripts are POSIX shell.
+func TestIntegrate_migration_hooks_run_end_to_end(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("migration hooks are POSIX shell in this test")
+	}
+
+	upstreamDir := NewUpstreamRepo(t, map[string]string{
+		"upstream-owned/file.txt":               "upstream content\n",
+		".gitspork/migrations/0001/migration.yml": migrationYML,
+		".gitspork/migrations/0001/pre.sh":        preScript,
+		".gitspork/migrations/0001/post.sh":       postScript,
+	}, migrationGitsporkYML)
+
+	// The two scripts need executable bits — NewUpstreamRepo writes with the
+	// default file mode, so chmod them here before the upstream is used.
+	require.NoError(t, os.Chmod(filepath.Join(upstreamDir, ".gitspork/migrations/0001/pre.sh"), 0755))
+	require.NoError(t, os.Chmod(filepath.Join(upstreamDir, ".gitspork/migrations/0001/post.sh"), 0755))
+	// Re-commit so the chmod is captured by the repo.
+	CommitAll(t, OpenRepo(t, upstreamDir), upstreamDir, "chmod +x migration scripts")
+
+	downstreamDir := NewDownstreamRepo(t)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+	args := integrateArgs(upstreamDir, downstreamDir)
+
+	// First integrate: hooks should run.
+	out, code := runner.Run(t, args, downstreamDir)
+	require.Equal(t, 0, code, "first integrate exited non-zero:\n%s", out)
+
+	logAfterFirst := ReadFile(t, downstreamDir, "migration-log.txt")
+	assert.Equal(t, "pre-ran\npost-ran\n", logAfterFirst,
+		"first integrate should run pre_integrate then post_integrate exactly once each")
+
+	// Commit the log so the tree is clean before re-integrate.
+	CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "post-integrate baseline")
+
+	// State file should list both hooks as complete after run one.
+	stateAfterFirst := ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+	assert.Contains(t, stateAfterFirst, ":pre_integrate",
+		"state.migrations_complete should record the pre_integrate hook")
+	assert.Contains(t, stateAfterFirst, ":post_integrate",
+		"state.migrations_complete should record the post_integrate hook")
+
+	// Second integrate: hooks must NOT run again.
+	out, code = runner.Run(t, args, downstreamDir)
+	require.Equal(t, 0, code, "second integrate exited non-zero:\n%s", out)
+
+	logAfterSecond := ReadFile(t, downstreamDir, "migration-log.txt")
+	assert.Equal(t, logAfterFirst, logAfterSecond,
+		"migration-log.txt must be unchanged after re-integrate: hooks are once-only")
+	// Defense in depth against future silent regressions of the once-only
+	// property: count occurrences directly rather than only comparing strings.
+	assert.Equal(t, 1, strings.Count(logAfterSecond, "pre-ran"),
+		"pre_integrate must run exactly once across two integrates")
+	assert.Equal(t, 1, strings.Count(logAfterSecond, "post-ran"),
+		"post_integrate must run exactly once across two integrates")
+}


### PR DESCRIPTION
## Summary

First PR in the coverage-audit series. Migration hooks — `pre_integrate` / `post_integrate` — were 0% covered across:

- `config.ParseMigrationConfig`
- `integrate.runMigration`
- `integrate.migrationCompletedInDownstream`
- `integrate.recordCompleteMigration`

A whole user-facing feature with no automated safety net. Added coverage at three tiers so a regression at any layer surfaces.

## What's covered

### Unit — `internal/config/migration_parse_test.go`
- pre-only / post-only / both / neither present
- missing file returns wrapped read error
- malformed YAML returns wrapped parse error

### Unit — `internal/integrate/migration_test.go`
- `runMigration`:
  - empty Exec no-ops
  - whitespace-only Exec returns zero-token error
  - upstream-relative script gets absolute-path resolved AND executes with `cmd.Dir == downstreamDir` (asserted via `pwd -P` sentinel; upstream tree remains untouched)
  - PATH command (`Exec="true"`) falls through cleanly
  - non-zero exit propagates as `"exit status 3"` error
  - `strings.Fields` tokenisation handles tabs and multi-space
- `migrationCompletedInDownstream`: ID present / absent / no state file
- `recordCompleteMigration`: fresh state, idempotence on duplicate ID (the invariant guaranteeing migrations run at most once), preserved order across distinct IDs

### Functional — `test/functional/migration_test.go`
- `TestIntegrate_migration_hooks_run_end_to_end`: two integrates against an upstream with pre+post hooks both appending to a sentinel file. Asserts the file has exactly one line per hook after run two AND that `.gitspork/downstream-state.json` records both hook IDs as complete. Skipped on Windows.

## Test plan

- [x] `go test ./internal/config/ -run Test_ParseMigrationConfig`
- [x] `go test ./internal/integrate/ -run 'Test_(runMigration|migrationCompletedInDownstream|recordCompleteMigration)'`
- [x] `make test-unit`
- [x] `make test-functional`

🤖 Generated with [Claude Code](https://claude.com/claude-code)