### PR TITLE
test: lock UpstreamSpec.Subpath at CLI + SDK tiers; move testharness under test/ with build tag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "gopls": {
-    "build.buildFlags": ["-tags=functional,functional_docker,examples,sdk"]
+    "build.buildFlags": ["-tags=functional,functional_docker,examples,sdk,testharness"]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,11 @@ internal/               # All business logic (unexported to SDK consumers)
   logutil/              # Default Logger, diff colorizer, ColorizeYAML
   sdktypes/             # Shared SDK types (options, results, errors, Logger interface) — reason: avoids import cycles between root gitspork, drift, and integrate packages
   input/                # Prompt and JSON input resolution
-  testharness/          # Shared test helpers (non-test package, importable by all test packages)
 test/
   functional/           # Scenario tests against compiled binary or Docker image
   examples/             # Tests that run against the docs/examples/ upstream directories
   sdk/                  # Black-box tests importing github.com/rockholla/gitspork/v2 as a library
+  testharness/          # Shared test helpers (build-tag guarded, see below)
 docs/
   examples/             # Four fully worked upstream examples (platform-team, open-source-template, standards-library, integrate-local)
   superpowers/          # Design specs and implementation plans (specs/ and plans/)
@@ -71,7 +71,7 @@ make test-sdk               # -tags sdk (black-box tests importing github.com/ro
 - `sdk` — activates `test/sdk/` (black-box library tests)
 - `harness_native.go` uses `//go:build functional && !functional_docker` to avoid gopls duplicate declaration errors when both tags are active
 
-**Shared test helpers** live in `internal/testharness/testharness.go` (no build tag). Both `test/functional/`, `test/examples/`, and `test/sdk/` import from there. `test/functional/harness.go` wraps them with thin delegating functions.
+**Shared test helpers** live in `test/testharness/testharness.go` and are guarded by `//go:build testharness`. Every `make test-*` target passes the `testharness` tag (chained with the suite tier tag, e.g. `-tags functional,testharness`); a direct `go test ./…` invocation that imports the harness must include `-tags testharness` too. A production import from anywhere under `cmd/` or `internal/` fails at compile time with `build constraints exclude all Go files in …/test/testharness`, so test-only code cannot silently leak into the release binary. Both `test/functional/`, `test/examples/`, and `test/sdk/` import from the harness; `test/functional/harness.go` wraps them with thin delegating functions.
 
 ## CI
 

--- a/Makefile
+++ b/Makefile
@@ -11,25 +11,30 @@ build: ## Builds gitspork to dist/gitspork and builds Docker image tagged gitspo
 	@docker build -t gitspork:local dist/.docker-build/
 	@rm -rf dist/.docker-build
 
+# Every test suite links against the shared testharness package under
+# ./test/testharness, which is guarded by `//go:build testharness` so a plain
+# `go build` never compiles it. Every `go test` invocation below must include
+# the testharness tag, chained with the suite-specific tier tag.
+
 .PHONY: test-unit
 test-unit: ## Run unit tests
-	@go vet ./... && go test -v ./...
+	@go vet -tags testharness ./... && go test -tags testharness -v ./...
 
 .PHONY: test-functional
 test-functional: ## Run functional tests, compiles the tool and executes in real, functional scenarios using synthetic/dynamic repos
-	@go test -tags functional -timeout 120s -v ./test/functional/...
+	@go test -tags functional,testharness -timeout 120s -v ./test/functional/...
 
 .PHONY: test-functional-docker
 test-functional-docker: ## Run tests specific to testing the containerized version of the tool
-	@go test -tags functional_docker -timeout 300s -v ./test/functional/...
+	@go test -tags functional_docker,testharness -timeout 300s -v ./test/functional/...
 
 .PHONY: test-examples
 test-examples: ## Run example scenario tests
-	@go test -tags examples -timeout 120s -v ./test/examples/...
+	@go test -tags examples,testharness -timeout 120s -v ./test/examples/...
 
 .PHONY: test-sdk
 test-sdk: ## Run black-box SDK tests
-	@go test -tags sdk -timeout 120s -v ./test/sdk/...
+	@go test -tags sdk,testharness -timeout 120s -v ./test/sdk/...
 
 .PHONY: test-security-gate
 test-security-gate: ## Run unit tests for the CI security gate script

--- a/internal/drift/check_drift_test.go
+++ b/internal/drift/check_drift_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rockholla/gitspork/v2/internal/config"
 	"github.com/rockholla/gitspork/v2/internal/integrate"
 	"github.com/rockholla/gitspork/v2/internal/logutil"
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/integrate/integrate_test.go
+++ b/internal/integrate/integrate_test.go
@@ -13,7 +13,7 @@ import (
 	gogitssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	"github.com/rockholla/gitspork/v2/internal/config"
 	"github.com/rockholla/gitspork/v2/internal/logutil"
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 	"github.com/rockholla/gitspork/v2/internal/sdktypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/testharness/testharness.go
+++ b/internal/testharness/testharness.go
@@ -102,6 +102,31 @@ func MinimalUpstream(t *testing.T) (string, plumbing.Hash) {
 	return dir, hash
 }
 
+// MinimalUpstreamInSubpath initialises a local upstream git repo whose
+// .gitspork.yml (and integratable content) sits under <dir>/<subpath>/ rather
+// than at the repo root. Also drops an unrelated marker file at the repo root
+// so subpath handling is exercised against a realistic "monorepo with a
+// gitspork subdir" shape. Returns the temp dir and the initial commit hash.
+func MinimalUpstreamInSubpath(t *testing.T, subpath string) (string, plumbing.Hash) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false,
+		gogit.WithDefaultBranch(plumbing.NewBranchReferenceName("main")),
+	)
+	require.NoError(t, err)
+
+	// Unrelated file at the repo root — gitspork must not pick this up.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# repo root — not a gitspork target\n"), 0644))
+
+	sub := filepath.Join(dir, subpath)
+	require.NoError(t, os.MkdirAll(filepath.Join(sub, "upstream-owned"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "upstream-owned", "file.txt"), []byte("upstream content\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, ".gitspork.yml"), []byte("upstream_owned:\n- upstream-owned/**\n"), 0644))
+
+	hash := CommitAllWithMessage(t, repo, "initial")
+	return dir, hash
+}
+
 // EmptyDownstream initialises a bare local downstream git repo ready for
 // Integrate to write into.
 func EmptyDownstream(t *testing.T) string {

--- a/test/examples/integrate_local_test.go
+++ b/test/examples/integrate_local_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/examples/open_source_template_test.go
+++ b/test/examples/open_source_template_test.go
@@ -5,7 +5,7 @@ package examples
 import (
 	"testing"
 
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/test/examples/platform_team_test.go
+++ b/test/examples/platform_team_test.go
@@ -5,7 +5,7 @@ package examples
 import (
 	"testing"
 
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/test/examples/standards_library_test.go
+++ b/test/examples/standards_library_test.go
@@ -5,7 +5,7 @@ package examples
 import (
 	"testing"
 
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/test/functional/harness.go
+++ b/test/functional/harness.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	gogit "github.com/go-git/go-git/v6"
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 )
 
 type Runner interface {

--- a/test/functional/subpath_test.go
+++ b/test/functional/subpath_test.go
@@ -10,7 +10,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/test/functional/subpath_test.go
+++ b/test/functional/subpath_test.go
@@ -1,0 +1,159 @@
+//go:build functional || functional_docker
+
+package functional
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildSubpathUpstream wraps testharness.MinimalUpstreamInSubpath for the
+// functional tier. The upstream has:
+//   - README.md at the repo root (should NOT be integrated)
+//   - infra/.gitspork.yml + infra/upstream-owned/file.txt (should be integrated)
+func buildSubpathUpstream(t *testing.T, subpath string) (string, plumbing.Hash) {
+	t.Helper()
+	return testharness.MinimalUpstreamInSubpath(t, subpath)
+}
+
+// TestIntegrate_subpath_via_cli_flag runs `gitspork integrate` with the
+// `--upstream-repo-subpath` scalar flag against a monorepo-shaped upstream.
+// Locks the subpath-scoped integration behaviour at the compiled-binary tier.
+func TestIntegrate_subpath_via_cli_flag(t *testing.T) {
+	upstreamDir, upstreamHash := buildSubpathUpstream(t, "infra")
+	downstreamDir := NewDownstreamRepo(t)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	args := []string{
+		"integrate",
+		"--upstream-repo-url", "file://" + upstreamDir,
+		"--upstream-repo-version", "main",
+		"--upstream-repo-subpath", "infra",
+		"--downstream-repo-path", downstreamDir,
+	}
+	out, code := runner.Run(t, args, downstreamDir)
+	require.Equal(t, 0, code, "integrate exited non-zero:\n%s", out)
+
+	// File scoped by subpath landed in downstream with the prefix stripped.
+	AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "upstream content")
+
+	// Repo-root file MUST NOT have been picked up.
+	AssertFileAbsent(t, downstreamDir, "README.md")
+
+	// State records the subpath alongside URL and commit hash so subsequent
+	// integrates (and check-drift) can find this upstream.
+	stateRaw := ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+	var state struct {
+		Upstreams []struct {
+			URL        string `json:"url"`
+			Subpath    string `json:"subpath"`
+			CommitHash string `json:"commit_hash"`
+		} `json:"upstreams"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stateRaw), &state))
+	require.Len(t, state.Upstreams, 1)
+	assert.Equal(t, "infra", state.Upstreams[0].Subpath)
+	assert.Equal(t, upstreamHash.String(), state.Upstreams[0].CommitHash)
+}
+
+// TestIntegrate_subpath_via_upstream_kv_flag runs `gitspork integrate` with
+// the repeatable `--upstream url=...,subpath=...` KV flag. This is the
+// multi-upstream flag path — subpath must flow through ParseUpstreamFlag
+// into the integration in the same shape as the legacy scalar flag.
+func TestIntegrate_subpath_via_upstream_kv_flag(t *testing.T) {
+	upstreamDir, _ := buildSubpathUpstream(t, "infra")
+	downstreamDir := NewDownstreamRepo(t)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	args := []string{
+		"integrate",
+		"--upstream", "url=file://" + upstreamDir + ",version=main,subpath=infra",
+		"--downstream-repo-path", downstreamDir,
+	}
+	out, code := runner.Run(t, args, downstreamDir)
+	require.Equal(t, 0, code, "integrate exited non-zero:\n%s", out)
+
+	AssertFileContains(t, downstreamDir, "upstream-owned/file.txt", "upstream content")
+	AssertFileAbsent(t, downstreamDir, "README.md")
+}
+
+// TestIntegrate_subpath_trailing_slash_still_matches_state_entry verifies the
+// PR #62/#64 fix at the CLI tier: a user who ran `subpath=infra` once and then
+// `subpath=infra/` (tab-completion appended slash) must not produce two state
+// entries. The delta-propagation path relies on this — a duplicate entry
+// causes upstream-remove-file cases to silently miss.
+func TestIntegrate_subpath_trailing_slash_still_matches_state_entry(t *testing.T) {
+	upstreamDir, _ := buildSubpathUpstream(t, "infra")
+	downstreamDir := NewDownstreamRepo(t)
+	runner := resolveRunner(t, upstreamDir, downstreamDir)
+
+	firstArgs := []string{
+		"integrate",
+		"--upstream-repo-url", "file://" + upstreamDir,
+		"--upstream-repo-version", "main",
+		"--upstream-repo-subpath", "infra",
+		"--downstream-repo-path", downstreamDir,
+	}
+	out, code := runner.Run(t, firstArgs, downstreamDir)
+	require.Equal(t, 0, code, "first integrate exited non-zero:\n%s", out)
+
+	// Commit the downstream so tree is clean before re-integrate.
+	CommitAll(t, OpenRepo(t, downstreamDir), downstreamDir, "post-integrate baseline")
+
+	// Second run: user (or shell tab-completion) sneaks a trailing slash in.
+	secondArgs := []string{
+		"integrate",
+		"--upstream-repo-url", "file://" + upstreamDir,
+		"--upstream-repo-version", "main",
+		"--upstream-repo-subpath", "infra/",
+		"--downstream-repo-path", downstreamDir,
+	}
+	out, code = runner.Run(t, secondArgs, downstreamDir)
+	require.Equal(t, 0, code, "second integrate (with trailing slash on subpath) exited non-zero:\n%s", out)
+
+	// Exactly one state entry — normalization collapsed the shape variants.
+	stateRaw := ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+	var state struct {
+		Upstreams []struct {
+			URL     string `json:"url"`
+			Subpath string `json:"subpath"`
+		} `json:"upstreams"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stateRaw), &state))
+	assert.Len(t, state.Upstreams, 1,
+		"subpath shape variants must resolve to one state entry — locks the PR #62/#64 fix at the CLI boundary")
+	// The persisted subpath is the canonical form (no trailing slash).
+	assert.Equal(t, "infra", state.Upstreams[0].Subpath)
+}
+
+// Sanity: make sure the harness helper produces the expected tree shape.
+// If MinimalUpstreamInSubpath changes, the assertions above need to be
+// revisited — this test guards against silent drift in the fixture itself.
+func TestSubpathUpstreamHarness_tree_shape(t *testing.T) {
+	upstreamDir, _ := buildSubpathUpstream(t, "infra")
+
+	_, err := os.Stat(filepath.Join(upstreamDir, "README.md"))
+	assert.NoError(t, err, "harness should drop an unrelated README at repo root")
+
+	_, err = os.Stat(filepath.Join(upstreamDir, "infra", ".gitspork.yml"))
+	assert.NoError(t, err, "harness should place .gitspork.yml under the subpath dir")
+
+	_, err = os.Stat(filepath.Join(upstreamDir, "infra", "upstream-owned", "file.txt"))
+	assert.NoError(t, err, "harness should place upstream-owned content under the subpath dir")
+
+	// And nothing at the repo root that looks like a gitspork target.
+	_, err = os.Stat(filepath.Join(upstreamDir, ".gitspork.yml"))
+	assert.Error(t, err, "harness must NOT drop .gitspork.yml at the repo root when subpath is set")
+
+	// Sanity that the harness actually made a git repo (some helpers just build a directory).
+	_, err = gogit.PlainOpen(upstreamDir)
+	assert.NoError(t, err)
+}

--- a/test/sdk/helpers_test.go
+++ b/test/sdk/helpers_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rockholla/gitspork/v2"
-	"github.com/rockholla/gitspork/v2/internal/testharness"
+	"github.com/rockholla/gitspork/v2/test/testharness"
 )
 
 // minimalUpstream builds a local upstream git repo with a minimal .gitspork.yml

--- a/test/sdk/helpers_test.go
+++ b/test/sdk/helpers_test.go
@@ -3,6 +3,7 @@
 package sdk_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rockholla/gitspork/v2"
 	"github.com/rockholla/gitspork/v2/internal/testharness"
 )
 
@@ -19,6 +21,15 @@ import (
 func minimalUpstream(t *testing.T) (string, plumbing.Hash) {
 	t.Helper()
 	return testharness.MinimalUpstream(t)
+}
+
+// minimalUpstreamInSubpath builds a local upstream git repo whose .gitspork.yml
+// (and integratable content) sits under <dir>/<subpath>/ rather than at the
+// repo root — the "monorepo with a gitspork subdir" shape. Returns the repo
+// dir and its HEAD hash.
+func minimalUpstreamInSubpath(t *testing.T, subpath string) (string, plumbing.Hash) {
+	t.Helper()
+	return testharness.MinimalUpstreamInSubpath(t, subpath)
 }
 
 // emptyDownstream returns a fresh non-bare local downstream git repo dir.
@@ -43,4 +54,16 @@ func writeAndCommit(t *testing.T, downstreamDir, relPath, content string) plumbi
 func fileExists(base string, parts ...string) error {
 	_, err := os.Stat(filepath.Join(append([]string{base}, parts...)...))
 	return err
+}
+
+// readStateJSON loads and decodes .gitspork/downstream-state.json into a
+// gitspork.DownstreamState (the public SDK type). Used by SDK tests that need
+// to inspect the on-disk state shape a consumer would see.
+func readStateJSON(t *testing.T, downstreamDir string) gitspork.DownstreamState {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(downstreamDir, ".gitspork", "downstream-state.json"))
+	require.NoError(t, err, "expected downstream-state.json to exist after Integrate")
+	var state gitspork.DownstreamState
+	require.NoError(t, json.Unmarshal(b, &state))
+	return state
 }

--- a/test/sdk/sdk_test.go
+++ b/test/sdk/sdk_test.go
@@ -28,6 +28,72 @@ func TestIntegrate_singleUpstream(t *testing.T) {
 	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
 }
 
+// integrate: subpath is round-tripped end-to-end
+//
+// Pins the multi-PR (#62, #64) subpath fix at the black-box SDK boundary:
+// an upstream whose .gitspork.yml lives under <upstream>/infra/ must
+// integrate correctly when Subpath is set, and IntegratedUpstream must
+// carry the (normalized) subpath back to the SDK caller for state matching.
+func TestIntegrate_subpath(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstreamInSubpath(t, "infra")
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams: []gitspork.UpstreamSpec{{
+			URL:     "file://" + upstreamDir,
+			Version: "main",
+			Subpath: "infra",
+		}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, "file://"+upstreamDir, result.Upstreams[0].URL)
+	assert.Equal(t, "infra", result.Upstreams[0].Subpath,
+		"IntegratedUpstream.Subpath must round-trip so consumers can match state entries by URL+subpath")
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+
+	// Files land in the downstream WITHOUT the subpath prefix — content comes
+	// from <upstream>/infra/upstream-owned/file.txt but the downstream layout
+	// is upstream-owned/file.txt (subpath is stripped by the integrator).
+	require.NoError(t, fileExists(downstreamDir, "upstream-owned", "file.txt"),
+		"upstream-owned file should be present in downstream stripped of the subpath prefix")
+
+	// The unrelated repo-root file from the "monorepo shape" MUST NOT land in
+	// the downstream — subpath scoping should exclude everything outside it.
+	err = fileExists(downstreamDir, "README.md")
+	assert.Error(t, err, "unrelated repo-root file should NOT land in the downstream when Subpath is scoped to a subdirectory")
+}
+
+// integrate: subpath shape variants ("infra/", "/infra", "./infra") all match
+// the same state entry — pins the NormalizeUpstreamPath + NormalizeUpstreamURL
+// fix from PR #64 at the SDK boundary.
+func TestIntegrate_subpath_shape_variants_share_state_entry(t *testing.T) {
+	upstreamDir, _ := minimalUpstreamInSubpath(t, "infra")
+	downstreamDir := emptyDownstream(t)
+
+	// First integrate with the canonical form.
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main", Subpath: "infra"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+
+	// Second integrate with a trailing-slash variant — must update the same
+	// state entry, not append a duplicate.
+	_, err = gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "main", Subpath: "infra/"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err)
+
+	// Inspect state directly: must have exactly one upstream entry after two
+	// integrates against subpath-shape variants of the same upstream.
+	state := readStateJSON(t, downstreamDir)
+	assert.Len(t, state.Upstreams, 1,
+		"integrating twice with subpath shape variants must not create duplicate state entries")
+}
+
 // integrate: multi-upstream order is preserved in the result
 func TestIntegrate_multiUpstreamOrder(t *testing.T) {
 	upstreamA, hashA := minimalUpstream(t)

--- a/test/testharness/testharness.go
+++ b/test/testharness/testharness.go
@@ -1,3 +1,13 @@
+//go:build testharness
+
+// Package testharness provides fixtures and helpers used only by gitspork's
+// own tests. It is guarded by the `testharness` build tag so a plain
+// `go build` never compiles it (production code cannot import it — the
+// import would fail with an empty-package error unless the tag is set).
+//
+// Every `make test-*` target passes `-tags testharness`. Direct
+// `go test ./…` invocations must include `-tags testharness` too, chained
+// with any other tier tag (e.g. `-tags testharness,functional`).
 package testharness
 
 import (


### PR DESCRIPTION
## Summary

Two commits, related by touching the shared testharness surface:

1. **Subpath coverage at CLI + SDK tiers** (unit-tested via PRs #62/#64 but had zero outer-tier coverage).
2. **Reorganize testharness** to make its test-only nature structural — moved to `test/testharness/` and guarded with `//go:build testharness`.

## 1. Subpath at CLI + SDK

### Test fixture — `test/testharness/testharness.go`
- `MinimalUpstreamInSubpath(t, subpath)`: builds an upstream repo with an unrelated `README.md` at root and `.gitspork.yml` + `upstream-owned` content under `<dir>/<subpath>/`. Sanity-tested to catch accidental drift in the fixture itself.

### SDK — `test/sdk/sdk_test.go`
- `TestIntegrate_subpath`: `Integrate` with `UpstreamSpec.Subpath="infra"` ends with `IntegratedUpstream.Subpath="infra"`, downstream contains the subpath'd files (prefix stripped), and repo-root files are absent from the downstream tree.
- `TestIntegrate_subpath_shape_variants_share_state_entry`: two `Integrate` calls with `Subpath="infra"` and `Subpath="infra/"` produce exactly one state entry — locks PR #62/#64 fix at the SDK boundary.
- `helpers_test.go`: new `readStateJSON` helper.

### Functional — `test/functional/subpath_test.go`
- `TestIntegrate_subpath_via_cli_flag`: `--upstream-repo-subpath` scalar flag path; asserts file placement, README absence, state contents including `Subpath` field and `CommitHash`.
- `TestIntegrate_subpath_via_upstream_kv_flag`: `--upstream url=…,subpath=…` KV flag path through `ParseUpstreamFlag`.
- `TestIntegrate_subpath_trailing_slash_still_matches_state_entry`: integrate once with `"infra"`, then with `"infra/"`; asserts one state entry and canonical persisted form. Locks PR #62/#64 at the CLI tier.
- `TestSubpathUpstreamHarness_tree_shape`: guards against silent drift in the harness fixture.

## 2. Testharness reorg (second commit)

`testharness` was under `internal/testharness/` with no build tag — used only by tests but structurally reachable by production imports. Nothing in the compiled release binary today, but the safety was purely conventional.

Made two things explicit:

- **Location** — moved `internal/testharness/` → `test/testharness/`. Every file under `test/` is now either `_test.go` or build-tag-guarded, so "if it's under `test/`, it does not ship" is a clean invariant.
- **Compile-time barrier** — added `//go:build testharness` to the file. A plain `go build ./cmd/gitspork` (the goreleaser default) refuses to compile any production import of testharness with `build constraints exclude all Go files in …/test/testharness`. Empirically verified via a throwaway probe file. Test-only code cannot silently leak into a release binary.

Makefile: every `test-*` target now passes `-tags testharness` chained with its tier tag (e.g. `-tags functional,testharness`). CI calls the Make targets, so no workflow changes needed.

Consumer imports updated across `internal/integrate/`, `internal/drift/`, `test/functional/`, `test/sdk/`, `test/examples/` (9 files). CLAUDE.md layout + testing sections updated.

## Test plan

- [x] `make test-unit`
- [x] `make test-functional`
- [x] `make test-sdk`
- [x] `make test-examples`
- [x] `go build ./cmd/gitspork` succeeds without the tag (release binary clean)
- [x] Probe verified: production import of testharness under `cmd/gitspork` refuses to compile without `-tags testharness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)