### PR TITLE
test: guard JSON large-integer precision invariant end-to-end

### DIFF
--- a/internal/integrate/integrator_shared_ownership_test.go
+++ b/internal/integrate/integrator_shared_ownership_test.go
@@ -132,6 +132,48 @@ func TestIntegratorSharedOwnershipStructuredPreferDownstream_YAML(t *testing.T) 
 	})
 }
 
+// TestIntegratorSharedOwnershipStructured_preservesLargeIntegerPrecisionEndToEnd
+// locks the UseNumber() invariant through the full structured-merge pipeline.
+// The scalar-parse regression this test guards against corrupts JSON integers
+// above 2^53 as they flow through parseJSON → merge → writeJSON. A shared-
+// ownership.structured entry on a JSON file with a large integer field must
+// end with the exact literal preserved in the downstream output.
+func TestIntegratorSharedOwnershipStructured_preservesLargeIntegerPrecisionEndToEnd(t *testing.T) {
+	const largeInt = "9007199254740993"
+
+	t.Run("prefer_upstream keeps upstream's large integer verbatim", func(t *testing.T) {
+		upstreamJSON := `{"id":` + largeInt + `,"upstream_only":"u"}`
+		downstreamJSON := `{"id":123,"downstream_only":"d"}`
+		upstreamDir, downstreamDir := setupStructuredPair(t, "config.json", upstreamJSON, downstreamJSON)
+
+		integrator := &IntegratorSharedOwnershipStructuredPreferUpstream{}
+		require.NoError(t, integrator.Integrate([]string{"config.json"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+		// Read the merged file as raw bytes — the merged map[string]any decoded
+		// via encoding/json without UseNumber would silently corrupt this, so
+		// the byte-level assertion is what actually pins the invariant.
+		mergedBytes, err := os.ReadFile(filepath.Join(downstreamDir, "config.json"))
+		require.NoError(t, err)
+		assert.Contains(t, string(mergedBytes), largeInt,
+			"prefer_upstream merge must not lose precision on large integers — regression here means UseNumber() was dropped somewhere in the pipeline")
+		assert.NotContains(t, string(mergedBytes), "9007199254740992",
+			"corrupted value indicates float64 rounding")
+	})
+
+	t.Run("prefer_downstream keeps downstream's large integer verbatim", func(t *testing.T) {
+		upstreamJSON := `{"id":123,"upstream_only":"u"}`
+		downstreamJSON := `{"id":` + largeInt + `,"downstream_only":"d"}`
+		upstreamDir, downstreamDir := setupStructuredPair(t, "config.json", upstreamJSON, downstreamJSON)
+
+		integrator := &IntegratorSharedOwnershipStructuredPreferDownstream{}
+		require.NoError(t, integrator.Integrate([]string{"config.json"}, upstreamDir, downstreamDir, sdktypes.NoopLogger()))
+
+		mergedBytes, err := os.ReadFile(filepath.Join(downstreamDir, "config.json"))
+		require.NoError(t, err)
+		assert.Contains(t, string(mergedBytes), largeInt)
+	})
+}
+
 func TestIntegratorSharedOwnershipStructuredPreferDownstream_JSON(t *testing.T) {
 	upstreamJSON := `{"shared_key":"from-upstream","upstream_only":"value-u"}`
 	downstreamJSON := `{"shared_key":"from-downstream","downstream_only":"value-d"}`

--- a/internal/integrate/structured_json_test.go
+++ b/internal/integrate/structured_json_test.go
@@ -91,6 +91,73 @@ func TestWriteJSON_usesTwoSpaceIndent(t *testing.T) {
 	assert.Equal(t, "{\n  \"a\": \"one\",\n  \"b\": \"two\"\n}", string(out))
 }
 
+// TestParseJSON_preservesLargeIntegerPrecision is a regression guard against
+// dropping `dec.UseNumber()` from parseJSON. Without UseNumber, integer tokens
+// are decoded into float64 — which loses precision above 2^53 = 9007199254740992.
+// A regression would silently corrupt IDs, epoch timestamps in nanoseconds,
+// and other JSON integers users legitimately write. The test asserts the
+// literal survives a full parse+write round-trip byte-for-byte, which is only
+// possible if the scalar was captured as json.Number and not float64.
+func TestParseJSON_preservesLargeIntegerPrecision(t *testing.T) {
+	// 2^53 + 1 — the smallest positive integer that float64 cannot represent
+	// exactly. If UseNumber() is removed, this parses as float64 9007199254740992
+	// (rounded down) and the round-trip output will contain the WRONG value.
+	const largeInt = "9007199254740993"
+	in := []byte(`{"id":` + largeInt + `}`)
+
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+
+	idNode, ok := n.mapping.Get("id")
+	require.True(t, ok)
+	// The scalar type is what enforces the invariant — json.Number is a string
+	// alias that carries the literal characters verbatim. Any other type
+	// (float64 in particular) indicates UseNumber() is missing.
+	num, isNumber := idNode.scalar.(json.Number)
+	require.True(t, isNumber, "large integer scalar must be json.Number (was %T) — indicates dec.UseNumber() removed from parseJSON", idNode.scalar)
+	assert.Equal(t, largeInt, string(num))
+
+	out, err := writeJSON(n)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), largeInt,
+		"round-tripped output must contain the exact %s literal — loss of precision here means dec.UseNumber() was removed from parseJSON", largeInt)
+	assert.NotContains(t, string(out), "9007199254740992",
+		"a value of 9007199254740992 in the output would indicate float64 rounding — the exact regression this test guards against")
+}
+
+func TestParseJSON_preservesLargeNegativeIntegerPrecision(t *testing.T) {
+	// Same invariant for the negative direction — a value beyond -2^53.
+	const largeNegInt = "-9007199254740993"
+	in := []byte(`{"id":` + largeNegInt + `}`)
+
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	out, err := writeJSON(n)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), largeNegInt)
+}
+
+// TestParseJSON_integerScalarsRoundTripAsIntegers guards against a subtler
+// regression: even for small integers where float64 has enough precision,
+// dropping UseNumber() would decode `100` as `float64(100)`, and
+// `json.Marshal(100.0)` emits `100` — that's fine, BUT for smaller values
+// like `1e-6` or numbers that look integer-ish in JSON but round through
+// float, we can see scientific-notation output. The safer assertion is that
+// the exact input literal is preserved on round-trip.
+func TestParseJSON_integerScalarsRoundTripAsIntegers(t *testing.T) {
+	// A moderate integer that both branches handle equivalently, plus a
+	// float that must not be re-emitted as scientific notation.
+	in := []byte(`{"count":100,"ratio":0.5}`)
+
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	out, err := writeJSON(n)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), `"count": 100`, "integer scalar must not be re-emitted as 100.0 or 1e+02")
+	assert.Contains(t, string(out), `"ratio": 0.5`, "float scalar must round-trip as decimal, not scientific notation")
+}
+
 func TestWriteJSON_emptyStructures(t *testing.T) {
 	t.Run("empty mapping", func(t *testing.T) {
 		out, err := writeJSON(newMappingNode())


### PR DESCRIPTION
## Summary

`parseJSON` uses `dec.UseNumber()` to keep integers above float64's exact range (>2^53 = 9007199254740992) as `json.Number` strings rather than letting them decode into float64 and lose precision. Removing that one call would silently corrupt JSON integer IDs, epoch nanoseconds, and similar large-integer fields on every `shared_ownership.structured` merge — the exact category of silent data corruption users would find hardest to catch.

Locked the invariant at two tiers.

### Unit — `internal/integrate/structured_json_test.go`

- **`preservesLargeIntegerPrecision`**: parse+write of `9007199254740993` (2^53 + 1) round-trips byte-identically. Asserts BOTH that the scalar arrives as `json.Number` (not `float64`) AND that the output byte-stream contains the exact literal. Explicit `NotContains` on the corrupted value `9007199254740992` spells the regression out for the reader.
- **`preservesLargeNegativeIntegerPrecision`**: same for `-9007199254740993` to cover the negative direction.
- **`integerScalarsRoundTripAsIntegers`**: moderate integer (`100`) is not re-emitted as `100.0` or scientific notation; float scalar (`0.5`) stays decimal.

### End-to-end — `internal/integrate/integrator_shared_ownership_test.go`

- **`preservesLargeIntegerPrecisionEndToEnd`**: two subtests, one per `prefer-upstream`/`prefer-downstream`, that run the full structured merge integrator against a JSON config carrying the large integer and assert the merged output file's bytes still contain the exact literal.

## Sanity-verified the guard actually works

Temporarily commented out `dec.UseNumber()` in `parseJSON`; both key tests failed as expected. Restored — passes.

## Test plan

- [x] `go test -tags testharness ./internal/integrate/ -run 'TestParseJSON_preserves|TestIntegratorSharedOwnershipStructured_preservesLargeInteger'`
- [x] Regression verified via temporary `UseNumber()` removal
- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)