### PR TITLE
test: exercise {from, to} rename form in the open-source-template example

### DIFF
--- a/docs/examples/open-source-template/README.md
+++ b/docs/examples/open-source-template/README.md
@@ -8,6 +8,7 @@
 |---|---|---|
 | `upstream_owned` | `.github/**`, `LICENSE`, `CONTRIBUTING.md` | The template maintainer owns these — they are always synced to downstream on integrate |
 | `downstream_owned` | `README.md`, `CHANGELOG.md` | Seeded from upstream on first integrate, then never touched again — the project owner writes their own |
+| `downstream_owned` (rename form) | `starter/AUTHORS.md` → `AUTHORS.md` | Upstream keeps a canonical seed under `starter/`; downstream receives it at the conventional top-level location. `{from, to}` lets the template author use one path in the upstream and let the downstream see it at another |
 | `shared_ownership.structured.prefer_downstream` | `project-meta.json` | Upstream seeds this file with defaults; once the downstream customises it, their values survive all future re-integrates |
 | `templated` | `CODE_OF_CONDUCT.md` | Rendered from `project-meta.json` using `project_name` — re-rendered on every integrate so it always reflects the current project name |
 
@@ -43,6 +44,8 @@ upstream/                          ← the gitspork upstream repo (the template)
   CONTRIBUTING.md                  ← upstream-owned contributing guide
   README.md                        ← seeded to downstream; downstream owns it thereafter
   CHANGELOG.md                     ← seeded to downstream; downstream owns it thereafter
+  starter/
+    AUTHORS.md                     ← seeded to downstream as AUTHORS.md (via {from, to} rename)
   project-meta.json                ← prefer_downstream structured data; upstream seeds defaults
   .gitspork-templates/             ← Go templates rendered into each downstream
     CODE_OF_CONDUCT.md.go.tmpl     ← rendered using project_name from project-meta.json

--- a/docs/examples/open-source-template/upstream/.gitspork.yml
+++ b/docs/examples/open-source-template/upstream/.gitspork.yml
@@ -5,6 +5,11 @@ upstream_owned:
 downstream_owned:
   - README.md
   - CHANGELOG.md
+  # {from, to} rename form: upstream keeps a canonical seed at
+  # starter/AUTHORS.md; the downstream receives it at the conventional
+  # top-level AUTHORS.md location and owns it thereafter.
+  - from: starter/AUTHORS.md
+    to: AUTHORS.md
 shared_ownership:
   structured:
     prefer_downstream:

--- a/docs/examples/open-source-template/upstream/starter/AUTHORS.md
+++ b/docs/examples/open-source-template/upstream/starter/AUTHORS.md
@@ -1,0 +1,5 @@
+# Authors
+
+> Seeded by gitspork on first integrate — this file is yours to own.
+
+- Your Name <you@example.com>

--- a/test/examples/open_source_template_test.go
+++ b/test/examples/open_source_template_test.go
@@ -38,6 +38,13 @@ func TestOpenSourceTemplateExample(t *testing.T) {
 	testharness.AssertFileContains(t, downstreamDir, "CHANGELOG.md", "Seeded by gitspork")
 	testharness.AssertFileContains(t, downstreamDir, "project-meta.json", "my-project")
 
+	// downstream_owned rename: upstream's canonical starter/AUTHORS.md lands
+	// in the downstream at the conventional top-level AUTHORS.md path. The
+	// raw upstream path must NOT appear in the downstream — the rename must
+	// actually rename.
+	testharness.AssertFileContains(t, downstreamDir, "AUTHORS.md", "Seeded by gitspork")
+	testharness.AssertFileAbsent(t, downstreamDir, "starter/AUTHORS.md")
+
 	// template rendered using project-meta.json
 	testharness.AssertFileContains(t, downstreamDir, "CODE_OF_CONDUCT.md", "my-project")
 
@@ -51,10 +58,15 @@ func TestOpenSourceTemplateExample(t *testing.T) {
 	}, downstreamDir)
 	require.Equal(t, 0, code, "check-drift expected no drift:\n%s", out)
 
-	// customize README and CHANGELOG, re-integrate, assert not overwritten
+	// customize README, CHANGELOG, and the renamed AUTHORS.md; re-integrate,
+	// assert none are overwritten (the defining invariant of downstream_owned,
+	// which applies to the rename form too — the destination path is what's
+	// checked for existence, and the rename lands there once, then downstream
+	// owns it).
 	testharness.WriteFiles(t, downstreamDir, map[string]string{
 		"README.md":    "# my-project\n\nCustom readme.\n",
 		"CHANGELOG.md": "# Changelog\n\n## v1.0.0\n- initial release\n",
+		"AUTHORS.md":   "# Authors\n\n- Alice <alice@example.com>\n- Bob <bob@example.com>\n",
 	})
 	testharness.CommitAll(t, testharness.OpenRepo(t, downstreamDir), downstreamDir, "customize downstream-owned files")
 
@@ -71,6 +83,17 @@ func TestOpenSourceTemplateExample(t *testing.T) {
 
 	changelog := testharness.ReadFile(t, downstreamDir, "CHANGELOG.md")
 	assert.Contains(t, changelog, "initial release", "CHANGELOG.md should not be overwritten")
+
+	// The renamed downstream_owned entry follows the same invariant: once
+	// the destination path is populated, subsequent integrates leave it alone.
+	authors := testharness.ReadFile(t, downstreamDir, "AUTHORS.md")
+	assert.Contains(t, authors, "Alice <alice@example.com>",
+		"AUTHORS.md (rename destination) should not be overwritten on re-integrate")
+	assert.NotContains(t, authors, "Seeded by gitspork",
+		"the customized content must have fully replaced the seed content")
+	// The upstream source path still must not be in the downstream even
+	// after re-integrate — the rename should not "leak" the source path.
+	testharness.AssertFileAbsent(t, downstreamDir, "starter/AUTHORS.md")
 
 	// downstream modified project-meta.json, re-integrate: prefer_downstream value survives
 	testharness.WriteFiles(t, downstreamDir, map[string]string{


### PR DESCRIPTION
## Summary

None of the four worked examples used the `{from, to}` rename form for owned entries — a documented and unit-tested primitive with **zero example-tier coverage**. Extended `open-source-template` because a rename fits its story naturally: template scaffolding routinely wants a canonical source path in the upstream (`starter/*`, `template/*`, etc.) that lands at a different, conventional path in the downstream.

## What's added

### `docs/examples/open-source-template/upstream/starter/AUTHORS.md`
New seed file with a `Seeded by gitspork` marker matching the existing README.md and CHANGELOG.md pattern in this example.

### `.gitspork.yml`
Added a `downstream_owned` rename entry:
```yaml
- from: starter/AUTHORS.md
  to: AUTHORS.md
```
Inline comment explains the `{from, to}` shape so readers see how the primitive is spelled.

### `docs/examples/open-source-template/README.md`
New row in the "What this example demonstrates" table for the rename form, plus a directory-structure entry under `starter/`.

### `test/examples/open_source_template_test.go`
Extended `TestOpenSourceTemplateExample`:

- **Post-first-integrate**: `AUTHORS.md` exists with seed content; `starter/AUTHORS.md` is absent (the rename must actually rename, not duplicate).
- **Downstream customizes** `AUTHORS.md` alongside `README.md` and `CHANGELOG.md` before re-integrate.
- **Post-re-integrate**: the customized content survives (rename form inherits the `downstream_owned` defining invariant), the seed content is fully gone (not additively merged), and the upstream source path still doesn't leak into the downstream.

## Test plan

- [x] `make test-examples`

🤖 Generated with [Claude Code](https://claude.com/claude-code)