### PR TITLE
test: cover deeper structured YAML/JSON edge cases

### DIFF
--- a/internal/integrate/structured_json_test.go
+++ b/internal/integrate/structured_json_test.go
@@ -158,6 +158,77 @@ func TestParseJSON_integerScalarsRoundTripAsIntegers(t *testing.T) {
 	assert.Contains(t, string(out), `"ratio": 0.5`, "float scalar must round-trip as decimal, not scientific notation")
 }
 
+// TestParseJSON_preservesFourLevelNestingOrder pins mapping-order at 3+
+// levels of nesting on the JSON side. Existing tests only go two deep.
+func TestParseJSON_preservesFourLevelNestingOrder(t *testing.T) {
+	in := []byte(`{"root":{"layer_z":{"layer_y":{"layer_x":{"zebra":1,"apple":2,"mango":3},"layer_before_x":"before"},"layer_before_y":"before"},"layer_after_z":"after"}}`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+
+	root, ok := n.mapping.Get("root")
+	require.True(t, ok)
+	assert.Equal(t, []string{"layer_z", "layer_after_z"}, root.mapping.Keys(), "level 2 key order")
+
+	layerZ, ok := root.mapping.Get("layer_z")
+	require.True(t, ok)
+	assert.Equal(t, []string{"layer_y", "layer_before_y"}, layerZ.mapping.Keys(), "level 3 key order")
+
+	layerY, ok := layerZ.mapping.Get("layer_y")
+	require.True(t, ok)
+	assert.Equal(t, []string{"layer_x", "layer_before_x"}, layerY.mapping.Keys(), "level 4 key order")
+
+	layerX, ok := layerY.mapping.Get("layer_x")
+	require.True(t, ok)
+	assert.Equal(t, []string{"zebra", "apple", "mango"}, layerX.mapping.Keys(), "level 5 key order")
+}
+
+// TestParseJSON_topLevelArray: existing tests only exercise arrays nested
+// inside objects. parseJSONFromToken's '[' branch is reachable at the top
+// level too, and this test locks that branch.
+func TestParseJSON_topLevelArray(t *testing.T) {
+	in := []byte(`["alpha","beta","gamma"]`)
+	n, err := parseJSON(in)
+	require.NoError(t, err)
+	require.Equal(t, nodeSequence, n.kind)
+	require.Len(t, n.seq, 3)
+	assert.Equal(t, "alpha", n.seq[0].scalar)
+	assert.Equal(t, "gamma", n.seq[2].scalar)
+
+	// Round-trip must also work at the top level.
+	out, err := writeJSON(n)
+	require.NoError(t, err)
+	roundTripped, err := parseJSON(out)
+	require.NoError(t, err)
+	require.Equal(t, nodeSequence, roundTripped.kind)
+	require.Len(t, roundTripped.seq, 3)
+	assert.Equal(t, "beta", roundTripped.seq[1].scalar)
+}
+
+// TestParseJSON_topLevelScalar: the parseJSONFromToken branch that returns
+// newScalarNode for a non-delimiter token IS reachable at the top level
+// (e.g., a JSON file containing just `"hello"` or `42`). Locks the branch
+// so a regression restricting parseJSON to object-only inputs would fail
+// here.
+func TestParseJSON_topLevelScalar(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+	}{
+		{"top-level string", []byte(`"hello"`)},
+		{"top-level bool", []byte(`true`)},
+		{"top-level null", []byte(`null`)},
+		{"top-level integer", []byte(`42`)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n, err := parseJSON(tc.in)
+			require.NoError(t, err)
+			require.Equal(t, nodeScalar, n.kind,
+				"top-level JSON scalar must parse as nodeScalar, not fall through to a mapping or error")
+		})
+	}
+}
+
 func TestWriteJSON_emptyStructures(t *testing.T) {
 	t.Run("empty mapping", func(t *testing.T) {
 		out, err := writeJSON(newMappingNode())

--- a/internal/integrate/structured_yaml_test.go
+++ b/internal/integrate/structured_yaml_test.go
@@ -65,6 +65,96 @@ func TestWriteYAML_roundTripPreservesNestedKeyOrder(t *testing.T) {
 	assert.Equal(t, []string{"b", "a"}, outer.mapping.Keys())
 }
 
+// TestParseYAML_preservesFourLevelNestingOrder locks the mapping-order
+// invariant at three-plus levels of nesting. Existing tests only go two
+// levels deep; a regression that collapsed key order at deeper levels
+// (e.g., a map value stored as unordered map[string]any at layer 3+)
+// would slip past the shallow tests.
+func TestParseYAML_preservesFourLevelNestingOrder(t *testing.T) {
+	in := []byte(`root:
+  layer_z:
+    layer_y:
+      layer_x:
+        zebra: 1
+        apple: 2
+        mango: 3
+      layer_before_x: before
+    layer_before_y: before
+  layer_after_z: after
+`)
+	n, err := parseYAML(in)
+	require.NoError(t, err)
+
+	// Walk the hierarchy and assert order at every level.
+	root, ok := n.mapping.Get("root")
+	require.True(t, ok)
+	assert.Equal(t, []string{"layer_z", "layer_after_z"}, root.mapping.Keys(), "level 2 key order")
+
+	layerZ, ok := root.mapping.Get("layer_z")
+	require.True(t, ok)
+	assert.Equal(t, []string{"layer_y", "layer_before_y"}, layerZ.mapping.Keys(), "level 3 key order")
+
+	layerY, ok := layerZ.mapping.Get("layer_y")
+	require.True(t, ok)
+	assert.Equal(t, []string{"layer_x", "layer_before_x"}, layerY.mapping.Keys(), "level 4 key order")
+
+	layerX, ok := layerY.mapping.Get("layer_x")
+	require.True(t, ok)
+	assert.Equal(t, []string{"zebra", "apple", "mango"}, layerX.mapping.Keys(), "level 5 key order")
+}
+
+// TestParseYAML_nonStringMappingKey_fallbackToFmtSprint exercises the
+// fmt.Sprint(item.Key) fallback in yamlValueToNode when a mapping key
+// isn't already a string (e.g., integer keys, which are legal in YAML
+// even though gitspork's schema doesn't use them).
+//
+// Documents the current behaviour rather than a specific bug: integer
+// keys survive as their string representation. Users authoring configs
+// don't need to worry about this — the schema is string-keyed — but a
+// user's downstream file might carry non-string keys, and gitspork's
+// merge must handle it without panicking.
+func TestParseYAML_nonStringMappingKey_fallbackToFmtSprint(t *testing.T) {
+	in := []byte("1: first\n2: second\ntrue: yes-value\n")
+	n, err := parseYAML(in)
+	require.NoError(t, err)
+	require.Equal(t, nodeMapping, n.kind)
+
+	// Order preserved even for non-string keys — fmt.Sprint yields
+	// deterministic string forms.
+	assert.Equal(t, []string{"1", "2", "true"}, n.mapping.Keys(),
+		"non-string keys must fmt.Sprint to their canonical form and preserve order")
+
+	first, ok := n.mapping.Get("1")
+	require.True(t, ok)
+	assert.Equal(t, "first", first.scalar)
+}
+
+// TestYAML_commentsAreDroppedOnRoundTrip documents the current behaviour:
+// parseYAML → writeYAML strips YAML comments. shared_ownership.structured
+// merges of a downstream YAML file that carried comments will lose them.
+// This is a KNOWN limitation worth pinning explicitly — a future
+// enhancement to preserve comments would flip this test.
+func TestYAML_commentsAreDroppedOnRoundTrip(t *testing.T) {
+	in := []byte(`# top-level comment
+key1: value1
+# inline comment
+key2: value2  # trailing comment
+`)
+	n, err := parseYAML(in)
+	require.NoError(t, err)
+
+	out, err := writeYAML(n)
+	require.NoError(t, err)
+
+	// Values survive but comments do not — assert both halves so a future
+	// change that preserves comments flips this test loudly.
+	assert.NotContains(t, string(out), "top-level comment")
+	assert.NotContains(t, string(out), "inline comment")
+	assert.NotContains(t, string(out), "trailing comment")
+	assert.Contains(t, string(out), "key1: value1")
+	assert.Contains(t, string(out), "key2: value2")
+}
+
 func TestWriteYAML_preservesScalarTypes(t *testing.T) {
 	in := []byte("s: hello\ni: 42\nb: true\nn:\n")
 	n, err := parseYAML(in)


### PR DESCRIPTION
## Summary

Fills in the last set of gaps in structured YAML/JSON coverage from the audit's Nice-to-have bucket. Existing tests exercised two-level nesting and only nested-inside-object arrays/scalars.

## What's added

### `internal/integrate/structured_yaml_test.go`

- **`preservesFourLevelNestingOrder`**: mapping-order invariant asserted at levels 2, 3, 4, and 5 of a nested YAML structure. A regression that dropped ordering at deeper levels (e.g., a value stored as unordered `map[string]any` at layer 3+) would slip past the shallow tests.
- **`nonStringMappingKey_fallbackToFmtSprint`**: integer + bool keys in a YAML mapping — legal YAML, not part of gitspork's schema but a downstream file might carry them. `yamlValueToNode`'s `fmt.Sprint(item.Key)` fallback stringifies them; order is preserved. Documents the behaviour rather than a specific bug.
- **`commentsAreDroppedOnRoundTrip`**: explicit assertion that YAML comments (top-level, inline, trailing) do NOT survive a `parseYAML → writeYAML` round-trip. Locks the KNOWN behaviour; users of `shared_ownership.structured` on YAML files with comments lose them today. A future enhancement to preserve comments would flip this test loudly.

### `internal/integrate/structured_json_test.go`

- **`preservesFourLevelNestingOrder`**: same 3+-level invariant for JSON.
- **`topLevelArray`**: `parseJSON` handles a top-level JSON array (existing tests only exercised arrays nested inside objects). Round-trip also validated.
- **`topLevelScalar`** (4 subtests: string, bool, null, integer): `parseJSONFromToken`'s `newScalarNode` branch is reachable when a JSON file contains just a bare scalar — locked so a regression that restricts `parseJSON` to objects would fail here.

## Test plan

- [x] `make test-unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)