### PR TITLE
test: add multi-upstream worked example + examples-tier test

### DIFF
--- a/docs/examples/multi-upstream/README.md
+++ b/docs/examples/multi-upstream/README.md
@@ -1,0 +1,57 @@
+# Example: Multi-Upstream Integration
+
+**Scenario:** A downstream repo integrates from two upstream sources at once — a shared platform base and a language-specific overlay. This is the pattern for organisations layering standards: a common platform team owns baseline CI, security, and app config; a language guild adds language-specific CI and amends the shared config with tuning.
+
+## What this example demonstrates
+
+| Feature | File(s) | Behaviour |
+|---|---|---|
+| Multi-upstream `--upstream` (repeatable) | both upstreams | Two `--upstream` flags on one `gitspork integrate` call; each contributes files to the same downstream in the order they're specified |
+| `upstream_owned` from each upstream | `ci/build.yml`, `ci/lint.yml` (from base), `ci/language-check.yml` (from overlay) | Both upstreams write into `ci/`. Non-overlapping files coexist; last-writer-wins on any overlap |
+| Structured merge across upstreams | `app-config.yaml` | Each upstream lists `app-config.yaml` under `shared_ownership.structured.prefer_upstream`. Fields present in both merge; overlay's values overwrite base's on collision because it runs SECOND |
+| State records both upstreams | `.gitspork/downstream-state.json` | The `upstreams` array carries one entry per integrated upstream (URL + commit_hash), so `check-drift` re-integrates each at its recorded commit |
+
+## Real-world mapping
+
+Common shapes this pattern fits:
+
+- **Platform-team baseline + team overlay.** A central platform team publishes shared CI, security scanners, and app-config defaults. Each team layers their own upstream on top with team-specific CI (custom scanners, release workflows) and app-config tuning (retry counts, feature flags).
+- **Compliance + language guild.** One upstream enforces compliance-required workflows and license headers; a second, language-specific upstream (Go, TypeScript, Python) adds lint/test tooling appropriate to the language.
+- **Base template + org overlay.** A public open-source template plus a private org-specific upstream that adds internal dashboards, deploy hooks, and org-required annotations.
+
+## How ordering + precedence works
+
+Upstreams are integrated in the order they appear on the command line. For `upstream_owned` files that both upstreams write, the last integrated upstream wins. For `shared_ownership.structured.prefer_upstream` files, the merge is applied per-upstream in order: the second upstream's values overwrite the first upstream's values on any shared key, while unique keys from both sides survive.
+
+If you want the base upstream to win in a specific conflict, invert the flag order.
+
+## Running this example
+
+From the repo root:
+
+```bash
+make test-examples
+```
+
+Or to run just this scenario:
+
+```bash
+go test -tags examples,testharness -v ./test/examples/... -run TestMultiUpstreamExample
+```
+
+## Directory structure
+
+```
+platform-base/                     ← first upstream (shared platform defaults)
+  .gitspork.yml
+  ci/
+    build.yml
+    lint.yml
+  app-config.yaml                  ← baseline log_level, timeout, owner tag
+
+language-overlay/                  ← second upstream (language-specific additions)
+  .gitspork.yml
+  ci/
+    language-check.yml
+  app-config.yaml                  ← overrides log_level, adds retry_count + language tag
+```

--- a/docs/examples/multi-upstream/language-overlay/.gitspork.yml
+++ b/docs/examples/multi-upstream/language-overlay/.gitspork.yml
@@ -1,0 +1,6 @@
+upstream_owned:
+  - ci/**
+shared_ownership:
+  structured:
+    prefer_upstream:
+      - app-config.yaml

--- a/docs/examples/multi-upstream/language-overlay/app-config.yaml
+++ b/docs/examples/multi-upstream/language-overlay/app-config.yaml
@@ -1,0 +1,4 @@
+log_level: debug
+retry_count: 5
+tags:
+  language: go

--- a/docs/examples/multi-upstream/language-overlay/ci/language-check.yml
+++ b/docs/examples/multi-upstream/language-overlay/ci/language-check.yml
@@ -1,0 +1,2 @@
+# Language-specific CI: Go vet / test workflow layered on the platform base.
+name: language-check

--- a/docs/examples/multi-upstream/platform-base/.gitspork.yml
+++ b/docs/examples/multi-upstream/platform-base/.gitspork.yml
@@ -1,0 +1,6 @@
+upstream_owned:
+  - ci/**
+shared_ownership:
+  structured:
+    prefer_upstream:
+      - app-config.yaml

--- a/docs/examples/multi-upstream/platform-base/app-config.yaml
+++ b/docs/examples/multi-upstream/platform-base/app-config.yaml
@@ -1,0 +1,4 @@
+log_level: info
+timeout_seconds: 30
+tags:
+  owner: platform

--- a/docs/examples/multi-upstream/platform-base/ci/build.yml
+++ b/docs/examples/multi-upstream/platform-base/ci/build.yml
@@ -1,0 +1,2 @@
+# Platform-base CI: build workflow shared by every downstream.
+name: build

--- a/docs/examples/multi-upstream/platform-base/ci/lint.yml
+++ b/docs/examples/multi-upstream/platform-base/ci/lint.yml
@@ -1,0 +1,2 @@
+# Platform-base CI: baseline lint workflow.
+name: lint

--- a/test/examples/main_test.go
+++ b/test/examples/main_test.go
@@ -74,11 +74,20 @@ func examplePath(t *testing.T, name string) string {
 	return filepath.Join(repoRoot, "docs", "examples", name)
 }
 
-// initExampleRepo copies a docs/examples/<name>/upstream dir into a fresh temp git repo
-// and commits everything, making it cloneable via file:// URL.
-func initExampleRepo(t *testing.T, name string) string {
+// initExampleRepoAt copies a docs/examples/<name>/<subdir> tree into a fresh
+// temp git repo and commits everything, making it cloneable via file:// URL.
+// Used by multi-upstream examples where docs/examples/<name>/ contains
+// multiple sibling upstream directories rather than a single ./upstream dir.
+func initExampleRepoAt(t *testing.T, name, subdir string) string {
 	t.Helper()
-	srcDir := exampleUpstreamPath(t, name)
+	srcDir := filepath.Join(examplePath(t, name), subdir)
+	return initExampleRepoFromSrc(t, srcDir)
+}
+
+// initExampleRepoFromSrc is the shared implementation behind initExampleRepo
+// and initExampleRepoAt.
+func initExampleRepoFromSrc(t *testing.T, srcDir string) string {
+	t.Helper()
 	dstDir := t.TempDir()
 
 	repo, err := gogit.PlainInit(dstDir, false,
@@ -114,4 +123,11 @@ func initExampleRepo(t *testing.T, name string) string {
 	require.NoError(t, err)
 
 	return dstDir
+}
+
+// initExampleRepo copies a docs/examples/<name>/upstream dir into a fresh temp git repo
+// and commits everything, making it cloneable via file:// URL.
+func initExampleRepo(t *testing.T, name string) string {
+	t.Helper()
+	return initExampleRepoFromSrc(t, exampleUpstreamPath(t, name))
 }

--- a/test/examples/multi_upstream_test.go
+++ b/test/examples/multi_upstream_test.go
@@ -1,0 +1,100 @@
+//go:build examples
+
+package examples
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/rockholla/gitspork/v2/test/testharness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiUpstreamExample covers the multi-upstream integration pattern at
+// the examples tier. All four other worked examples use a single upstream;
+// this scenario locks in the "platform base + language overlay" layering
+// pattern real teams use to layer standards.
+//
+// The example lives at docs/examples/multi-upstream/ with two sibling
+// upstream directories: platform-base/ (shared platform defaults) and
+// language-overlay/ (language-specific additions that override selected
+// base values).
+func TestMultiUpstreamExample(t *testing.T) {
+	baseUpstream := initExampleRepoAt(t, "multi-upstream", "platform-base")
+	overlayUpstream := initExampleRepoAt(t, "multi-upstream", "language-overlay")
+	downstreamDir := testharness.NewDownstreamRepo(t)
+
+	// Integrate BOTH upstreams in one gitspork invocation, base first then
+	// overlay. That order is what gives us last-writer-wins overlay
+	// precedence on any shared_ownership.structured collision.
+	out, code := runGitspork(t, []string{
+		"integrate",
+		"--upstream", "url=file://" + baseUpstream + ",version=main",
+		"--upstream", "url=file://" + overlayUpstream + ",version=main",
+		"--downstream-repo-path", downstreamDir,
+	}, downstreamDir)
+	require.Equal(t, 0, code, "multi-upstream integrate failed:\n%s", out)
+
+	t.Run("non-overlapping upstream_owned files from BOTH upstreams land", func(t *testing.T) {
+		// From platform-base (upstream #1)
+		testharness.AssertFileContains(t, downstreamDir, "ci/build.yml", "name: build")
+		testharness.AssertFileContains(t, downstreamDir, "ci/lint.yml", "name: lint")
+		// From language-overlay (upstream #2)
+		testharness.AssertFileContains(t, downstreamDir, "ci/language-check.yml", "name: language-check")
+	})
+
+	t.Run("structured shared file merges with overlay winning on collisions", func(t *testing.T) {
+		got := testharness.ReadFile(t, downstreamDir, "app-config.yaml")
+		m := map[string]any{}
+		require.NoError(t, yaml.Unmarshal([]byte(got), &m))
+
+		// Overlay overrides base on the collision.
+		assert.Equal(t, "debug", m["log_level"],
+			"overlay's log_level=debug must win over base's log_level=info because overlay integrates SECOND (last-writer-wins for shared_ownership.structured under prefer_upstream)")
+
+		// Overlay-only key lands.
+		assert.EqualValues(t, 5, m["retry_count"], "overlay-added key must survive")
+
+		// Base-only key survives.
+		assert.EqualValues(t, 30, m["timeout_seconds"], "base-only key must survive across the overlay merge")
+
+		// Nested map: both sides contribute — tags.owner from base,
+		// tags.language from overlay.
+		tags, ok := m["tags"].(map[string]any)
+		require.True(t, ok, "tags must be a nested mapping")
+		assert.Equal(t, "platform", tags["owner"], "base's tags.owner must survive")
+		assert.Equal(t, "go", tags["language"], "overlay's tags.language must land")
+	})
+
+	t.Run("state records BOTH upstreams in integration order", func(t *testing.T) {
+		raw := testharness.ReadFile(t, downstreamDir, ".gitspork/downstream-state.json")
+		var state struct {
+			Upstreams []struct {
+				URL        string `json:"url"`
+				CommitHash string `json:"commit_hash"`
+			} `json:"upstreams"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(raw), &state))
+		require.Len(t, state.Upstreams, 2,
+			"multi-upstream integrate must record every integrated upstream in state, in order")
+		assert.Equal(t, "file://"+baseUpstream, state.Upstreams[0].URL,
+			"base upstream must land at slot 0 (integrated first)")
+		assert.Equal(t, "file://"+overlayUpstream, state.Upstreams[1].URL,
+			"overlay upstream must land at slot 1 (integrated second)")
+		assert.NotEmpty(t, state.Upstreams[0].CommitHash)
+		assert.NotEmpty(t, state.Upstreams[1].CommitHash)
+	})
+
+	t.Run("check-drift succeeds with no drift after multi-upstream integrate", func(t *testing.T) {
+		// Commit baseline so the working tree is clean.
+		testharness.CommitAll(t, testharness.OpenRepo(t, downstreamDir), downstreamDir, "post-multi-upstream integrate baseline")
+
+		out, code := runGitspork(t, []string{
+			"check-drift",
+			"--downstream-repo-path", downstreamDir,
+		}, downstreamDir)
+		assert.Equal(t, 0, code, "check-drift should report no drift immediately after integrate:\n%s", out)
+	})
+}


### PR DESCRIPTION
## Summary

All four existing worked examples use a single upstream. Multi-upstream integration is a real feature (from PR #37) with functional-tier coverage but **no worked example** — the "layered standards" pattern (platform base + team overlay, base template + org overlay, compliance + language guild) had no in-tree documentation of how to spell it in `.gitspork.yml`.

## What's added

### `docs/examples/multi-upstream/` — new worked example

- **`platform-base/`** upstream: baseline CI (`ci/build.yml`, `ci/lint.yml`) plus a shared `app-config.yaml` with `log_level` / `timeout_seconds` / `owner` tag.
- **`language-overlay/`** upstream: language-specific CI (`ci/language-check.yml`) plus an `app-config.yaml` that overrides `log_level`, adds `retry_count`, and adds a `language` tag.
- **`README.md`** documents the "layered standards" scenario, feature matrix, real-world mappings (platform+team, compliance+language, base+org), and the ordering-based precedence rule.

### `test/examples/main_test.go`

Extracted `initExampleRepoFromSrc` as the shared implementation behind both `initExampleRepo` and the new `initExampleRepoAt` helper. `initExampleRepoAt` takes an example name + subdir so multi-upstream examples can lay out multiple sibling upstream dirs without breaking the existing `initExampleRepo` API.

### `test/examples/multi_upstream_test.go`

`TestMultiUpstreamExample` with four subtests:

- **non-overlapping `upstream_owned` files from BOTH upstreams land** (build/lint from base, language-check from overlay)
- **structured shared file merges with overlay winning on collisions**: `log_level=debug` (overlay wins), `retry_count=5` (overlay-added survives), `timeout_seconds=30` (base-only survives), nested `tags` map merges (base's `owner=platform` + overlay's `language=go`)
- **state records BOTH upstreams in integration order** with commit hashes populated
- **check-drift succeeds with no drift** after the multi-upstream integrate baseline

## Test plan

- [x] `make test-examples`

🤖 Generated with [Claude Code](https://claude.com/claude-code)