### PR TITLE
test: cover all Version resolution shapes at the SDK boundary

### DIFF
--- a/test/sdk/helpers_test.go
+++ b/test/sdk/helpers_test.go
@@ -32,6 +32,13 @@ func minimalUpstreamInSubpath(t *testing.T, subpath string) (string, plumbing.Ha
 	return testharness.MinimalUpstreamInSubpath(t, subpath)
 }
 
+// minimalUpstreamWithTag builds a local upstream git repo with a lightweight
+// tag pointing at HEAD. Used to exercise Version=<tag> resolution paths.
+func minimalUpstreamWithTag(t *testing.T, tagName string) (string, plumbing.Hash) {
+	t.Helper()
+	return testharness.MinimalUpstreamWithTag(t, tagName)
+}
+
 // emptyDownstream returns a fresh non-bare local downstream git repo dir.
 func emptyDownstream(t *testing.T) string {
 	t.Helper()

--- a/test/sdk/sdk_test.go
+++ b/test/sdk/sdk_test.go
@@ -28,6 +28,115 @@ func TestIntegrate_singleUpstream(t *testing.T) {
 	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
 }
 
+// integrate: Version="" resolves to the default branch (HEAD)
+//
+// The empty-Version branch is explicitly documented in the code
+// (`cloneOptions.SingleBranch = true`, integrate.go:432) and in the field's
+// godoc but had no SDK-tier assertion. Empty means "clone the default
+// branch"; the result's CommitHash should be the HEAD commit.
+func TestIntegrate_version_empty_resolvesToDefaultBranch(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir /* Version intentionally omitted */}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "empty Version should clone the default branch")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+// integrate: Version=<bare-tag> resolves to the tag
+//
+// The bare-tag branch probes the remote for tag vs branch precedence
+// (integrate.go:439-445). Tag wins over a same-named branch — the internal
+// test Test_Integrate_bare_tag covers that at the package boundary; this
+// pins the same contract at the SDK boundary so an SDK consumer using
+// Version="v1.2.3" gets a reproducible result.
+func TestIntegrate_version_bareTag(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstreamWithTag(t, "v1.0.0")
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "v1.0.0"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "bare tag name should resolve as a tag")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+// integrate: Version="tags/<name>" is the explicit-tag form (backward-compat
+// with pre-bare-tag callers) — integrate.go:436-438.
+func TestIntegrate_version_tagsPrefixed(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstreamWithTag(t, "v1.0.0")
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "tags/v1.0.0"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "tags/ prefix should resolve as a tag (backward compat)")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+// integrate: Version=<full-40-char-commit-hash> pins to that commit
+//
+// commitHashRe matches 7-40 hex chars (integrate.go:42). The full-hash case
+// triggers a full-history clone + explicit worktree checkout at the given
+// hash (integrate.go:433-435 + 468-480).
+func TestIntegrate_version_fullCommitHash(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: upstreamHash.String()}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "full commit hash should be resolvable")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash)
+}
+
+// integrate: Version=<7-char-short-commit-hash> resolves to full hash
+//
+// The result's CommitHash is what state persistence uses to match on
+// subsequent integrates. A short hash must resolve to the FULL 40-char hash
+// in the returned IntegratedUpstream so state lookups stay stable across
+// runs, regardless of how the caller specified the pin.
+func TestIntegrate_version_shortCommitHash(t *testing.T) {
+	upstreamDir, upstreamHash := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+	shortHash := upstreamHash.String()[:7]
+
+	result, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: shortHash}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.NoError(t, err, "short commit hash should be resolvable")
+	require.Len(t, result.Upstreams, 1)
+	assert.Equal(t, upstreamHash.String(), result.Upstreams[0].CommitHash,
+		"short hash should resolve to the full 40-char commit hash in the result — state persistence relies on this")
+	assert.Len(t, result.Upstreams[0].CommitHash, 40,
+		"IntegratedUpstream.CommitHash must be 40 chars, not a short-hash echo")
+}
+
+// integrate: Version=<unknown> surfaces a clear error naming the ref
+func TestIntegrate_version_unknownRef_errorsWithRefName(t *testing.T) {
+	upstreamDir, _ := minimalUpstream(t)
+	downstreamDir := emptyDownstream(t)
+
+	_, err := gitspork.Integrate(&gitspork.IntegrateOptions{
+		Upstreams:          []gitspork.UpstreamSpec{{URL: "file://" + upstreamDir, Version: "no-such-ref"}},
+		DownstreamRepoPath: downstreamDir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no-such-ref",
+		"error must name the unresolved ref so the SDK consumer can act on it")
+}
+
 // integrate: subpath is round-tripped end-to-end
 //
 // Pins the multi-PR (#62, #64) subpath fix at the black-box SDK boundary:

--- a/test/testharness/testharness.go
+++ b/test/testharness/testharness.go
@@ -112,6 +112,20 @@ func MinimalUpstream(t *testing.T) (string, plumbing.Hash) {
 	return dir, hash
 }
 
+// MinimalUpstreamWithTag builds on MinimalUpstream by creating a lightweight
+// tag pointing at HEAD. Callers use this to exercise Version=<tag> resolution
+// paths (bare tag name, "tags/" prefix form) without needing to reach into
+// go-git themselves.
+func MinimalUpstreamWithTag(t *testing.T, tagName string) (string, plumbing.Hash) {
+	t.Helper()
+	dir, hash := MinimalUpstream(t)
+	repo, err := gogit.PlainOpen(dir)
+	require.NoError(t, err)
+	_, err = repo.CreateTag(tagName, hash, nil)
+	require.NoError(t, err)
+	return dir, hash
+}
+
 // MinimalUpstreamInSubpath initialises a local upstream git repo whose
 // .gitspork.yml (and integratable content) sits under <dir>/<subpath>/ rather
 // than at the repo root. Also drops an unrelated marker file at the repo root


### PR DESCRIPTION
## Summary

The internal `integrate` package covers `Version=""`, bare tag, `"tags/<name>"` prefix, full commit hash, and short commit hash (via PR #50) — but the SDK tier only exercised `Version="main"`. SDK consumers wiring gitspork against pinned tags, `tags/`-prefixed refs, or specific commit hashes had **no black-box safety net**.

## What's added

### Shared helper — `test/testharness/testharness.go`
- `MinimalUpstreamWithTag(t, tagName)` builds on `MinimalUpstream` by creating a lightweight tag pointing at HEAD. Shared so other test tiers can pick it up.

### SDK — `test/sdk/sdk_test.go`
Six new tests:

- **`version_empty_resolvesToDefaultBranch`**: previously undocumented at the SDK boundary — `Version=""` clones the default branch, result's `CommitHash` is HEAD.
- **`version_bareTag`**: `Version="v1.0.0"` resolves via remote-list probe (tag wins over same-named branch).
- **`version_tagsPrefixed`**: `Version="tags/v1.0.0"` — backward-compat explicit-tag form.
- **`version_fullCommitHash`**: `Version=<40-char>` triggers full-history clone + explicit checkout at hash.
- **`version_shortCommitHash`**: `Version=<7-char>` resolves to the FULL 40-char hash in the returned `IntegratedUpstream` — asserts `len==40` so a regression that echoes the short-hash back would be caught. State persistence depends on this contract.
- **`version_unknownRef_errorsWithRefName`**: unknown ref returns an error that names the ref so SDK consumers can act on it.

Wrapper `minimalUpstreamWithTag` added to `test/sdk/helpers_test.go` following the existing tiny-wrapper pattern.

## Test plan

- [x] `make test-sdk`
- [x] `make test-unit`
- [x] `make test-functional`

🤖 Generated with [Claude Code](https://claude.com/claude-code)