### PR TITLE
test: assert the shape of gitspork schema stdout

### DIFF
--- a/test/functional/schema_test.go
+++ b/test/functional/schema_test.go
@@ -1,0 +1,89 @@
+//go:build functional || functional_docker
+
+package functional
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchema_printsAnnotatedScaffolds locks the shape of `gitspork schema`
+// stdout. This isn't a regression against a specific past bug — it's a
+// snapshot of the two annotated YAML sections the command emits so an
+// accidental change (deleted key, dropped section, rewritten header) is
+// caught at CI time. schema is user-facing documentation of the
+// .gitspork.yml surface, so silent shape drift is a real risk.
+func TestSchema_printsAnnotatedScaffolds(t *testing.T) {
+	// schema doesn't need any repo state — run it from a fresh temp dir.
+	dir := t.TempDir()
+	runner := resolveRunner(t, dir, "")
+	out, code := runner.Run(t, []string{"schema"}, dir)
+	require.Equal(t, 0, code, "schema exited non-zero:\n%s", out)
+
+	t.Run("section headers present", func(t *testing.T) {
+		assert.Contains(t, out, "Main .gitspork.yml schema:",
+			"main schema header should introduce the .gitspork.yml section")
+		assert.Contains(t, out, "Migration YAML schema:",
+			"migration schema header should introduce the migration section")
+	})
+
+	t.Run("main schema exposes every top-level ownership primitive", func(t *testing.T) {
+		// These keys are the public schema surface of .gitspork.yml. If any
+		// key is dropped from the scaffold, users lose in-tree documentation
+		// of that primitive — worth catching at CI time.
+		for _, key := range []string{
+			"upstream_owned:",
+			"downstream_owned:",
+			"shared_ownership:",
+			"templated:",
+			"migrations:",
+		} {
+			assert.Contains(t, out, key, "top-level key %q missing from main schema", key)
+		}
+	})
+
+	t.Run("main schema exposes shared_ownership sub-primitives", func(t *testing.T) {
+		for _, key := range []string{
+			"merged:",
+			"structured:",
+			"prefer_upstream:",
+			"prefer_downstream:",
+		} {
+			assert.Contains(t, out, key, "shared_ownership sub-key %q missing from main schema", key)
+		}
+	})
+
+	t.Run("main schema demonstrates rename ({from, to}) entries", func(t *testing.T) {
+		// The scaffold intentionally shows a rename entry so users see the
+		// {from, to} form is valid. Losing that example would degrade the
+		// self-documenting utility of the schema.
+		assert.Contains(t, out, "from:",
+			"scaffold should demonstrate the rename {from, to} form")
+		assert.Contains(t, out, "to:",
+			"scaffold should demonstrate the rename {from, to} form")
+	})
+
+	t.Run("main schema demonstrates all three templated input types", func(t *testing.T) {
+		// prompt / json_data_path / previous_input are the three ways a
+		// templated input can be sourced. The scaffold exercises all three
+		// so users see the full menu.
+		for _, key := range []string{
+			"prompt:",
+			"json_data_path:",
+			"previous_input:",
+		} {
+			assert.Contains(t, out, key, "templated input source %q missing from main schema", key)
+		}
+	})
+
+	t.Run("migration schema exposes both hook slots", func(t *testing.T) {
+		assert.Contains(t, out, "pre_integrate:",
+			"migration schema should show the pre_integrate hook")
+		assert.Contains(t, out, "post_integrate:",
+			"migration schema should show the post_integrate hook")
+		assert.Contains(t, out, "exec:",
+			"migration schema should show the exec instruction key")
+	})
+}


### PR DESCRIPTION
## Summary

`gitspork schema` prints an annotated `.gitspork.yml` scaffold plus a migration YAML scaffold as the tool's in-tree schema documentation. The command had **zero automated coverage** — dropping a top-level key, losing a `shared_ownership` sub-primitive, or renaming a section header would ship silently.

## What's added

`test/functional/schema_test.go` — `TestSchema_printsAnnotatedScaffolds` runs `gitspork schema` from a temp directory (no repo state needed) and asserts on the plain-text output:

- Both section headers are present (`"Main .gitspork.yml schema:"`, `"Migration YAML schema:"`)
- Every top-level ownership primitive appears in the main scaffold: `upstream_owned`, `downstream_owned`, `shared_ownership`, `templated`, `migrations`
- `shared_ownership` sub-primitives are present: `merged`, `structured`, `prefer_upstream`, `prefer_downstream`
- The scaffold demonstrates rename (`{from, to}`) entries
- The scaffold demonstrates all three templated input sources: `prompt`, `json_data_path`, `previous_input`
- The migration scaffold exposes both hook slots (`pre_integrate`, `post_integrate`) plus the `exec` key

`exec.Command` capture means stdout is not a TTY, so `ColorizeYAML`'s auto-detection suppresses ANSI codes and the plain-text substring assertions match cleanly.

## Test plan

- [x] `make test-functional`

🤖 Generated with [Claude Code](https://claude.com/claude-code)